### PR TITLE
Introduce XLinkVT mode

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -1,6 +1,7 @@
 ## Built-in Applications
 - `▀▄ Term`     Terminal Emulator
 - `▀▄ DirectVT` DirectVT Proxy Console
+- `▀▄ XLinkVT`  DirectVT Proxy Console with controlling terminal onboard
 - `▀▄ View`     Workspace Navigation Helper
 - `▀▄ Tile`     Tiling Window anager
 
@@ -233,6 +234,27 @@ TerminalStdioLog             | Stdin/stdout log toggle.
 # DirectVT Proxy Console
 
 ...
+
+This console mode is activated by the `-r dtvt` option.
+
+Example:
+```
+vtm -r dtvt vtm -r truecolor
+```
+
+# DirectVT Proxy Console with controlling terminal onboard
+
+This console mode is used when there is a need for interactive interaction with the user through the controlling terminal. For example, this is required when connecting via SSH with keyboard-interactive authentication or requesting a private key passphrase.
+
+This mode is enabled automatically if the first command line argument begins with `ssh` literal.
+
+The following commands are identical:
+```
+vtm -r xlvt ssh user@host vtm
+```
+```
+vtm ssh user@host vtm
+```
 
 # Workspace Navigation Helper
 

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -23,6 +23,7 @@ Application | Description
 ------------|------------------------------------------
 `Term`      | Terminal emulator (default)
 `DTVT`      | DirectVT Proxy Console
+`XLVT`      | DirectVT Proxy Console with controlling terminal onboard (Cross-linked VT)
 `Calc`      | Spreadsheet calculator (Demo)
 `Text`      | Text editor (Demo)
 `Gems`      | Application manager (Demo)

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -198,7 +198,9 @@ Attribute  | Description                                       | Value type | Ma
 `bgc`      |  App window background color                      | `RGBA`     |           |
 `fgc`      |  App window foreground color                      | `RGBA`     |           |
 `winsize`  |  App window 2D size                               | `x;y`      |           |
+`winform`  |  App window state                                 | `undefined` \| `maximized` \| `minimized` |           |
 `slimmenu` |  App window menu vertical size                    | `boolean`  |           | `no`
+`env`      |  Environment variable in "var=val" format         | `string`   |           |
 `cwd`      |  Current working directory                        | `string`   |           |
 `type`     |  App type                                         | `string`   |           | `SHELL`
 `param`    |  App constructor arguments                        | `string`   |           | empty
@@ -223,7 +225,7 @@ Type              | Parameter        | Description
 `Group`           | [[ v[`n:m:w`] \| h[`n:m:w`] ] ( id_1 \| _nested_block_ , id_2 \| _nested_block_ )] | Run tiling window manager with layout specified in `param`. Usage example `type=Group param="h1:1(Term, Term)"`.
 `Region`          | | The `param` attribute is not used, use attribute `title=_view_title_` to set region name.
 
