### PR TITLE
Add $VTM to the child process's environment block

### DIFF
--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -186,12 +186,14 @@ namespace netxs::app::desk
                 {
                     boss.base::hidden = true;
                     auto data_src_shadow = ptr::shadow(data_src);
-                    item_area->LISTEN(tier::release, e2::form::state::mouse, state, -)
+                    item_area->LISTEN(tier::release, e2::form::state::mouse, hover, -)
                     {
                         if (disabled) return;
-                        if (boss.base::hidden != !state)
+                        boss.RISEUP(tier::request, events::ui::toggle, unfolded, ());
+                        auto hidden = !unfolded || !hover;
+                        if (boss.base::hidden != hidden)
                         {
-                            boss.base::hidden = !state;
+                            boss.base::hidden = hidden;
                             boss.base::reflow();
                         }
                     };

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.24";
+    static const auto version = "v0.9.25";
     static const auto ipc_prefix = "vtm";
     static const auto log_suffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4931,7 +4931,7 @@ namespace netxs::os
                     os::stdout_fd = saved_fd;
                     if (ok(::SetConsoleActiveScreenBuffer(os::stdout_fd), "::SetConsoleActiveScreenBuffer()", os::unexpected))
                     {
-                        if (s != dtvt::consize()) // wt issue GH #16231
+                        if (dtvt::vtmode & ui::console::nt16 && s != dtvt::consize()) // wt issue GH #16231
                         {
                             std::cout << prompt::os << ansi::err("Terminal is out of sync. See https://github.com/microsoft/terminal/issues/16231 for details.") << "\n";
                         }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4931,7 +4931,7 @@ namespace netxs::os
                     os::stdout_fd = saved_fd;
                     if (ok(::SetConsoleActiveScreenBuffer(os::stdout_fd), "::SetConsoleActiveScreenBuffer()", os::unexpected))
                     {
-                        if (dtvt::vtmode & ui::console::nt16 && s != dtvt::consize()) // wt issue GH #16231
+                        if (!(dtvt::vtmode & ui::console::nt16) && s != dtvt::consize()) // wt issue GH #16231
                         {
                             std::cout << prompt::os << ansi::err("Terminal is out of sync. See https://github.com/microsoft/terminal/issues/16231 for details.") << "\n";
                         }

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1113,12 +1113,12 @@ namespace netxs::utf
                 auto frag = view{ utf8.data() + cur, pos - cur };
                 if constexpr (SkipEmpty) if (frag.empty()) { cur = pos + 1; continue; }
                 if constexpr (Plain) proc(frag);
-                else            if (!proc(frag)) return;
+                else            if (!proc(frag)) return faux;
                 cur = pos + 1;
             }
             auto end = view{ utf8.data() + cur, utf8.size() - cur };
-            if constexpr (SkipEmpty) if (end.empty()) return;
-            proc(end);
+            if constexpr (SkipEmpty) if (end.empty()) return true;
+            return proc(end);
         }
         else
         {
@@ -1130,12 +1130,12 @@ namespace netxs::utf
                 auto frag = view{ utf8.data() + next, cur - next };
                 if constexpr (SkipEmpty) if (frag.empty()) { cur = pos; continue; }
                 if constexpr (Plain) proc(frag);
-                else            if (!proc(frag)) return;
+                else            if (!proc(frag)) return faux;
                 cur = pos;
             }
             auto end = view{ utf8.data(), cur };
-            if constexpr (SkipEmpty) if (end.empty()) return;
-            proc(end);
+            if constexpr (SkipEmpty) if (end.empty()) return true;
+            return proc(end);
         }
     }
     template<feed Dir = feed::fwd, bool SkipEmpty = faux, class V1, class V2>


### PR DESCRIPTION
Changes
- Add $VTM to the child process's environment block
- Hide the close window button when the taskbar is folded

Closes #476