-The following configuration items have the same meaning:
+The following configuration items produce the same final result:
 ```
 <item …. param=‘mc’/>
 <item …. type=SHELL param=‘mc’/>

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -220,6 +220,7 @@ Type     | Format
 Type              | Parameter        | Description
 ------------------|------------------|-----------
 `DirectVT`        | `_command line_` | Run `_command line_` using DirectVT protocol. Usage example `type=DirectVT param="_command line_"`.
+`XLVT`\|`XLinkVT` | `_command line_` | Run `_command line_` using DirectVT protocol with controlling terminal attached for OpenSSH interactivity. Usage example `type=XLVT param="_command line_"`.
 `ANSIVT`          | `_command line_` | Run `_command line_` inside the built-in terminal. Usage example `type=ANSIVT param="_command line_"`. Same as `type=DirectVT param="$0 -r term _command line_"`.
 `SHELL` (default) | `_command line_` | Run `_command line_` on top of a system shell that runs inside the built-in terminal. Usage example `type=SHELL param="_command line_"`. Same as `type=DirectVT param="$0 -r term _shell_ -c _command line_"`.
 `Group`           | [[ v[`n:m:w`] \| h[`n:m:w`] ] ( id_1 \| _nested_block_ , id_2 \| _nested_block_ )] | Run tiling window manager with layout specified in `param`. Usage example `type=Group param="h1:1(Term, Term)"`.

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -529,6 +529,7 @@ namespace netxs::app::shared
                             pro::focus::off(window_inst.back());
                             pro::focus::set(window_inst.front(), gear_id_list, pro::focus::solo::off, pro::focus::flip::off, true); // Refocus.
                             window_inst.roll();
+                            boss.RISEUP(tier::preview, e2::form::prop::ui::footer, footer, ());
                             boss.reflow();
                         }
                         boss.bell::template expire<tier::preview>(true);

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -442,6 +442,7 @@ namespace netxs::app::shared
                 {
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root)
                     {
+                        //todo connect with external process using cmd, cwd, env
                         boss.start();
                     };
                     boss.LISTEN(tier::preview, e2::config::plugins::sizer::alive, state)

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -351,9 +351,9 @@ namespace netxs::app::shared
                                 ->limits(dot_11, { 400,200 });
                     auto scroll = layers->attach(ui::rail::ctor())
                                         ->limits({ 10,1 }); // mc crashes when window is too small
-                    auto data = param.empty() ? os::env::shell() + " -i"
-                                              : param;
-                    auto inst = scroll->attach(ui::term::ctor(env, cwd, data, config))
+                    auto cmd = param.empty() ? os::env::shell() + " -i"
+                                             : param;
+                    auto inst = scroll->attach(ui::term::ctor(cmd, cwd, env, config))
                                       ->plugin<pro::focus>(pro::focus::mode::focused)
                                       ->colors(whitelt, blackdk) //todo apply settings
                                       ->invoke([&](auto& boss)
@@ -430,12 +430,12 @@ namespace netxs::app::shared
                 layers->attach(app::shared::scroll_bars(scroll));
             return window;
         };
-        auto build_DirectVT      = [](text env, text cwd, text param, xmls& config, text patch)
+        auto build_DirectVT      = [](text env, text cwd, text cmd, xmls& config, text patch)
         {
-            auto param_shadow = view{ param };
-            auto term_type = shared::app_class(param_shadow);
-            param = param_shadow;
-            return ui::dtvt::ctor(env, cwd, param, patch)
+            auto cmd_shadow = view{ cmd };
+            auto term_type = shared::app_class(cmd_shadow);
+            cmd = cmd_shadow;
+            return ui::dtvt::ctor(cmd, cwd, env, patch)
                 ->plugin<pro::focus>(pro::focus::mode::active)
                 ->limits(dot_11)
                 ->invoke([](auto& boss)

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -64,7 +64,7 @@ namespace netxs::app::shared
 {
     namespace
     {
-        auto build_Strobe        = [](text cwd, text v,     xmls& config, text patch)
+        auto build_Strobe        = [](text env, text cwd, text v,     xmls& config, text patch)
         {
             auto window = ui::cake::ctor();
             auto strob = window->plugin<pro::focus>(pro::focus::mode::focused)
@@ -90,7 +90,7 @@ namespace netxs::app::shared
             };
             return window;
         };
-        auto build_Settings      = [](text cwd, text v,     xmls& config, text patch)
+        auto build_Settings      = [](text env, text cwd, text v,     xmls& config, text patch)
         {
             auto window = ui::cake::ctor();
             window->plugin<pro::focus>(pro::focus::mode::focused)
@@ -113,7 +113,7 @@ namespace netxs::app::shared
                   });
             return window;
         };
-        auto build_Empty         = [](text cwd, text v,     xmls& config, text patch)
+        auto build_Empty         = [](text env, text cwd, text v,     xmls& config, text patch)
         {
             auto window = ui::cake::ctor();
             window->plugin<pro::focus>(pro::focus::mode::focused)
@@ -135,7 +135,7 @@ namespace netxs::app::shared
                                 ->active();
             return window;
         };
-        auto build_Region        = [](text cwd, text v,     xmls& config, text patch)
+        auto build_Region        = [](text env, text cwd, text v,     xmls& config, text patch)
         {
             auto window = ui::cake::ctor();
             window->invoke([&](auto& boss)
@@ -194,7 +194,7 @@ namespace netxs::app::shared
                     });
             return window;
         };
-        auto build_Truecolor     = [](text cwd, text v,     xmls& config, text patch)
+        auto build_Truecolor     = [](text env, text cwd, text v,     xmls& config, text patch)
         {
             #pragma region samples
                 //todo put all ansi art into external files
@@ -328,7 +328,7 @@ namespace netxs::app::shared
                             auto hz = test_stat_area->attach(slot::_2, ui::grip<axis::X>::ctor(scroll));
             return window;
         };
-        auto build_Headless      = [](text cwd, text param, xmls& config, text patch)
+        auto build_Headless      = [](text env, text cwd, text param, xmls& config, text patch)
         {
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;
@@ -353,7 +353,7 @@ namespace netxs::app::shared
                                         ->limits({ 10,1 }); // mc crashes when window is too small
                     auto data = param.empty() ? os::env::shell() + " -i"
                                               : param;
-                    auto inst = scroll->attach(ui::term::ctor(cwd, data, config))
+                    auto inst = scroll->attach(ui::term::ctor(env, cwd, data, config))
                                       ->plugin<pro::focus>(pro::focus::mode::focused)
                                       ->colors(whitelt, blackdk) //todo apply settings
                                       ->invoke([&](auto& boss)
@@ -430,12 +430,12 @@ namespace netxs::app::shared
                 layers->attach(app::shared::scroll_bars(scroll));
             return window;
         };
-        auto build_DirectVT      = [](text cwd, text param, xmls& config, text patch)
+        auto build_DirectVT      = [](text env, text cwd, text param, xmls& config, text patch)
         {
             auto param_shadow = view{ param };
             auto term_type = shared::app_class(param_shadow);
             param = param_shadow;
-            return ui::dtvt::ctor(cwd, param, patch)
+            return ui::dtvt::ctor(env, cwd, param, patch)
                 ->plugin<pro::focus>(pro::focus::mode::active)
                 ->limits(dot_11)
                 ->invoke([](auto& boss)
@@ -458,7 +458,7 @@ namespace netxs::app::shared
                     };
                 });
         };
-        auto build_ANSIVT        = [](text cwd, text param, xmls& config, text patch)
+        auto build_ANSIVT        = [](text env, text cwd, text param, xmls& config, text patch)
         {
             if (param.empty()) log(prompt::apps, "Nothing to run, use 'type=SHELL' to run instance without arguments");
 
@@ -466,15 +466,15 @@ namespace netxs::app::shared
             if (args.find(' ') != text::npos) args = "\"" + args + "\"";
             args += " -r term ";
             args += param;
-            return build_DirectVT(cwd, args, config, patch);
+            return build_DirectVT(env, cwd, args, config, patch);
         };
-        auto build_SHELL         = [](text cwd, text param, xmls& config, text patch)
+        auto build_SHELL         = [](text env, text cwd, text param, xmls& config, text patch)
         {
             auto args = os::process::binary();
             if (args.find(' ') != text::npos) args = "\"" + args + "\"";
             args += " -r term ";
             args += os::env::shell(param);
-            return build_DirectVT(cwd, args, config, patch);
+            return build_DirectVT(env, cwd, args, config, patch);
         };
 
         app::shared::initialize builder_Strobe    { app::strobe::id   , build_Strobe     };

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -18,6 +18,10 @@ namespace netxs::app::truecolor
     static constexpr auto id = "truecolor";
     static constexpr auto desc = "ANSI Art Test";
 }
+namespace netxs::app::ssh
+{
+    static constexpr auto id = "ssh";
+}
 namespace netxs::app::headless
 {
     static constexpr auto id = "headless";
@@ -46,12 +50,12 @@ namespace netxs::app::dtvt
 namespace netxs::app::xlinkvt
 {
     static constexpr auto id = "xlinkvt";
-    static constexpr auto desc = "XLinkVT Console";
+    static constexpr auto desc = "XLinkVT Console (Cross-linked VT)";
 }
 namespace netxs::app::xlvt
 {
     static constexpr auto id = "xlvt";
-    static constexpr auto desc = "XLinkVT Console";
+    static constexpr auto desc = "XLinkVT Console (Cross-linked VT)";
 }
 namespace netxs::app::shell
 {

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -442,7 +442,11 @@ namespace netxs::app::shared
                 {
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (cmd, cwd, env, patch))
                     {
-                        boss.start(patch, [cmd, cwd, env](auto r, auto w){ os::dtvt::connect(r, w, cmd, cwd, env); return cmd; });
+                        boss.start(patch, [cmd, cwd, env](auto r, auto w)
+                        {
+                            os::dtvt::connect(cmd, cwd, env, r, w);
+                            return cmd;
+                        });
                     };
                     boss.LISTEN(tier::preview, e2::config::plugins::sizer::alive, state)
                     {

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -435,15 +435,14 @@ namespace netxs::app::shared
             auto cmd_shadow = view{ cmd };
             auto term_type = shared::app_class(cmd_shadow);
             cmd = cmd_shadow;
-            return ui::dtvt::ctor(cmd, cwd, env, patch)
+            return ui::dtvt::ctor()
                 ->plugin<pro::focus>(pro::focus::mode::active)
                 ->limits(dot_11)
-                ->invoke([](auto& boss)
+                ->invoke([&](auto& boss)
                 {
-                    boss.LISTEN(tier::anycast, e2::form::upon::started, root)
+                    boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (cmd, cwd, env, patch))
                     {
-                        //todo connect with external process using cmd, cwd, env
-                        boss.start();
+                        boss.start(patch, [cmd, cwd, env](auto r, auto w){ os::dtvt::connect(r, w, cmd, cwd, env); return cmd; });
                     };
                     boss.LISTEN(tier::preview, e2::config::plugins::sizer::alive, state)
                     {

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -50,12 +50,12 @@ namespace netxs::app::dtvt
 namespace netxs::app::xlinkvt
 {
     static constexpr auto id = "xlinkvt";
-    static constexpr auto desc = "XLinkVT Console (Cross-linked VT)";
+    static constexpr auto desc = "XLinkVT";
 }
 namespace netxs::app::xlvt
 {
     static constexpr auto id = "xlvt";
-    static constexpr auto desc = "XLinkVT Console (Cross-linked VT)";
+    static constexpr auto desc = "XLinkVT";
 }
 namespace netxs::app::shell
 {
@@ -479,7 +479,8 @@ namespace netxs::app::shared
             auto cB = menu_white;
 
             auto window = ui::veer::ctor()
-                ->limits(dot_11, { 400,200 });
+                ->limits(dot_11, { 400,200 })
+                ->plugin<pro::focus>(pro::focus::mode::active);
             auto term = ui::cake::ctor()
                 ->plugin<pro::acryl>()
                 ->plugin<pro::cache>()
@@ -507,7 +508,7 @@ namespace netxs::app::shared
             auto& term_inst = *inst;
 
             auto dtvt = ui::dtvt::ctor()
-                ->plugin<pro::focus>(pro::focus::mode::active)
+                ->plugin<pro::focus>(pro::focus::mode::focusable)
                 ->limits(dot_11)
                 ->invoke([&](auto& boss)
                 {
@@ -524,6 +525,9 @@ namespace netxs::app::shared
                     {
                         if (window_inst.back() != boss.This())
                         {
+                            auto gear_id_list = pro::focus::get(window_inst.back(), true); // Expropriate all foci.
+                            pro::focus::off(window_inst.back());
+                            pro::focus::set(window_inst.front(), gear_id_list, pro::focus::solo::off, pro::focus::flip::off, true); // Refocus.
                             window_inst.roll();
                             boss.reflow();
                         }

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -432,9 +432,6 @@ namespace netxs::app::shared
         };
         auto build_DirectVT      = [](text env, text cwd, text cmd, xmls& config, text patch)
         {
-            auto cmd_shadow = view{ cmd };
-            auto term_type = shared::app_class(cmd_shadow);
-            cmd = cmd_shadow;
             return ui::dtvt::ctor()
                 ->plugin<pro::focus>(pro::focus::mode::active)
                 ->limits(dot_11)

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -453,9 +453,9 @@ namespace netxs::app::shared
                 {
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (cmd, cwd, env, patch))
                     {
-                        boss.start(patch, [cmd, cwd, env](auto r, auto w)
+                        boss.start(patch, [cmd, cwd, env](auto fds)
                         {
-                            os::dtvt::connect(cmd, cwd, env, r, w);
+                            os::dtvt::connect(cmd, cwd, env, fds);
                             return cmd;
                         });
                     };
@@ -514,9 +514,9 @@ namespace netxs::app::shared
                     auto& window_inst = *window;
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (cmd, cwd, env, patch))
                     {
-                        boss.start(patch, [&, cmd, cwd, env](auto r, auto w)
+                        boss.start(patch, [&, cmd, cwd, env](auto fds)
                         {
-                            term_inst.start(cmd, cwd, env, r, w);
+                            term_inst.start(cmd, cwd, env, fds);
                             return cmd;
                         });
                     };

--- a/src/netxs/apps/calc.cpp
+++ b/src/netxs/apps/calc.cpp
@@ -58,24 +58,25 @@ int main(int argc, char* argv[])
     {
         os::fail(errmsg);
         log("\n"
-            "  Syntax:\n"
+            "\n  Syntax:"
             "\n"
-            "    " + os::process::binary<true>() + " [ -c <file> ] [ -l ]\n"
+            "\n    " + os::process::binary<true>() + " [ -c <file> ] [ -l ]"
             "\n"
-            "  Options:\n"
+            "\n  Options:"
             "\n"
-            "    No arguments       Run application.\n"
-            "    -c, --config <..>  Load specified settings file.\n"
-            "    -l, --listconfig   Show configuration and exit.\n"
+            "\n    No arguments       Run application."
+            "\n    -c, --config <..>  Load specified settings file."
+            "\n    -l, --listconfig   Show configuration and exit."
             "\n"
-            "  Settings loading and merging order:\n"
+            "\n  Settings loading and merging order:"
             "\n"
-            "    - Initialize hardcoded settings\n"
-            "    - Merge with explicitly specified settings from --config <file>\n"
-            "    - If the --config option is not used or <file> cannot be loaded:\n"
-            "        - Merge with system-wide settings from " + os::path::expand(app::shared::sys_config).second + "\n"
-            "        - Merge with user-wise settings from "   + os::path::expand(app::shared::usr_config).second + "\n"
-            "        - Merge with DirectVT packet received from the parent process (dtvt-mode only)\n");
+            "\n    - Initialize hardcoded settings"
+            "\n    - Merge with explicitly specified settings from --config <file>"
+            "\n    - If the --config option is not used or <file> cannot be loaded:"
+            "\n        - Merge with system-wide settings from " + os::path::expand(app::shared::sys_config).second +
+            "\n        - Merge with user-wise settings from "   + os::path::expand(app::shared::usr_config).second +
+            "\n        - Merge with DirectVT packet received from the parent process (dtvt-mode only)"
+            "\n");
     }
     else if (cfonly)
     {

--- a/src/netxs/apps/calc.hpp
+++ b/src/netxs/apps/calc.hpp
@@ -317,7 +317,7 @@ namespace netxs::app::calc
             }
             return std::tuple{ cellatix_rows, cellatix_cols, cellatix_text };
         };
-        auto build = [](text cwd, text arg, xmls& config, text patch)
+        auto build = [](text env, text cwd, text arg, xmls& config, text patch)
         {
             auto highlight_color = skin::globals().highlight;
             auto label_color     = skin::globals().label;

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -26,6 +26,7 @@ namespace netxs::app::desk
         bool slimmenu{};
         bool splitter{};
         text   hotkey{};
+        text      env{}; // Environment var list delimited by \0.
         text      cwd{};
         text     type{};
         text    param{};
@@ -457,7 +458,7 @@ namespace netxs::app::desk
                 });
         };
 
-        auto build = [](text cwd, text v, xmls& config, text patch)
+        auto build = [](text env, text cwd, text v, xmls& config, text patch)
         {
             auto tall = si32{ skin::globals().menuwide };
             auto highlight_color = skin::globals().highlight;
@@ -477,6 +478,7 @@ namespace netxs::app::desk
 
             auto window = ui::fork::ctor(axis::Y, 0, 0, 1);
             auto panel_top = config.take("/config/panel/height", 1);
+            auto panel_env = config.take("/config/panel/env", ""s);
             auto panel_cwd = config.take("/config/panel/cwd", ""s);
             auto panel_cmd = config.take("/config/panel/cmd", ""s);
             auto panel = window->attach(slot::_1, ui::cake::ctor());
@@ -484,7 +486,7 @@ namespace netxs::app::desk
             {
                 panel_top = std::max(1, panel_top);
                 panel->limits({ -1, panel_top }, { -1, panel_top })
-                     ->attach(app::shared::builder(app::headless::id)(panel_cwd, panel_cmd, config, ""s));
+                     ->attach(app::shared::builder(app::headless::id)(panel_env, panel_cwd, panel_cmd, config, ""s));
             }
             auto my_id = id_t{};
 

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -187,11 +187,15 @@ namespace netxs::app::desk
                 {
                     boss.base::hidden = true;
                     auto data_src_shadow = ptr::shadow(data_src);
+                    auto& item_area_inst = *item_area;
                     item_area->LISTEN(tier::release, e2::form::state::mouse, hover, -)
                     {
                         if (disabled) return;
-                        boss.RISEUP(tier::request, events::ui::toggle, unfolded, ());
-                        auto hidden = !unfolded || !hover;
+                        //boss.RISEUP(tier::request, events::ui::toggle, unfolded, ());
+                        //auto hidden = !unfolded || !hover;
+                        //auto folded = item_area_inst.base::size().x <= boss.base::size().x * 2;
+                        //auto hidden = folded || !hover;
+                        auto hidden = !hover;
                         if (boss.base::hidden != hidden)
                         {
                             boss.base::hidden = hidden;
@@ -333,10 +337,6 @@ namespace netxs::app::desk
                         ->limits({ 5, -1 }, { 5, -1 })
                         ->invoke([&](auto& boss)
                         {
-                            boss.LISTEN(tier::anycast, events::ui::recalc, state)
-                            {
-                                boss.base::hidden = !isfolded && !state;
-                            };
                             boss.LISTEN(tier::release, e2::form::state::mouse, state)
                             {
                                 if (!state)

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -185,7 +185,7 @@ namespace netxs::app::shop
             return std::tuple{ appstore_head, appstore_body, desktopio_body };
         };
 
-        auto build = [](text cwd, text arg, xmls& config, text patch)
+        auto build = [](text env, text cwd, text arg, xmls& config, text patch)
         {
             auto highlight_color = skin::color(tone::highlight);
             auto c3 = highlight_color;

--- a/src/netxs/apps/term.cpp
+++ b/src/netxs/apps/term.cpp
@@ -58,24 +58,25 @@ int main(int argc, char* argv[])
     {
         os::fail(errmsg);
         log("\n"
-            "  Syntax:\n"
+            "\n  Syntax:"
             "\n"
-            "    " + os::process::binary<true>() + " [ -c <file> ] [ -l ]\n"
+            "\n    " + os::process::binary<true>() + " [ -c <file> ] [ -l ]"
             "\n"
-            "  Options:\n"
+            "\n  Options:"
             "\n"
-            "    No arguments       Run application.\n"
-            "    -c, --config <..>  Load specified settings file.\n"
-            "    -l, --listconfig   Show configuration and exit.\n"
+            "\n    No arguments       Run application."
+            "\n    -c, --config <..>  Load specified settings file."
+            "\n    -l, --listconfig   Show configuration and exit."
             "\n"
-            "  Settings loading and merging order:\n"
+            "\n  Settings loading and merging order:"
             "\n"
-            "    - Initialize hardcoded settings\n"
-            "    - Merge with explicitly specified settings from --config <file>\n"
-            "    - If the --config option is not used or <file> cannot be loaded:\n"
-            "        - Merge with system-wide settings from " + os::path::expand(app::shared::sys_config).second + "\n"
-            "        - Merge with user-wise settings from "   + os::path::expand(app::shared::usr_config).second + "\n"
-            "        - Merge with DirectVT packet received from the parent process (dtvt-mode only)\n");
+            "\n    - Initialize hardcoded settings"
+            "\n    - Merge with explicitly specified settings from --config <file>"
+            "\n    - If the --config option is not used or <file> cannot be loaded:"
+            "\n        - Merge with system-wide settings from " + os::path::expand(app::shared::sys_config).second +
+            "\n        - Merge with user-wise settings from "   + os::path::expand(app::shared::usr_config).second +
+            "\n        - Merge with DirectVT packet received from the parent process (dtvt-mode only)"
+            "\n");
     }
     else if (cfonly)
     {

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -620,7 +620,7 @@ namespace netxs::app::term
 
     namespace
     {
-        auto build = [](text cwd, text arg, xmls& config, text patch)
+        auto build = [](text env, text cwd, text arg, xmls& config, text patch)
         {
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;
@@ -685,7 +685,7 @@ namespace netxs::app::term
                 });
 
             auto shell = os::env::shell() + " -i";
-            auto inst = scroll->attach(ui::term::ctor(cwd, arg.empty() ? shell : arg, config))
+            auto inst = scroll->attach(ui::term::ctor(env, cwd, arg.empty() ? shell : arg, config))
                               ->plugin<pro::focus>(pro::focus::mode::focused);
             auto scroll_bars = layers->attach(ui::fork::ctor());
             auto vt = scroll_bars->attach(slot::_2, ui::grip<axis::Y>::ctor(scroll));

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -683,7 +683,7 @@ namespace netxs::app::term
 
             auto shell = os::env::shell() + " -i";
             auto cmd = arg.empty() ? shell : arg;
-            auto inst = scroll->attach(ui::term::ctor(cmd, cwd, env, config))
+            auto inst = scroll->attach(ui::term::ctor(config))
                               ->plugin<pro::focus>(pro::focus::mode::focused);
             auto scroll_bars = layers->attach(ui::fork::ctor());
             auto vt = scroll_bars->attach(slot::_2, ui::grip<axis::Y>::ctor(scroll));
@@ -778,7 +778,7 @@ namespace netxs::app::term
                 ->attach_property(ui::term::events::layout::wrapln,  app::term::events::release::wrapln)
                 ->attach_property(ui::term::events::layout::align,   app::term::events::release::align)
                 ->attach_property(ui::term::events::search::status,  app::term::events::search::status)
-                ->invoke([](auto& boss)
+                ->invoke([&](auto& boss)
                 {
                     boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, fast)
                     {
@@ -835,9 +835,9 @@ namespace netxs::app::term
                     {
                         boss.set_align(align);
                     };
-                    boss.LISTEN(tier::anycast, e2::form::upon::started, root)
+                    boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (cmd, cwd, env))
                     {
-                        boss.start();
+                        boss.start(cmd, cwd, env);
                     };
                     boss.LISTEN(tier::anycast, app::term::events::search::forward, gear)
                     {

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -634,7 +634,7 @@ namespace netxs::app::term
                       ->plugin<pro::acryl>()
                       ->plugin<pro::cache>();
             }
-            else window->plugin<pro::focus>(pro::focus::mode::focusable, faux);
+            else window->plugin<pro::focus>(pro::focus::mode::focusable);
 
             auto object = window->attach(ui::fork::ctor(axis::Y))
                                 ->colors(cB);

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -685,7 +685,8 @@ namespace netxs::app::term
                 });
 
             auto shell = os::env::shell() + " -i";
-            auto inst = scroll->attach(ui::term::ctor(env, cwd, arg.empty() ? shell : arg, config))
+            auto cmd = arg.empty() ? shell : arg;
+            auto inst = scroll->attach(ui::term::ctor(cmd, cwd, env, config))
                               ->plugin<pro::focus>(pro::focus::mode::focused);
             auto scroll_bars = layers->attach(ui::fork::ctor());
             auto vt = scroll_bars->attach(slot::_2, ui::grip<axis::Y>::ctor(scroll));

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -626,10 +626,7 @@ namespace netxs::app::term
             auto cB = menu_white;
 
             auto window = ui::cake::ctor();
-            auto arg_shadow = view{ arg };
-            auto term_type = shared::app_class(arg_shadow);
-            arg = arg_shadow;
-            if (term_type == shared::app_type::normal)
+            if (os::dtvt::active)
             {
                 //todo revise focus
                 window->plugin<pro::focus>()

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -786,7 +786,7 @@ namespace netxs::app::term
                     };
                     boss.LISTEN(tier::preview, e2::form::proceed::quit::one, fast)
                     {
-                        boss.sighup(fast);
+                        boss.close(fast);
                     };
                     boss.LISTEN(tier::anycast, app::term::events::cmd, cmd)
                     {

--- a/src/netxs/apps/test.hpp
+++ b/src/netxs/apps/test.hpp
@@ -416,7 +416,7 @@ namespace netxs::app::test
 
             return topic;
         };
-        auto build = [](text cwd, text arg, xmls& config, text patch)
+        auto build = [](text env, text cwd, text arg, xmls& config, text patch)
         {
             auto topic = get_text();
             auto window = ui::cake::ctor()

--- a/src/netxs/apps/text.hpp
+++ b/src/netxs/apps/text.hpp
@@ -75,7 +75,7 @@ displaying the requested definition in a popup window or temporary buffer. Some 
 
 )";
 
-        auto build = [](text cwd, text arg, xmls& config, text patch)
+        auto build = [](text env, text cwd, text arg, xmls& config, text patch)
         {
             auto highlight_color = skin::color(tone::highlight);
 

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -455,7 +455,7 @@ namespace netxs::app::tile
         auto empty_slot = [](auto&& empty_slot, auto min_state) -> netxs::sptr<ui::veer>
         {
             return ui::veer::ctor()
-                ->plugin<pro::focus>(pro::focus::mode::hub/*default*/, true/*default*/, true)
+                ->plugin<pro::focus>(pro::focus::mode::hub/*default*/, true/*cut_scope*/)
                 ->active()
                 ->invoke([&](auto& boss)
                 {

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -787,7 +787,7 @@ namespace netxs::app::tile
             }
             return slot;
         };
-        auto build_inst = [](text cwd, view param, xmls& config, text patch) -> sptr
+        auto build_inst = [](text env, text cwd, view param, xmls& config, text patch) -> sptr
         {
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -946,8 +946,8 @@ namespace netxs::app::tile
             {
                 auto err = std::error_code{};
                 fs::current_path(cwd, err);
-                if (err) log("%%Failed to change current working directory to '%cwd%', error code: %error%", prompt::tile, cwd, err.value());
-                else     log("%%Change current working directory to '%cwd%'", prompt::tile, cwd);
+                if (err) log("%%Failed to change current directory to '%cwd%', error code: %error%", prompt::tile, cwd, err.value());
+                else     log("%%Change current directory to '%cwd%'", prompt::tile, cwd);
             }
 
             object->attach(slot::_2, parse_data(parse_data, param, ui::fork::min_ratio))

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -128,7 +128,7 @@ namespace netxs::app::shared
         gear.dismiss(true);
     };
 
-    using builder_t = std::function<ui::sptr(text, text, xmls&, text)>;
+    using builder_t = std::function<ui::sptr(text, text, text, xmls&, text)>;
 
     namespace winform
     {
@@ -432,7 +432,7 @@ namespace netxs::app::shared
     auto& builder(text app_typename)
     {
         static builder_t empty =
-        [&](text, text, xmls&, text) -> ui::sptr
+        [&](text, text, text, xmls&, text) -> ui::sptr
         {
             auto window = ui::cake::ctor()
                 ->plugin<pro::focus>()
@@ -562,7 +562,7 @@ namespace netxs::app::shared
             ->plugin<scripting::host>();
         auto direct = os::dtvt::active;
         os::dtvt::isolated = !direct;
-        auto applet = app::shared::builder(aclass)("", (direct ? "" : "!") + params, config, /*patch*/(direct ? ""s : "<config isolated=1/>"s)); // ! - means simple (i.e. w/o plugins)
+        auto applet = app::shared::builder(aclass)("", "", (direct ? "" : "!") + params, config, /*patch*/(direct ? ""s : "<config isolated=1/>"s)); // ! - means simple (i.e. w/o plugins)
         domain->invite(server, applet, vtmode, winsz);
         domain->stop();
         server->shut();

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -29,23 +29,6 @@ namespace netxs::app::shared
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;
 
-    enum class app_type
-    {
-        simple,
-        normal,
-    };
-
-    const auto app_class = [](view& v)
-    {
-        auto type = app_type::normal;
-        if (!v.empty() && v.front() == '!')
-        {
-            type = app_type::simple;
-            v.remove_prefix(1);
-            v = utf::trim(v);
-        }
-        return type;
-    };
     const auto closing_on_quit = [](auto& boss)
     {
         boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, fast)
@@ -562,7 +545,7 @@ namespace netxs::app::shared
             ->plugin<scripting::host>();
         auto direct = os::dtvt::active;
         os::dtvt::isolated = !direct;
-        auto applet = app::shared::builder(aclass)("", "", (direct ? "" : "!") + params, config, /*patch*/(direct ? ""s : "<config isolated=1/>"s)); // ! - means simple (i.e. w/o plugins)
+        auto applet = app::shared::builder(aclass)("", "", params, config, /*patch*/(direct ? ""s : "<config isolated=1/>"s));
         domain->invite(server, applet, vtmode, winsz);
         domain->stop();
         server->shut();

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.26";
+    static const auto version = "v0.9.27";
     static const auto ipc_prefix = "vtm";
     static const auto log_suffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -434,23 +434,26 @@ namespace netxs::app::shared
                 });
             auto msg = ui::post::ctor()
                 ->colors(whitelt, rgba{ 0x7F404040 })
-                ->upload(ansi::fgc(yellowlt).mgl(4).mgr(4).wrp(wrap::off)
-                + "\n\nUnsupported application type\n\n"
-                + ansi::nil().wrp(wrap::on)
-                + "Only the following application types are supported\n\n"
-                + ansi::nil().wrp(wrap::off).fgc(whitedk)
-                + "   type = DirectVT(dtvt) \n"
-                  "   type = ANSIVT   \n"
-                  "   type = SHELL    \n"
-                  "   type = Group    \n"
-                  "   type = Region   \n\n"
-                + ansi::nil().wrp(wrap::on).fgc(whitelt)
-                 .add(prompt::apps, "See logs for details."));
+                ->upload(ansi::fgc(yellowlt).mgl(4).mgr(4).wrp(wrap::off) +
+                    "\n"
+                    "\nUnsupported application type"
+                    "\n" + ansi::nil().wrp(wrap::on) +
+                    "\nOnly the following application types are supported"
+                    "\n" + ansi::nil().wrp(wrap::off).fgc(whitedk) +
+                    "\n   type = DirectVT(dtvt)"
+                    "\n   type = XLinkVT(xlvt)"
+                    "\n   type = ANSIVT"
+                    "\n   type = SHELL"
+                    "\n   type = Group"
+                    "\n   type = Region"
+                    "\n"
+                    "\n" + ansi::nil().wrp(wrap::on).fgc(whitelt)
+                    .add(prompt::apps, "See logs for details."));
             auto placeholder = ui::cake::ctor()
                 ->colors(whitelt, rgba{ 0x7F404040 })
                 ->attach(msg->alignment({ snap::head, snap::head }));
             window->attach(ui::rail::ctor())
-                  ->attach(placeholder);
+                ->attach(placeholder);
             return window;
         };
         auto& map = creator();

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -32,7 +32,7 @@ struct consrv
     {
         if (waitexit.joinable())
         {
-            if (io_log) log(prompt::vtty, "Process waiter joining", ' ', utf::to_hex_0x(waitexit.get_id()));
+            if (io_log) log("%%Process waiter joining %%", prompt::vtty, utf::to_hex_0x(waitexit.get_id()));
             waitexit.join();
         }
     }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -65,9 +65,9 @@ struct consrv
             return err_code;
         }
         start();
-        startinf.StartupInfo.hStdInput  = 0;
-        startinf.StartupInfo.hStdOutput = 0;
-        startinf.StartupInfo.hStdError  = 0;
+        startinf.StartupInfo.hStdInput  = nt::console::handle(condrv, "\\Input",  true);        // Windows8's cmd.exe requires that handles.
+        startinf.StartupInfo.hStdOutput = nt::console::handle(condrv, "\\Output", true);        //
+        startinf.StartupInfo.hStdError  = nt::console::handle(startinf.StartupInfo.hStdOutput); //
         startinf.StartupInfo.dwX = 0;
         startinf.StartupInfo.dwY = 0;
         startinf.StartupInfo.dwXCountChars = 0;
@@ -80,19 +80,17 @@ struct consrv
                                      | STARTF_USEPOSITION
                                      | STARTF_USECOUNTCHARS
                                      | STARTF_USEFILLATTRIBUTE;
-        //::InitializeProcThreadAttributeList(nullptr, 2, 0, &attrsize);
-        ::InitializeProcThreadAttributeList(nullptr, 1, 0, &attrsize);
+        ::InitializeProcThreadAttributeList(nullptr, 2, 0, &attrsize);
         attrbuff.resize(attrsize);
         startinf.lpAttributeList = reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(attrbuff.data());
-        ::InitializeProcThreadAttributeList(startinf.lpAttributeList, 1, 0, &attrsize);
-        //::InitializeProcThreadAttributeList(startinf.lpAttributeList, 2, 0, &attrsize);
-        // ::UpdateProcThreadAttribute(startinf.lpAttributeList,
-        //                             0,
-        //                             PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
-        //                            &startinf.StartupInfo.hStdInput,
-        //                      sizeof(startinf.StartupInfo.hStdInput) * 3,
-        //                             nullptr,
-        //                             nullptr);
+        ::InitializeProcThreadAttributeList(startinf.lpAttributeList, 2, 0, &attrsize);
+        ::UpdateProcThreadAttribute(startinf.lpAttributeList,
+                                    0,
+                                    PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                                   &startinf.StartupInfo.hStdInput,
+                             sizeof(startinf.StartupInfo.hStdInput) * 3,
+                                    nullptr,
+                                    nullptr);
         ::UpdateProcThreadAttribute(startinf.lpAttributeList,
                                     0,
                                     ProcThreadAttributeValue(sizeof("Reference"), faux, true, faux),

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -45,7 +45,7 @@ struct consrv
         return inst;
     }
     template<class Term, class Proc>
-    auto attach(Term& terminal, twod win, text env, text cwd, text cmd, Proc trailer)
+    auto attach(Term& terminal, text cmd, text cwd, text env, twod win, Proc trailer)
     {
         auto err_code = 0;
         auto startinf = STARTUPINFOEXW{ sizeof(STARTUPINFOEXW) };
@@ -5205,7 +5205,7 @@ struct consrv : ipc::stdcon
         return ptr::shared<consrv>(terminal);
     }
     template<class Term, class Proc>
-    auto attach(Term& terminal, twod win, text env, text cwd, text cmd, Proc trailer)
+    auto attach(Term& terminal, text cmd, text cwd, text env, twod win, Proc trailer)
     {
         auto fdm = os::syscall{ ::posix_openpt(O_RDWR | O_NOCTTY) }; // Get master TTY.
         auto rc1 = os::syscall{ ::grantpt(fdm.value)              }; // Grant master TTY file access.
@@ -5243,7 +5243,7 @@ struct consrv : ipc::stdcon
                     "TERM=xterm-256color\0"
                     "COLORTERM=truecolor\0";
             env = os::env::add(env);
-            os::process::spawn(env, cwd, cmd);
+            os::process::spawn(cmd, cwd, env);
         }
         // Parent branch.
         auto err_code = 0;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -5244,9 +5244,18 @@ struct consrv : ipc::stdcon
             winsz(win); // TTY resize can be done only after assigning a controlling TTY (BSD-requirement).
             os::dtvt::active = faux; // Logger update.
             os::dtvt::client = {};   //
-            ::dup2(fds.value, STDIN_FILENO);  os::stdin_fd  = STDIN_FILENO;
-            ::dup2(fds.value, STDOUT_FILENO); os::stdout_fd = STDOUT_FILENO;
-            ::dup2(fds.value, STDERR_FILENO); os::stderr_fd = STDERR_FILENO;
+            if (r == os::invalid_fd)
+            {
+                ::dup2(fds.value, STDIN_FILENO);  os::stdin_fd  = STDIN_FILENO;
+                ::dup2(fds.value, STDOUT_FILENO); os::stdout_fd = STDOUT_FILENO;
+                ::dup2(fds.value, STDERR_FILENO); os::stderr_fd = STDERR_FILENO;
+            }
+            else
+            {
+                ::dup2(r,         STDIN_FILENO);  os::stdin_fd  = STDIN_FILENO;
+                ::dup2(w,         STDOUT_FILENO); os::stdout_fd = STDOUT_FILENO;
+                ::dup2(fds.value, STDERR_FILENO); os::stderr_fd = STDERR_FILENO;
+            }
             os::fdscleanup();
             os::signals::listener.reset();
             if (!fdm || !rc1 || !rc2 || !rc3 || !rc4 || !fds) // Report if something went wrong.

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -45,7 +45,7 @@ struct consrv
         return inst;
     }
     template<class Term, class Proc>
-    auto attach(Term& terminal, text cmd, text cwd, text env, twod win, Proc trailer)
+    auto attach(Term& terminal, text cmd, text cwd, text env, twod win, Proc trailer, fd_t r, fd_t w)
     {
         auto err_code = 0;
         auto startinf = STARTUPINFOEXW{ sizeof(STARTUPINFOEXW) };
@@ -65,9 +65,20 @@ struct consrv
             return err_code;
         }
         start();
-        startinf.StartupInfo.hStdInput  = nt::console::handle(condrv, "\\Input",  true);        // Windows8's cmd.exe requires that handles.
-        startinf.StartupInfo.hStdOutput = nt::console::handle(condrv, "\\Output", true);        //
-        startinf.StartupInfo.hStdError  = nt::console::handle(startinf.StartupInfo.hStdOutput); //
+        auto handle_count = 3;
+        //todo close unused handles
+        if (r == os::invalid_fd)
+        {
+            startinf.StartupInfo.hStdInput  = nt::console::handle(condrv, "\\Input",  true);        // Windows8's cmd.exe requires that handles.
+            startinf.StartupInfo.hStdOutput = nt::console::handle(condrv, "\\Output", true);        //
+            startinf.StartupInfo.hStdError  = nt::console::handle(startinf.StartupInfo.hStdOutput); //
+        }
+        else
+        {
+            handle_count = 2;
+            startinf.StartupInfo.hStdInput  = r;
+            startinf.StartupInfo.hStdOutput = w;
+        }
         startinf.StartupInfo.dwX = 0;
         startinf.StartupInfo.dwY = 0;
         startinf.StartupInfo.dwXCountChars = 0;
@@ -88,7 +99,7 @@ struct consrv
                                     0,
                                     PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
                                    &startinf.StartupInfo.hStdInput,
-                             sizeof(startinf.StartupInfo.hStdInput) * 3,
+                             sizeof(startinf.StartupInfo.hStdInput) * handle_count,
                                     nullptr,
                                     nullptr);
         ::UpdateProcThreadAttribute(startinf.lpAttributeList,
@@ -5213,7 +5224,7 @@ struct consrv : ipc::stdcon
         return ptr::shared<consrv>(terminal);
     }
     template<class Term, class Proc>
-    auto attach(Term& terminal, text cmd, text cwd, text env, twod win, Proc trailer)
+    auto attach(Term& terminal, text cmd, text cwd, text env, twod win, Proc trailer, fd_t r, fd_t w)
     {
         auto fdm = os::syscall{ ::posix_openpt(O_RDWR | O_NOCTTY) }; // Get master TTY.
         auto rc1 = os::syscall{ ::grantpt(fdm.value)              }; // Grant master TTY file access.

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1342,7 +1342,8 @@ namespace netxs::ui
             }
 
             focus(base&&) = delete;
-            focus(base& boss, mode m = mode::hub, bool visible = true, bool cut_scope = faux)
+            //todo drop visible
+            focus(base& boss, mode m = mode::hub, bool cut_scope = faux)
                 : skill{ boss },
                   focusable{ m != mode::hub && m != mode::active },
                   scope{ cut_scope }

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -14,6 +14,7 @@ namespace netxs::scripting
     }
     namespace attr
     {
+        static constexpr auto env = "env";
         static constexpr auto cwd = "cwd";
         static constexpr auto cmd = "cmd";
         static constexpr auto run = "run";
@@ -87,6 +88,7 @@ namespace netxs::scripting
         xlat stream; // scripting::host: Event tracker.
         text curdir; // scripting::host: Current working directory.
         text cmdarg; // scripting::host: Startup command line arguments.
+        text envvar; // scripting::host: Environment block.
         flag active; // scripting::host: Scripting engine lifetime.
         vtty engine; // scripting::host: Scripting engine instance.
 
@@ -137,15 +139,16 @@ namespace netxs::scripting
             engine->write(data + '\n');
         }
         // scripting::host: Start a new process.
-        void start(text cwd, text cmd)
+        void start(text env, text cwd, text cmd)
         {
             if (!engine) return;
             curdir = cwd;
             cmdarg = cmd;
+            envvar = env;
             if (!engine->connected())
             {
-                engine->start(curdir, cmdarg, os::ttysize, [&](auto utf8_shadow) { ondata(utf8_shadow); },
-                                                           [&](auto code, auto msg) { onexit(code, msg); });
+                engine->start(envvar, curdir, cmdarg, os::ttysize, [&](auto utf8_shadow) { ondata(utf8_shadow); },
+                                                                   [&](auto code, auto msg) { onexit(code, msg); });
             }
         }
         void shut()
@@ -166,13 +169,14 @@ namespace netxs::scripting
                 config.pushd(path::scripting);
                 auto rse = config.take(attr::rse, ""s);
                 config.cd(rse);
+                auto env = config.take(attr::env, ""s);
                 auto cwd = config.take(attr::cwd, ""s);
                 auto cmd = config.take(attr::cmd, ""s);
                 auto run = config.take(attr::run, ""s);
                 auto tty = config.take(attr::tty, faux);
                 if (tty) engine = ptr::shared<os::runspace::tty<scripting::host>>(*this);
                 else     engine = ptr::shared<os::runspace::raw<scripting::host>>(*this);
-                start(cwd, cmd);
+                start(env, cwd, cmd);
                 //todo run integration script
                 if (run.size()) write(run);
                 config.popd();

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -107,7 +107,7 @@ namespace netxs::scripting
             });
         }
         // scripting::host: Shutdown callback handler.
-        void onexit(si32 code, view msg = {})
+        void onexit(si32 code, view msg = {}, bool exit_after_sighup = faux)
         {
             //todo initiate global shutdown
 

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -139,16 +139,16 @@ namespace netxs::scripting
             engine->write(data + '\n');
         }
         // scripting::host: Start a new process.
-        void start(text env, text cwd, text cmd)
+        void start(text cmd, text cwd, text env, twod win)
         {
             if (!engine) return;
-            curdir = cwd;
             cmdarg = cmd;
+            curdir = cwd;
             envvar = env;
             if (!engine->connected())
             {
-                engine->start(envvar, curdir, cmdarg, os::ttysize, [&](auto utf8_shadow) { ondata(utf8_shadow); },
-                                                                   [&](auto code, auto msg) { onexit(code, msg); });
+                engine->start(cmd, cwd, env, win, [&](auto utf8_shadow) { ondata(utf8_shadow); },
+                                                  [&](auto code, auto msg) { onexit(code, msg); });
             }
         }
         void shut()
@@ -174,9 +174,10 @@ namespace netxs::scripting
                 auto cmd = config.take(attr::cmd, ""s);
                 auto run = config.take(attr::run, ""s);
                 auto tty = config.take(attr::tty, faux);
+                auto win = os::ttysize;
                 if (tty) engine = ptr::shared<os::runspace::tty<scripting::host>>(*this);
                 else     engine = ptr::shared<os::runspace::raw<scripting::host>>(*this);
-                start(env, cwd, cmd);
+                start(cmd, cwd, env, win);
                 //todo run integration script
                 if (run.size()) write(run);
                 config.popd();

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -139,7 +139,7 @@ namespace netxs::scripting
             engine->write(data + '\n');
         }
         // scripting::host: Start a new process.
-        void start(text cmd, text cwd, text env, twod win)
+        void runapp(text cmd, text cwd, text env, twod win)
         {
             if (!engine) return;
             cmdarg = cmd;
@@ -147,8 +147,8 @@ namespace netxs::scripting
             envvar = env;
             if (!engine->connected())
             {
-                engine->start(cmd, cwd, env, win, [&](auto utf8_shadow) { ondata(utf8_shadow); },
-                                                  [&](auto code, auto msg) { onexit(code, msg); });
+                engine->runapp(cmd, cwd, env, win, [&](auto utf8_shadow) { ondata(utf8_shadow); },
+                                                   [&](auto code, auto msg) { onexit(code, msg); });
             }
         }
         void shut()
@@ -177,7 +177,7 @@ namespace netxs::scripting
                 auto win = os::ttysize;
                 if (tty) engine = ptr::shared<os::runspace::tty<scripting::host>>(*this);
                 else     engine = ptr::shared<os::runspace::raw<scripting::host>>(*this);
-                start(cmd, cwd, env, win);
+                runapp(cmd, cwd, env, win);
                 //todo run integration script
                 if (run.size()) write(run);
                 config.popd();

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2095,6 +2095,13 @@ namespace netxs::os
             }
             // args: Return true if not the end.
             operator bool () const { return iter != data.end(); }
+            // args: Test the starting substring of the current argument.
+            template<class ...Args>
+            auto starts(Args&&... args)
+            {
+                auto result = iter != data.end() && (iter->starts_with(args) || ...);
+                return result;
+            }
             // args: Test the current argument and step forward if met.
             template<class ...Args>
             auto match(Args&&... args)

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2297,7 +2297,10 @@ namespace netxs::os
                         envp.push_back((char*)c.data());
                     }
                     envp.push_back(nullptr);
-                    ::execvpe(argv.front(), argv.data(), envp.data());
+                    auto backup = environ;
+                    environ = envp.data();
+                    ::execvp(argv.front(), argv.data());
+                    environ = backup;
                 }
 
             #endif

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3304,7 +3304,7 @@ namespace netxs::os
                             return faux;
                         }
                     };
-                    auto create = [&]
+                    auto create = [](fd_t s_pipe_r, fd_t s_pipe_w, text cmd, text cwd, text env)
                     {
                         auto wcmd = utf::to_utf(cmd);
                         auto wcwd = utf::to_utf(cwd);
@@ -3348,7 +3348,7 @@ namespace netxs::os
                         }
                         return ok;
                     };
-                    auto result = tunnel() && create();
+                    auto result = tunnel() && create(s_pipe_r, s_pipe_w, cmd, cwd, env);
                     if (!result) onerror();
 
                 #else

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3503,10 +3503,7 @@ namespace netxs::os
                         auto exitcode = termlink->wait();
                         log("%%Process '%cmd%' exited with code %code%", prompt::vtty, utf::debase(cmd), utf::to_hex_0x(exitcode));
                         writesyn.notify_one(); // Interrupt writing thread.
-                        if (!signaled.exchange(true))
-                        {
-                            terminal.onexit(exitcode); // Only if the process terminates on its own (not forced by sighup).
-                        }
+                        terminal.onexit(exitcode, "Process exited", signaled.exchange(true)); // Only if the process terminates on its own (not forced by sighup).
                     }
                 };
                 auto errcode = termlink->attach(terminal, cmd, cwd, env, win, trailer, fds);

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3386,6 +3386,7 @@ namespace netxs::os
                             ::setsid(); // Dissociate from existing controlling terminal (create a new session without a controlling terminal).
                             ::dup2(s_pipe_r, STDIN_FILENO);  os::stdin_fd  = STDIN_FILENO;
                             ::dup2(s_pipe_w, STDOUT_FILENO); os::stdout_fd = STDOUT_FILENO;
+                            ::close(STDERR_FILENO);          os::stderr_fd = os::invalid_fd;
                             if (cwd.size())
                             {
                                 auto err = std::error_code{};

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3242,7 +3242,6 @@ namespace netxs::os
             text env; // vtty: Environment block.
             text cfg; // vtty: App config.
 
-            //fd_t                    prochndl{ os::invalid_fd };
             flag                    attached{};
             ipc::stdcon             termlink{};
             std::thread             stdinput{};

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7819,13 +7819,13 @@ namespace netxs::ui
             ipccon.output(data);
         }
         // dtvt: Attach a new process.
-        void start()
+        void start(text config, auto connect)
         {
             if (!ipccon)
             {
                 auto winsize = base::size();
-                ipccon.runapp(winsize, [&](view utf8) { ondata(utf8); },
-                                       [&]            { onexit();     });
+                ipccon.runapp(config, winsize, connect, [&](view utf8) { ondata(utf8); },
+                                                        [&]            { onexit();     });
             }
         }
         // dtvt: Close dtvt-object.
@@ -7873,13 +7873,12 @@ namespace netxs::ui
         }
 
     protected:
-        dtvt(text cmd, text cwd, text env, text cfg)
+        dtvt()
             : stream{*this },
               active{ true },
               opaque{ 0xFF },
               nodata{      },
-              errmsg{ genmsg(msgs::no_signal) },
-              ipccon{ .cmd = cmd, .cwd = cwd, .env = env, .cfg = cfg }
+              errmsg{ genmsg(msgs::no_signal) }
         {
             //todo make it configurable (max_drops)
             static constexpr auto max_drops = 1;

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7045,9 +7045,10 @@ namespace netxs::ui
             follow[axis::Y] = true;
             write(data);
         }
-        void onexit(si32 code, text msg = {})
+        void onexit(si32 code, text msg = {}, bool exit_after_sighup = faux)
         {
-            netxs::events::enqueue<faux>(This(), [&, code, msg, backup = This()](auto& boss)
+            if (exit_after_sighup) close();
+            else netxs::events::enqueue<faux>(This(), [&, code, msg, backup = This()](auto& boss)
             {
                 ipccon.payoff(io_log);
                 auto lock = netxs::events::sync{};

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7108,7 +7108,7 @@ namespace netxs::ui
         {
             if (!ipccon)
             {
-                ipccon.start(*this, envvar, curdir, cmdarg, target->panel);
+                ipccon.start(*this, cmdarg, curdir, envvar, target->panel);
             }
         }
         void close()
@@ -7176,7 +7176,7 @@ namespace netxs::ui
             new_area.size.y += console.get_basis();
             new_area -= base::intpad;
         }
-        term(text env, text cwd, text cmd, xmls& xml_config)
+        term(text cmd, text cwd, text env, xmls& xml_config)
             : config{ xml_config },
               normal{ *this },
               altbuf{ *this },
@@ -7828,7 +7828,7 @@ namespace netxs::ui
             if (!ipccon)
             {
                 auto winsize = base::size();
-                ipccon.start(envvar, curdir, cmdarg, xmlcfg, winsize, [&](view utf8) { ondata(utf8); },
+                ipccon.start(cmdarg, curdir, envvar, winsize, xmlcfg, [&](view utf8) { ondata(utf8); },
                                                                       [&]            { onexit();     });
             }
         }
@@ -7877,7 +7877,7 @@ namespace netxs::ui
         }
 
     protected:
-        dtvt(text env, text cwd, text cmd, text cfg)
+        dtvt(text cmd, text cwd, text env, text cfg)
             : stream{*this },
               active{ true },
               opaque{ 0xFF },

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -6208,8 +6208,7 @@ namespace netxs::ui
         text       envvar; // term: Environment block.
         text       curdir; // term: Current working directory.
         text       cmdarg; // term: Startup command line arguments.
-        os::fd_t   r_link; // term: .
-        os::fd_t   w_link; // term: .
+        os::fdrw   fdlink; // term: Optional DirectVT uplink.
         hook       onerun; // term: One-shot token for restart session.
         twod       origin; // term: Viewport position.
         twod       follow; // term: Viewport follows cursor (bool: X, Y).
@@ -7110,21 +7109,16 @@ namespace netxs::ui
         {
             if (!ipccon)
             {
-                ipccon.runapp(*this, cmdarg, curdir, envvar, target->panel, r_link, w_link);
+                ipccon.runapp(*this, cmdarg, curdir, envvar, target->panel, fdlink);
             }
         }
-        void start(text cmd, text cwd, text env, os::fd_t r = os::invalid_fd, os::fd_t w = os::invalid_fd)
+        void start(text cmd, text cwd, text env, os::fdrw fds = {})
         {
             cmdarg = cmd;
             curdir = cwd;
             envvar = env;
-            //todo close unused handles (ipc::stdcon)
-            r_link = r;
-            w_link = w;
-            if (!ipccon)
-            {
-                ipccon.runapp(*this, cmd, cwd, env, target->panel, r, w);
-            }
+            fdlink = fds;
+            start();
         }
         void close()
         {

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -946,14 +946,14 @@ namespace netxs::utf
     }
     // utf: Return left substring (from begin) until delimeter (lazy=faux: from left, true: from right).
     template<class T>
-    T cutoff(T const& txt, T const& delimiter = T{ '.' }, bool lazy = true)
+    T cutoff(T const& txt, T const& delimiter = T{ '.' }, bool lazy = true, size_t skip = 0)
     {
-        return txt.substr(0, lazy ? txt.find(delimiter) : txt.rfind(delimiter));
+        return txt.substr(0, lazy ? txt.find(delimiter, skip) : txt.rfind(delimiter, txt.size() - skip));
     }
     template<class T>
-    T cutoff(T const& txt, char delimiter, bool lazy = true)
+    T cutoff(T const& txt, char delimiter, bool lazy = true, size_t skip = 0)
     {
-        return txt.substr(0, lazy ? txt.find(delimiter) : txt.rfind(delimiter));
+        return txt.substr(0, lazy ? txt.find(delimiter, skip) : txt.rfind(delimiter, txt.size() - skip));
     }
     template<class T>
     inline T domain(T const& txt)

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -202,9 +202,11 @@ int main(int argc, char* argv[])
         utf::to_low(shadow);
              if (shadow.starts_with(app::term::id))      { aclass = app::term::id;      apname = app::term::desc;      }
         else if (shadow.starts_with(app::dtvt::id))      { aclass = app::dtvt::id;      apname = app::dtvt::desc;      }
+        else if (shadow.starts_with(app::xlvt::id))      { aclass = app::xlvt::id;      apname = app::xlvt::desc;      }
         else if (shadow.starts_with(app::calc::id))      { aclass = app::calc::id;      apname = app::calc::desc;      }
         else if (shadow.starts_with(app::shop::id))      { aclass = app::shop::id;      apname = app::shop::desc;      }
         else if (shadow.starts_with(app::test::id))      { aclass = app::test::id;      apname = app::test::desc;      }
+        else if (shadow.starts_with(app::xlinkvt::id))   { aclass = app::xlinkvt::id;   apname = app::xlinkvt::desc;   }
         else if (shadow.starts_with(app::directvt::id))  { aclass = app::directvt::id;  apname = app::directvt::desc;  }
         else if (shadow.starts_with(app::textancy::id))  { aclass = app::textancy::id;  apname = app::textancy::desc;  }
         else if (shadow.starts_with(app::headless::id))  { aclass = app::headless::id;  apname = app::headless::desc;  }

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -22,7 +22,12 @@ int main(int argc, char* argv[])
     auto errmsg = text{};
     auto vtpipe = text{};
     auto getopt = os::process::args{ argc, argv };
-    while (getopt)
+    if (getopt.starts(app::ssh::id))
+    {
+        whoami = type::runapp;
+        params = getopt.rest();
+    }
+    else while (getopt)
     {
         if (getopt.match("-r", "--runapp"))
         {
@@ -116,44 +121,45 @@ int main(int argc, char* argv[])
     if (errmsg.size())
     {
         failed(code::errormsg);
-        log("\n"
-            "Virtual terminal multiplexer with window manager and session sharing.\n"
+        log("\nVirtual terminal multiplexer."
             "\n"
-            "  Syntax:\n"
+            "\n  Syntax:"
             "\n"
-            "    " + os::process::binary<true>() + " [ -c <file> ] [ -p <pipe> ] [ -q ] [ -l | -m | -d | -s | -r [<app> [<args...>]] ]\n"
+            "\n    " + os::process::binary<true>() + " [ -c <file> ] [ -p <pipe> ] [ -q ] [ -l | -m | -d | -s | -r [<app> [<args...>]] ]"
             "\n"
-            "  Options:\n"
+            "\n  Options:"
             "\n"
-            "    No arguments       Run client, auto start server if it is not running.\n"
-            "    -c, --config <..>  Load specified settings file.\n"
-            "    -p, --pipe   <..>  Set the pipe to connect to.\n"
-            "    -q, --quiet        Disable logging.\n"
-            "    -l, --listconfig   Show configuration and exit.\n"
-            "    -m, --monitor      Monitor server log.\n"
-            "    -d, --daemon       Run server in background.\n"
-            "    -s, --server       Run server in interactive mode.\n"
-            "    -r, --runapp <..>  Run standalone application.\n"
-            "    -v, --version      Show version and exit.\n"
-            "    -?, -h, --help     Show usage message.\n"
-            "    --onlylog          Disable interactive user input.\n"
+            "\n    No arguments       Run client, auto start server if it is not running."
+            "\n    -c, --config <..>  Load specified settings file."
+            "\n    -p, --pipe   <..>  Set the pipe to connect to."
+            "\n    -q, --quiet        Disable logging."
+            "\n    -l, --listconfig   Show configuration and exit."
+            "\n    -m, --monitor      Monitor server log."
+            "\n    -d, --daemon       Run server in background."
+            "\n    -s, --server       Run server in interactive mode."
+            "\n    -r, --runapp <..>  Run standalone application."
+            "\n    -v, --version      Show version and exit."
+            "\n    -?, -h, --help     Show usage message."
+            "\n    --onlylog          Disable interactive user input."
             "\n"
-            "  Settings loading and merging order:\n"
+            "\n  Settings loading and merging order:"
             "\n"
-            "    - Initialize hardcoded settings\n"
-            "    - Merge with explicitly specified settings from --config <file>\n"
-            "    - If the --config option is not used or <file> cannot be loaded:\n"
-            "        - Merge with system-wide settings from " + os::path::expand(app::shared::sys_config).second + "\n"
-            "        - Merge with user-wise settings from "   + os::path::expand(app::shared::usr_config).second + "\n"
-            "        - Merge with DirectVT packet received from the parent process (dtvt-mode only)\n"
+            "\n    - Initialize hardcoded settings"
+            "\n    - Merge with explicitly specified settings from --config <file>"
+            "\n    - If the --config option is not used or <file> cannot be loaded:"
+            "\n        - Merge with system-wide settings from " + os::path::expand(app::shared::sys_config).second +
+            "\n        - Merge with user-wise settings from "   + os::path::expand(app::shared::usr_config).second +
+            "\n        - Merge with DirectVT packet received from the parent process (dtvt-mode only)"
             "\n"
-            "  Registered applications:\n"
+            "\n  Registered applications:"
             "\n"
-            "    Term  Terminal emulator (default)\n"
-            "    DTVT  DirectVT Proxy Console\n"
-            "    Text  (Demo) Text editor\n"
-            "    Calc  (Demo) Spreadsheet calculator\n"
-            "    Gems  (Demo) Application distribution hub\n"
+            "\n    Term  Terminal emulator (default)"
+            "\n    DTVT  DirectVT Proxy Console"
+            "\n    XLVT  DTVT with controlling terminal onboard (for OpenSSH interactivity)"
+            "\n    Text  (Demo) Text editor"
+            "\n    Calc  (Demo) Spreadsheet calculator"
+            "\n    Gems  (Demo) Application distribution hub"
+            "\n"
             );
     }
     else if (whoami == type::config)
@@ -212,6 +218,12 @@ int main(int argc, char* argv[])
         else if (shadow.starts_with(app::headless::id))  { aclass = app::headless::id;  apname = app::headless::desc;  }
         else if (shadow.starts_with(app::settings::id))  { aclass = app::settings::id;  apname = app::settings::desc;  }
         else if (shadow.starts_with(app::truecolor::id)) { aclass = app::truecolor::id; apname = app::truecolor::desc; }
+        else if (shadow.starts_with(app::ssh::id))
+        {
+            params = " "s + params;
+            aclass = app::xlvt::id;
+            apname = app::xlvt::desc;
+        }
         else
         {
             params = " "s + params;

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -324,6 +324,7 @@ namespace netxs::app::vtm
                         gear.owner.SIGNAL(tier::request, e2::form::prop::viewport, boundary, ());
                         robo.actify(gear.fader<quadratic<twod>>(2s), [&, boundary](auto x)
                         {
+                            //todo revise: crash after window closed (bad weak ptr)
                             convey(x, boundary);
                             boss.strike();
                         });
@@ -1267,7 +1268,10 @@ namespace netxs::app::vtm
                     };
                     boss.LISTEN(tier::release, e2::area, new_area)
                     {
-                        boss.SIGNAL(tier::anycast, e2::form::upon::resized, new_area);
+                        if (new_area.size != boss.base::size())
+                        {
+                            boss.SIGNAL(tier::anycast, e2::form::upon::resized, new_area);
+                        }
                     };
                     auto last_state = ptr::shared(faux);
                     boss.LISTEN(tier::release, e2::form::layout::selected, gear, -, (last_state))

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -148,6 +148,7 @@ R"==(
         <color fgc=whitedk bgc=0xC0202020 /> <!-- Set the bgc alpha to FF to disable acrylics in taskbar. -->
     </menu>
     <panel> <!-- Desktop info panel. -->
+        <env = ""/> <!-- Environment block. -->
         <cmd = ""/> <!-- Command-line to activate. -->
         <cwd = ""/> <!-- Working directory. -->
         <height = 1 /> <!-- Desktop space reserved on top. -->


### PR DESCRIPTION
Changes
- Show the close app button if the taskbar is wide enough.
- Add environment variables support.
  Now it is possible to specify additional environment variables in the menu item configuration:
  ```xml
  <config>
    <menu>
      <item ... env="var1=val1" env="var2=val2" ... />
    </menu>
  </config>
  ```
- Implement XLinkVT (Cross-linked VT) mode to support OpenSSH keyboard-interactivity over DirectVT stream.
  Now it is possible to run dtvt-applications over SSH with any kind of interactive authentication that requires controlling terminal. For example, you can install vtm and the latest OpenSSH server on Windows8 and connect to it via SSH from any terminal on Windows (connection from unix terminal has some unfixed yet keyboard issues). You will get working all win32 console stuff directly over SSH - mouse, keyboard modifiers, and truecolor support. Just type `vtm ssh user@win8host vtm` in your remote terminal (or `vtm -xlvt ssh user@win8host vtm`).
  Also you can configure menu items for such connections:
  ```xml
  <config>
    <menu>
      <item ... type=xlvt param="ssh user@win8host vtm" ... />
    </menu>
  </config>
  ```

Related to #401
Closes #464