### PR TITLE
Fix keybd/mouse input on win<->unix connections

### DIFF
--- a/src/netxs/apps/calc.cpp
+++ b/src/netxs/apps/calc.cpp
@@ -53,6 +53,7 @@ int main(int argc, char* argv[])
     }
     auto params = getopt.rest();
 
+    os::dtvt::checkpoint();
     banner();
     if (errmsg.size())
     {

--- a/src/netxs/apps/term.cpp
+++ b/src/netxs/apps/term.cpp
@@ -53,6 +53,7 @@ int main(int argc, char* argv[])
     }
     auto params = getopt.rest();
 
+    os::dtvt::checkpoint();
     banner();
     if (errmsg.size())
     {

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -862,27 +862,27 @@ namespace netxs::ansi
     static auto link(si32 i)          { return escx{}.link(i);       } // ansi: Set object id link.
     static auto ref(si32 i)           { return escx{}.ref(i);        } // ansi: Create the reference to the existing paragraph. Create new id if it is not existing.
     static auto idx(si32 i)           { return escx{}.idx(i);        } // ansi: Split the text run and associate the fragment with an id.
-                                                                      //       All following text is under the IDX until the next command is issued.
-                                                                      //       Redefine if the id already exists.
-    // ansi: Caret forwarding instructions.
+                                                                       //       All following text is under the IDX until the next command is issued.
+                                                                       //       Redefine if the id already exists.
+    // ansi: Curses commands.
     // The order is important (see the richtext::flow::exec constexpr).
     //todo tie with richtext::flow::exec
     enum fn : si32
     {
-        dx, // horizontal delta.
-        dy, // vertical delta.
-        ax, // x absolute (0-based).
-        ay, // y absolute (0-based).
+        dx, // Cursor step horizontal delta.
+        dy, // Cursor step vertical delta.
+        ax, // Cursor to x absolute (0-based).
+        ay, // Cursor to y absolute (0-based).
 
         //todo deprecated
         ox, // old format x absolute (1-based).
         oy, // old format y absolute (1-based).
 
-        px, // x percent.
-        py, // y percent.
+        px, // Cursor to x percent position.
+        py, // Cursor to y percent position.
         //ts, // set tab size.
-        tb, // tab forward.
-        nl, // next line and reset x to west (carriage return).
+        tb, // Cursor tab forward.
+        nl, // Cursor to next line and reset x to west (carriage return).
         //br, // text wrap mode (DECSET: CSI ? 7 h/l Auto-wrap Mode (DECAWM) or CSI ? 45 h/l reverse wrap around mode).
         //yx, // bidi.
         //hz, // text horizontal alignment.
@@ -893,22 +893,22 @@ namespace netxs::ansi
         //wt, // set top		vertical wrapping field.
         //wb, // set bottom	vertical wrapping field.
 
-        sc, // save caret position.
-        rc, // load caret position.
-        zz, // all params reset to zero.
+        sc, // Save cursor position.
+        rc, // Load cursor position.
+        zz, // All params reset to zero.
 
         //todo revise/deprecated
         // ansi: Paint instructions. The order is important (see the mill).
         // CSI Ps J  Erase in Display (ED), VT100.
-        ed, // Ps = 0  ⇒  Erase Below (default).
-            // Ps = 1  ⇒  Erase Above.
+        ed, // Ps = 0  ⇒  Erase viewport Below (default).
+            // Ps = 1  ⇒  Erase viewport Above.
             // Ps = 2  ⇒  Erase All.
             // Ps = 3  ⇒  Erase Scrollback
 
         // CSI Ps K  Erase in Line (EL), VT100. Caret position does not change.
-        el, // Ps = 0  ⇒  Erase to Right (default).
-            // Ps = 1  ⇒  Erase to Left.
-            // Ps = 2  ⇒  Erase All.
+        el, // Ps = 0  ⇒  Erase line to Right (default).
+            // Ps = 1  ⇒  Erase line to Left.
+            // Ps = 2  ⇒  Erase line All.
 
         fn_count
     };
@@ -934,7 +934,7 @@ namespace netxs::ansi
             return *this;
         }
         mark(cell const& brush)
-            : cell { brush },
+            :  cell{ brush },
               fresh{ brush },
               spare{ brush }
         { }
@@ -1301,7 +1301,7 @@ namespace netxs::ansi
     template<class T>                      typename T::template vt_parser<T> _glb<T>::vt_parser;
 
     template<class T> inline void parse(view utf8, T*&  dest) { _glb<T>::vt_parser.parse(utf8, dest); }
-    template<class T> inline void parse(view utf8, T*&& dest) { T* dptr = dest;    parse(utf8, dptr); }
+    template<class T> inline void parse(view utf8, T*&& dest) { auto dptr = dest;  parse(utf8, dptr); }
     template<class T> inline auto& get_parser()               { return _glb<T>::vt_parser; }
 
     template<class T> using esc_t = func<qiew, T>;
@@ -1336,14 +1336,13 @@ namespace netxs::ansi
                 //esc['M'  ] = __ri;
         }
 
-        // vt_parser: Static UTF-8/ANSI parser proc.
+        // vt_parser: Static UTF-8/ANSI parser.
         void parse(view utf8, T*& client)
         {
-            auto s = [&](auto& traits, auto& utf8)
+            auto s = [&](auto const& traits, qiew utf8)
             {
-                qiew queue{ utf8 };
-                intro.execute(traits.control, queue, client); // Make one iteration using firstcmd and return.
-                return queue;
+                intro.execute(traits.control, utf8, client); // Make one iteration using firstcmd and return.
+                return utf8;
             };
             auto y = [&](auto const& cluster) { client->post(cluster); };
 
@@ -1353,7 +1352,7 @@ namespace netxs::ansi
         // vt_parser: Static UTF-8/ANSI parser proc.
         void parse(view utf8, T*&& client)
         {
-            T* p = client;
+            auto p = client;
             parse(utf8, p);
         }
 
@@ -1371,11 +1370,11 @@ namespace netxs::ansi
             if (ascii.length())
             {
                 auto b = '\0';
-                auto ints = []  (unsigned char cmd) { return cmd >= 0x20 && cmd <= 0x2f; }; // "intermediate bytes" in the range 0x20–0x2F
-                auto pars = []  (unsigned char cmd) { return cmd >= 0x3C && cmd <= 0x3f; }; // "parameter bytes" in the range 0x30–0x3F
-                auto cmds = []  (unsigned char cmd) { return cmd >= 0x40 && cmd <= 0x7E; };
-                auto isC0 = []  (unsigned char cmd) { return cmd <= 0x1F; };
-                auto trap = [&] (auto& c) // Catch and execute C0.
+                auto ints = [](unsigned char cmd) { return cmd >= 0x20 && cmd <= 0x2f; }; // "intermediate bytes" in the range 0x20–0x2F
+                auto pars = [](unsigned char cmd) { return cmd >= 0x3C && cmd <= 0x3f; }; // "parameter bytes" in the range 0x30–0x3F
+                auto cmds = [](unsigned char cmd) { return cmd >= 0x40 && cmd <= 0x7E; };
+                auto isC0 = [](unsigned char cmd) { return cmd <= 0x1F; };
+                auto trap = [&](auto& c) // Catch and execute C0.
                 {
                     if (isC0(c))
                     {
@@ -1393,7 +1392,7 @@ namespace netxs::ansi
                     }
                     return faux;
                 };
-                auto fill = [&] (auto& queue)
+                auto fill = [&](auto& queue)
                 {
                     auto a = ';';
                     auto push = [&](auto num) // Parse subparameters divided by colon ':' (max arg value<int32_t> is 1,073,741,823)

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -17,7 +17,7 @@ namespace netxs::ansi
 
     static const auto esc_csi     = '['; // ESC [ ...
     static const auto esc_ocs     = ']'; // ESC ] ...
-    static const auto esc_dsc     = 'P'; // ESC P ... BELL/ST
+    static const auto esc_dcs     = 'P'; // ESC P ... BELL/ST
     static const auto esc_sos     = 'X'; // ESC X ... BELL/ST
     static const auto esc_pm      = '^'; // ESC ^ ... BELL/ST
     static const auto esc_apc     = '_'; // ESC _ ... BELL/ST
@@ -1820,7 +1820,7 @@ namespace netxs::ansi
                         }
                     }
                     // test Message/Command:
-                    else if (c == 'P'  // DSC ESC P ... BEL
+                    else if (c == 'P'  // DCS ESC P ... BEL
                           || c == 'X'  // SOS ESC X ... BEL
                           || c == '^'  // PM  ESC ^ ... BEL
                           || c == '_') // APC ESC _ ... BEL

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1159,7 +1159,7 @@ namespace netxs::ansi
             if constexpr (InitOutputMode)
             {
                 #define V [](auto& q, auto& p)
-                #define F(t, q) p->task(rule{ fn::t, q })
+                #define F(t, n) p->task(rule{ fn::t, n })
 
                 table[csi_cuu] = V{ F(dy,-q(1)); };              // fx_cuu
                 table[csi_cud] = V{ F(dy, q(1)); };              // fx_cud
@@ -1336,6 +1336,7 @@ namespace netxs::ansi
                 esc[esc_key_a ] = keym;
                 esc[esc_key_n ] = keym;
                 esc[esc_g0set ] = g0__;
+                //esc[esc_ss3   ] = xss3;
                 //esc[esc_sc] = ;
                 //esc[esc_rc] = ;
                 //esc['M'  ] = __ri;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.27";
+    static const auto version = "v0.9.28";
     static const auto ipc_prefix = "vtm";
     static const auto log_suffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -274,7 +274,7 @@ namespace netxs
         // rgba: Rough alpha blending RGBA colors.
         //void mix_alpha(rgba c)
         //{
-        //	auto blend = [] (auto const& c1, auto const& c2, auto const& alpha)
+        //	auto blend = [](auto const& c1, auto const& c2, auto const& alpha)
         //	{
         //		return ((c1 << 8) + (c2 - c1) * alpha) >> 8;
         //	};

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1174,7 +1174,7 @@ namespace netxs::ui
             LISTEN(tier::preview, hids::events::keybd::data::any, gear, tokens)
             {
                 //todo unify
-                if (gear.keystrokes == props.debug_toggle)
+                if (gear.keybd::cluster == props.debug_toggle)
                 {
                     debug ? debug.stop()
                           : debug.start();

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -860,7 +860,7 @@ struct impl : consrv
             auto bttns = gear.m.buttons & 0b00011111;
             auto flags = ui32{};
             if (moved) flags |= MOUSE_MOVED;
-            for (auto i = 0; i < dclick.size(); i++)
+            for (auto i = 0_sz; i < dclick.size(); i++)
             {
                 auto prvbtn = mstate & (1 << i);
                 auto sysbtn = bttns  & (1 << i);

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -951,143 +951,6 @@ struct impl : consrv
                                && need__ctrl == !!(s & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))
                                && need___alt == !!(s & (LEFT_ALT_PRESSED  | RIGHT_ALT_PRESSED ));
         }
-        auto vtencode(input::hids& gear, bool decckm)
-        {
-            static auto truenull = input::key::Key2; //takevkey<'\0'>().vkey; // Ctrl+Shift+VK_2 for US
-            static auto alonekey = std::unordered_map<ui16, text>
-            {
-                { input::key::Backspace,  "\x7f"     },
-                { input::key::Tab,        "\x09"     },
-                { input::key::Pause,      "\x1a"     },
-                { input::key::Esc,        "\033"     },
-                { input::key::PageUp,     "\033[5~"  },
-                { input::key::PageDown,   "\033[6~"  },
-                { input::key::End,        "\033[F"   },
-                { input::key::Home,       "\033[H"   },
-                { input::key::LeftArrow,  "\033[D"   },
-                { input::key::UpArrow,    "\033[A"   },
-                { input::key::RightArrow, "\033[C"   },
-                { input::key::DownArrow,  "\033[B"   },
-                { input::key::Insert,     "\033[2~"  },
-                { input::key::Delete,     "\033[3~"  },
-                { input::key::F1,         "\033OP"   },
-                { input::key::F2,         "\033OQ"   },
-                { input::key::F3,         "\033OR"   },
-                { input::key::F4,         "\033OS"   },
-                { input::key::F5,         "\033[15~" },
-                { input::key::F6,         "\033[17~" },
-                { input::key::F7,         "\033[18~" },
-                { input::key::F8,         "\033[19~" },
-                { input::key::F9,         "\033[20~" },
-                { input::key::F10,        "\033[21~" },
-                { input::key::F11,        "\033[23~" },
-                { input::key::F12,        "\033[24~" },
-            };
-            static auto shiftkey = std::unordered_map<ui16, text>
-            {
-                { input::key::PageUp,     "\033[5; ~"  },
-                { input::key::PageDown,   "\033[6; ~"  },
-                { input::key::End,        "\033[1; F"  },
-                { input::key::Home,       "\033[1; H"  },
-                { input::key::LeftArrow,  "\033[1; D"  },
-                { input::key::UpArrow,    "\033[1; A"  },
-                { input::key::RightArrow, "\033[1; C"  },
-                { input::key::DownArrow,  "\033[1; B"  },
-                { input::key::Insert,     "\033[2; ~"  },
-                { input::key::Delete,     "\033[3; ~"  },
-                { input::key::F1,         "\033[1; P"  },
-                { input::key::F2,         "\033[1; Q"  },
-                { input::key::F3,         "\033[1; R"  },
-                { input::key::F4,         "\033[1; S"  },
-                { input::key::F5,         "\033[15; ~" },
-                { input::key::F6,         "\033[17; ~" },
-                { input::key::F7,         "\033[18; ~" },
-                { input::key::F8,         "\033[19; ~" },
-                { input::key::F9,         "\033[20; ~" },
-                { input::key::F10,        "\033[21; ~" },
-                { input::key::F11,        "\033[23; ~" },
-                { input::key::F12,        "\033[24; ~" },
-            };
-            static auto specials = std::unordered_map<ui32, text>
-            {
-                { input::key::Backspace | input::hids::anyCtrl  << 8, { "\x08"      }},
-                { input::key::Backspace | input::hids::anyAlt   << 8, { "\033\x7f"  }},
-                { input::key::Backspace | input::hids::anyAltGr << 8, { "\033\x08"  }},
-                { input::key::Tab       | input::hids::anyCtrl  << 8, { "\t"        }},
-                { input::key::Tab       | input::hids::anyShift << 8, { "\033[Z"    }},
-                { input::key::Tab       | input::hids::anyAlt   << 8, { "\033[1;3I" }},
-                { input::key::Esc       | input::hids::anyAlt   << 8, { "\033\033"  }},
-                { input::key::Key1      | input::hids::anyCtrl  << 8, { "1"         }},
-                { input::key::Key3      | input::hids::anyCtrl  << 8, { "\x1b"      }},
-                { input::key::Key4      | input::hids::anyCtrl  << 8, { "\x1c"      }},
-                { input::key::Key5      | input::hids::anyCtrl  << 8, { "\x1d"      }},
-                { input::key::Key6      | input::hids::anyCtrl  << 8, { "\x1e"      }},
-                { input::key::Key7      | input::hids::anyCtrl  << 8, { "\x1f"      }},
-                { input::key::Key8      | input::hids::anyCtrl  << 8, { "\x7f"      }},
-                { input::key::Key9      | input::hids::anyCtrl  << 8, { "9"         }},
-                { input::key::Slash     | input::hids::anyAltGr << 8, { "\033\x1f"  }}, // takevkey<'/'>().base
-                { input::key::Slash     | input::hids::anyCtrl  << 8, { "\x1f"      }}, // takevkey<'/'>().base
-                { input::key::Slash     |(input::hids::anyAltGr | input::hids::anyShift) << 8, { "\033\x7f"  }}, // takevkey<'?'>().base
-                { input::key::Slash     |(input::hids::anyCtrl  | input::hids::anyShift) << 8, { "\x7f"      }}, // takevkey<'?'>().base
-                //{ input::key::Slash     | input::hids::anyCtrl  << 8, { "\x1f"      }}, // VK_DIVIDE
-            };
-
-            if (server.inpmod & nt::console::inmode::vt && gear.pressed)
-            {
-                auto s = gear.ctlstate;
-                auto v = gear.keycode & -2; // Generic keys only
-                auto c = gear.cluster.empty() ? 0 : gear.cluster.front();
-
-                if (s & input::hids::LCtrl && s & input::hids::RAlt) // This combination is already translated.
-                {
-                    s &= ~(input::hids::LCtrl | input::hids::RAlt);
-                }
-
-                auto shift = s & input::hids::anyShift ? input::hids::anyShift : 0;
-                auto alt   = s & input::hids::anyAlt   ? input::hids::anyAlt   : 0;
-                auto ctrl  = s & input::hids::anyCtrl  ? input::hids::anyCtrl  : 0;
-                if (shift || alt || ctrl)
-                {
-                    if (ctrl && alt) // c == 0 for ctrl+alt+key combinationsons on windows.
-                    {
-                        if (c == 0) // Chars and vkeys for ' '(0x20),'A'-'Z'(0x41-5a) are the same on windows.
-                        {
-                                 if (v >= input::key::KeyA  && v <= input::key::KeyZ) return "\033"s + (char)((0x41 + (v - input::key::KeyA) / 2) & 0b00011111);//generate('\033', (wchr)( a  & 0b00011111)); // Alt causes to prepend '\033'. Ctrl trims by 0b00011111.
-                            else if (v == input::key::Space || v == truenull)         return "\033\0"s;  //'\033' + (wchr)('@' & 0b00011111)); // Map ctrl+alt+@ to ^[^@;
-                        }
-                        else if (c == 0x20 || (c >= 'A' && c <= 'Z')) return "\033"s + (char)(c & 0b00011111);//generate('\033', (wchr)( a  & 0b00011111)); // Alt causes to prepend '\033'. Ctrl trims by 0b00011111.
-                    }
-
-                    if (auto iter = shiftkey.find(v); iter != shiftkey.end())
-                    {
-                        auto& mods = *++(iter->second.rbegin());
-                        mods = '1';
-                        if (shift) mods += 1;
-                        if (alt  ) mods += 2;
-                        if (ctrl ) mods += 4;
-                        return iter->second;
-                    }
-                    else if (auto iter = specials.find(v | (shift | alt | ctrl) << 8); iter != specials.end())
-                    {
-                        return iter->second;
-                    }
-                    else if (!ctrl &&  alt && c) return text{ '\033' + gear.cluster };
-                    else if ( ctrl && !alt)
-                    {
-                             if (c == 0x20 || (c == 0x00 && v == truenull))                     return text(1, '@' & 0b00011111); // Detect ctrl+@ and ctrl+space.
-                        else if (c == 0x00 && (v >= input::key::KeyA && v <= input::key::KeyZ)) return text(1, (0x41 + (v - input::key::KeyA) / 2) & 0b00011111); // Emulate ctrl+key mapping to C0 if current kb layout does not contain it.
-                    }
-                }
-
-                if (auto iter = alonekey.find(v); iter != alonekey.end())
-                {
-                    if (v >= input::key::End && v <= input::key::DownArrow) iter->second[1] = decckm ? 'O' : '[';
-                    return iter->second;
-                }
-                else if (c) return gear.cluster;
-            }
-            return text{};
-        }
         void keybd(input::hids& gear, bool decckm)
         {
             auto lock = std::lock_guard{ locker };
@@ -1110,12 +973,15 @@ struct impl : consrv
             }
             else
             {
-                auto yield = vtencode(gear, decckm);
-                if (yield.size())
+                if (server.inpmod & nt::console::inmode::vt)
                 {
-                    toWIDE.clear();
-                    utf::to_utf(yield, toWIDE);
-                    generate(toWIDE);
+                    auto yield = gear.interpret(decckm);
+                    if (yield.size())
+                    {
+                        toWIDE.clear();
+                        utf::to_utf(yield, toWIDE);
+                        generate(toWIDE);
+                    }
                 }
                 else generate(c, ctrls, gear.virtcod, gear.pressed, gear.scancod);
             }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -806,10 +806,10 @@ struct impl : consrv
                 if (c == '\n' || c == '\r')
                 {
                     if (head != tail && *head == (c == '\n' ? '\r' : '\n')) head++; // Eat CR+LF/LF+CR.
-                    generate('\r', s, VK_RETURN, 1, 0x1c /*takevkey<VK_RETURN>().key*/); // Emulate hitting Enter.
+                    generate('\r', s, VK_RETURN, 1, 0x1c /*os::nt::takevkey<VK_RETURN>().key*/); // Emulate hitting Enter.
                     // Far Manager treats Shift+Enter as its own macro not a soft break.
                     //if (noni) generate('\n', s);
-                    //else      generate('\r', s | SHIFT_PRESSED, VK_RETURN, 1, 0x1c /*takevkey<VK_RETURN>().key*/); // Emulate hitting Enter. Pressed Shift to soft line break when pasting from clipboard.
+                    //else      generate('\r', s | SHIFT_PRESSED, VK_RETURN, 1, 0x1c /*os::nt::takevkey<VK_RETURN>().key*/); // Emulate hitting Enter. Pressed Shift to soft line break when pasting from clipboard.
                 }
                 else
                 {
@@ -931,19 +931,9 @@ struct impl : consrv
             signal.notify_one();
         }
         template<char C>
-        static auto takevkey()
-        {
-            struct vkey { si16 key, vkey; ui32 base; };
-            static auto x = ::VkKeyScanW(C);
-            static auto k = vkey{ x, x & 0xff, x & 0xff |((x & 0x0100 ? input::hids::anyShift : 0)
-                                                        | (x & 0x0200 ? input::hids::anyCtrl  : 0)
-                                                        | (x & 0x0400 ? input::hids::anyAlt   : 0)) << 8 };
-            return k;
-        }
-        template<char C>
         static auto truechar(ui16 v, ui32 s)
         {
-            static auto x = takevkey<C>();
+            static auto x = os::nt::takevkey<C>();
             static auto need_shift = !!(x.key & 0x100);
             static auto need__ctrl = !!(x.key & 0x200);
             static auto need___alt = !!(x.key & 0x400);

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -872,7 +872,7 @@ struct impl : consrv
                 if (prvbtn != sysbtn && sysbtn) // MS UX guidelines recommend signaling a double-click when the button is pressed twice rather than when it is released twice.
                 {
                     auto& s = dclick[i];
-                    auto fired = datetime::now();
+                    auto fired = gear.m.timecod;
                     if (fired - s.fired < gear.delay && s.coord == coord) // Set the double-click flag if the delay has not expired and the mouse is in the same position.
                     {
                         flags |= DOUBLE_CLICK;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -953,89 +953,89 @@ struct impl : consrv
         }
         auto vtencode(input::hids& gear, bool decckm)
         {
-            static auto truenull = takevkey<'\0'>().vkey;
+            static auto truenull = input::key::Key2; //takevkey<'\0'>().vkey; // Ctrl+Shift+VK_2 for US
             static auto alonekey = std::unordered_map<ui16, text>
             {
-                { VK_BACK,   "\x7f"     },
-                { VK_TAB,    "\x09"     },
-                { VK_PAUSE,  "\x1a"     },
-                { VK_ESCAPE, "\033"     },
-                { VK_PRIOR,  "\033[5~"  },
-                { VK_NEXT,   "\033[6~"  },
-                { VK_END,    "\033[F"   },
-                { VK_HOME,   "\033[H"   },
-                { VK_LEFT,   "\033[D"   },
-                { VK_UP,     "\033[A"   },
-                { VK_RIGHT,  "\033[C"   },
-                { VK_DOWN,   "\033[B"   },
-                { VK_INSERT, "\033[2~"  },
-                { VK_DELETE, "\033[3~"  },
-                { VK_F1,     "\033OP"   },
-                { VK_F2,     "\033OQ"   },
-                { VK_F3,     "\033OR"   },
-                { VK_F4,     "\033OS"   },
-                { VK_F5,     "\033[15~" },
-                { VK_F6,     "\033[17~" },
-                { VK_F7,     "\033[18~" },
-                { VK_F8,     "\033[19~" },
-                { VK_F9,     "\033[20~" },
-                { VK_F10,    "\033[21~" },
-                { VK_F11,    "\033[23~" },
-                { VK_F12,    "\033[24~" },
+                { input::key::Backspace,  "\x7f"     },
+                { input::key::Tab,        "\x09"     },
+                { input::key::Pause,      "\x1a"     },
+                { input::key::Esc,        "\033"     },
+                { input::key::PageUp,     "\033[5~"  },
+                { input::key::PageDown,   "\033[6~"  },
+                { input::key::End,        "\033[F"   },
+                { input::key::Home,       "\033[H"   },
+                { input::key::LeftArrow,  "\033[D"   },
+                { input::key::UpArrow,    "\033[A"   },
+                { input::key::RightArrow, "\033[C"   },
+                { input::key::DownArrow,  "\033[B"   },
+                { input::key::Insert,     "\033[2~"  },
+                { input::key::Delete,     "\033[3~"  },
+                { input::key::F1,         "\033OP"   },
+                { input::key::F2,         "\033OQ"   },
+                { input::key::F3,         "\033OR"   },
+                { input::key::F4,         "\033OS"   },
+                { input::key::F5,         "\033[15~" },
+                { input::key::F6,         "\033[17~" },
+                { input::key::F7,         "\033[18~" },
+                { input::key::F8,         "\033[19~" },
+                { input::key::F9,         "\033[20~" },
+                { input::key::F10,        "\033[21~" },
+                { input::key::F11,        "\033[23~" },
+                { input::key::F12,        "\033[24~" },
             };
             static auto shiftkey = std::unordered_map<ui16, text>
             {
-                { VK_PRIOR,  "\033[5; ~"  },
-                { VK_NEXT,   "\033[6; ~"  },
-                { VK_END,    "\033[1; F"  },
-                { VK_HOME,   "\033[1; H"  },
-                { VK_LEFT,   "\033[1; D"  },
-                { VK_UP,     "\033[1; A"  },
-                { VK_RIGHT,  "\033[1; C"  },
-                { VK_DOWN,   "\033[1; B"  },
-                { VK_INSERT, "\033[2; ~"  },
-                { VK_DELETE, "\033[3; ~"  },
-                { VK_F1,     "\033[1; P"  },
-                { VK_F2,     "\033[1; Q"  },
-                { VK_F3,     "\033[1; R"  },
-                { VK_F4,     "\033[1; S"  },
-                { VK_F5,     "\033[15; ~" },
-                { VK_F6,     "\033[17; ~" },
-                { VK_F7,     "\033[18; ~" },
-                { VK_F8,     "\033[19; ~" },
-                { VK_F9,     "\033[20; ~" },
-                { VK_F10,    "\033[21; ~" },
-                { VK_F11,    "\033[23; ~" },
-                { VK_F12,    "\033[24; ~" },
+                { input::key::PageUp,     "\033[5; ~"  },
+                { input::key::PageDown,   "\033[6; ~"  },
+                { input::key::End,        "\033[1; F"  },
+                { input::key::Home,       "\033[1; H"  },
+                { input::key::LeftArrow,  "\033[1; D"  },
+                { input::key::UpArrow,    "\033[1; A"  },
+                { input::key::RightArrow, "\033[1; C"  },
+                { input::key::DownArrow,  "\033[1; B"  },
+                { input::key::Insert,     "\033[2; ~"  },
+                { input::key::Delete,     "\033[3; ~"  },
+                { input::key::F1,         "\033[1; P"  },
+                { input::key::F2,         "\033[1; Q"  },
+                { input::key::F3,         "\033[1; R"  },
+                { input::key::F4,         "\033[1; S"  },
+                { input::key::F5,         "\033[15; ~" },
+                { input::key::F6,         "\033[17; ~" },
+                { input::key::F7,         "\033[18; ~" },
+                { input::key::F8,         "\033[19; ~" },
+                { input::key::F9,         "\033[20; ~" },
+                { input::key::F10,        "\033[21; ~" },
+                { input::key::F11,        "\033[23; ~" },
+                { input::key::F12,        "\033[24; ~" },
             };
             static auto specials = std::unordered_map<ui32, text>
             {
-                { VK_BACK              | input::hids::anyCtrl  << 8, { "\x08"      }},
-                { VK_BACK              | input::hids::anyAlt   << 8, { "\033\x7f"  }},
-                { VK_BACK              | input::hids::anyAltGr << 8, { "\033\x08"  }},
-                { VK_TAB               | input::hids::anyCtrl  << 8, { "\t"        }},
-                { VK_TAB               | input::hids::anyShift << 8, { "\033[Z"    }},
-                { VK_TAB               | input::hids::anyAlt   << 8, { "\033[1;3I" }},
-                { VK_ESCAPE            | input::hids::anyAlt   << 8, { "\033\033"  }},
-                { '1'                  | input::hids::anyCtrl  << 8, { "1"         }},
-                { '3'                  | input::hids::anyCtrl  << 8, { "\x1b"      }},
-                { '4'                  | input::hids::anyCtrl  << 8, { "\x1c"      }},
-                { '5'                  | input::hids::anyCtrl  << 8, { "\x1d"      }},
-                { '6'                  | input::hids::anyCtrl  << 8, { "\x1e"      }},
-                { '7'                  | input::hids::anyCtrl  << 8, { "\x1f"      }},
-                { '8'                  | input::hids::anyCtrl  << 8, { "\x7f"      }},
-                { '9'                  | input::hids::anyCtrl  << 8, { "9"         }},
-                { VK_DIVIDE            | input::hids::anyCtrl  << 8, { "\x1f"      }},
-                { takevkey<'?'>().base | input::hids::anyAltGr << 8, { "\033\x7f"  }},
-                { takevkey<'?'>().base | input::hids::anyCtrl  << 8, { "\x7f"      }},
-                { takevkey<'/'>().base | input::hids::anyAltGr << 8, { "\033\x1f"  }},
-                { takevkey<'/'>().base | input::hids::anyCtrl  << 8, { "\x1f"      }},
+                { input::key::Backspace | input::hids::anyCtrl  << 8, { "\x08"      }},
+                { input::key::Backspace | input::hids::anyAlt   << 8, { "\033\x7f"  }},
+                { input::key::Backspace | input::hids::anyAltGr << 8, { "\033\x08"  }},
+                { input::key::Tab       | input::hids::anyCtrl  << 8, { "\t"        }},
+                { input::key::Tab       | input::hids::anyShift << 8, { "\033[Z"    }},
+                { input::key::Tab       | input::hids::anyAlt   << 8, { "\033[1;3I" }},
+                { input::key::Esc       | input::hids::anyAlt   << 8, { "\033\033"  }},
+                { input::key::Key1      | input::hids::anyCtrl  << 8, { "1"         }},
+                { input::key::Key3      | input::hids::anyCtrl  << 8, { "\x1b"      }},
+                { input::key::Key4      | input::hids::anyCtrl  << 8, { "\x1c"      }},
+                { input::key::Key5      | input::hids::anyCtrl  << 8, { "\x1d"      }},
+                { input::key::Key6      | input::hids::anyCtrl  << 8, { "\x1e"      }},
+                { input::key::Key7      | input::hids::anyCtrl  << 8, { "\x1f"      }},
+                { input::key::Key8      | input::hids::anyCtrl  << 8, { "\x7f"      }},
+                { input::key::Key9      | input::hids::anyCtrl  << 8, { "9"         }},
+                { input::key::Slash     | input::hids::anyAltGr << 8, { "\033\x1f"  }}, // takevkey<'/'>().base
+                { input::key::Slash     | input::hids::anyCtrl  << 8, { "\x1f"      }}, // takevkey<'/'>().base
+                { input::key::Slash     |(input::hids::anyAltGr | input::hids::anyShift) << 8, { "\033\x7f"  }}, // takevkey<'?'>().base
+                { input::key::Slash     |(input::hids::anyCtrl  | input::hids::anyShift) << 8, { "\x7f"      }}, // takevkey<'?'>().base
+                //{ input::key::Slash     | input::hids::anyCtrl  << 8, { "\x1f"      }}, // VK_DIVIDE
             };
 
             if (server.inpmod & nt::console::inmode::vt && gear.pressed)
             {
                 auto s = gear.ctlstate;
-                auto v = gear.virtcod;
+                auto v = gear.keycode & -2; // Generic keys only
                 auto c = gear.cluster.empty() ? 0 : gear.cluster.front();
 
                 if (s & input::hids::LCtrl && s & input::hids::RAlt) // This combination is already translated.
@@ -1050,9 +1050,12 @@ struct impl : consrv
                 {
                     if (ctrl && alt) // c == 0 for ctrl+alt+key combinationsons on windows.
                     {
-                        auto a = c ? c : v; // Chars and vkeys for ' '(0x20),'A'-'Z'(0x41-5a) are the same on windows.
-                             if (a == 0x20 || (a >= 0x41 && a <= 0x5a)) return "\033"s + (char)(a & 0b00011111);//generate('\033', (wchr)( a  & 0b00011111)); // Alt causes to prepend '\033'. Ctrl trims by 0b00011111.
-                        else if (c == 0x00 && v == truenull           ) return "\033\0"s;  //'\033' + (wchr)('@' & 0b00011111)); // Map ctrl+alt+@ to ^[^@;
+                        if (c == 0) // Chars and vkeys for ' '(0x20),'A'-'Z'(0x41-5a) are the same on windows.
+                        {
+                                 if (v >= input::key::KeyA  && v <= input::key::KeyZ) return "\033"s + (char)((0x41 + (v - input::key::KeyA) / 2) & 0b00011111);//generate('\033', (wchr)( a  & 0b00011111)); // Alt causes to prepend '\033'. Ctrl trims by 0b00011111.
+                            else if (v == input::key::Space || v == truenull)         return "\033\0"s;  //'\033' + (wchr)('@' & 0b00011111)); // Map ctrl+alt+@ to ^[^@;
+                        }
+                        else if (c == 0x20 || (c >= 'A' && c <= 'Z')) return "\033"s + (char)(c & 0b00011111);//generate('\033', (wchr)( a  & 0b00011111)); // Alt causes to prepend '\033'. Ctrl trims by 0b00011111.
                     }
 
                     if (auto iter = shiftkey.find(v); iter != shiftkey.end())
@@ -1071,14 +1074,14 @@ struct impl : consrv
                     else if (!ctrl &&  alt && c) return text{ '\033' + gear.cluster };
                     else if ( ctrl && !alt)
                     {
-                             if (c == 0x20 || (c == 0x00 && v == truenull)) return text(1, '@' & 0b00011111); // Detect ctrl+@ and ctrl+space.
-                        else if (c == 0x00 && (v >= 0x41 && v <= 0x5A))     return text(1,  v  & 0b00011111); // Emulate ctrl+key mapping to C0 if current kb layout does not contain it.
+                             if (c == 0x20 || (c == 0x00 && v == truenull))                     return text(1, '@' & 0b00011111); // Detect ctrl+@ and ctrl+space.
+                        else if (c == 0x00 && (v >= input::key::KeyA && v <= input::key::KeyZ)) return text(1, (0x41 + (v - input::key::KeyA) / 2) & 0b00011111); // Emulate ctrl+key mapping to C0 if current kb layout does not contain it.
                     }
                 }
 
                 if (auto iter = alonekey.find(v); iter != alonekey.end())
                 {
-                    if (v >= VK_END && v <= VK_DOWN) iter->second[1] = decckm ? 'O' : '[';
+                    if (v >= input::key::End && v <= input::key::DownArrow) iter->second[1] = decckm ? 'O' : '[';
                     return iter->second;
                 }
                 else if (c) return gear.cluster;

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -823,7 +823,6 @@ namespace netxs::directvt
                                         (ui32, ctlstat)  // sysmouse: Keybd modifiers.
                                         (ui32, enabled)  // sysmouse: Mouse device health status.
                                         (ui32, buttons)  // sysmouse: Buttons bit state.
-                                        (bool, doubled)  // sysmouse: Double click.
                                         (bool, wheeled)  // sysmouse: Vertical scroll wheel.
                                         (bool, hzwheel)  // sysmouse: Horizontal scroll wheel.
                                         (si32, wheeldt)  // sysmouse: Scroll delta.

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -827,6 +827,7 @@ namespace netxs::directvt
                                         (bool, hzwheel)  // sysmouse: Horizontal scroll wheel.
                                         (si32, wheeldt)  // sysmouse: Scroll delta.
                                         (twod, coordxy)  // sysmouse: Cursor coordinates.
+                                        (time, timecod)  // sysmouse: Event time code.
                                         (ui32, changed)) // sysmouse: Update stamp.
         STRUCT_macro(mousebar,          (bool, mode)) // CCC_SMS/* 26:1p */
         STRUCT_macro(unknown_gc,        (ui64, token))

--- a/src/netxs/desktopio/events.hpp
+++ b/src/netxs/desktopio/events.hpp
@@ -418,8 +418,8 @@ namespace netxs::events
     #endif
 
     //todo deprecated?
-    //#define LISTEN_AND_RUN_T(level, event, token, param, arg) bell::template submit2<level,decltype( event )>( arg, token ) = [&] (typename decltype( event )::type && param)
-    //#define LISTEN_AND_RUN(  level, event,        param, arg) bell::template submit2<level,decltype( event )>( arg        ) = [&] (typename decltype( event )::type && param)
+    //#define LISTEN_AND_RUN_T(level, event, token, param, arg) bell::template submit2<level,decltype( event )>( arg, token ) = [&](typename decltype( event )::type && param)
+    //#define LISTEN_AND_RUN(  level, event,        param, arg) bell::template submit2<level,decltype( event )>( arg        ) = [&](typename decltype( event )::type && param)
     //#define SIGNAL_GLOBAL(        event, param              ) bell::template signal_global(decltype( event )::id, static_cast<typename decltype( event )::type &&>(param))
     //#define LISTEN_GLOBAL(        event, param, token       ) bell::template submit_global( event, token -0 ) = [&]                  (typename decltype( event )::type&& param)
 

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1132,6 +1132,7 @@ namespace netxs::input
             NumLock  = 1 << 12, // ⇭ Num Lock
             CapsLock = 1 << 13, // ⇪ Caps Lock
             ScrlLock = 1 << 14, // ⇳ Scroll Lock (⤓)
+            AltGr    = LAlt   | LCtrl,
             anyCtrl  = LCtrl  | RCtrl,
             anyAlt   = LAlt   | RAlt,
             anyShift = LShift | RShift,

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -335,6 +335,7 @@ namespace netxs::input
             };
         };
 
+        //todo check non-us kb layouts with key::Slash
         #define key_list \
             /*Id   Vkey  Scan    CtrlState          Mask  I  Name            */\
             X(0,      0,    0,           0, 0x0000'00'FF, 1, undef            )\

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -822,7 +822,6 @@ namespace netxs::input
                 m.wheeled = {}; // Clear one-shot events.
                 m.hzwheel = {};
                 m.wheeldt = {};
-                m.doubled = {};
             }
         }
         // mouse: Initiator of visual tree informing about mouse enters/leaves.
@@ -1467,7 +1466,6 @@ namespace netxs::input
                         m.wheeled = {};
                         m.wheeldt = {};
                         m.hzwheel = {};
-                        m.doubled = {};
                     }
                 }
                 else if (mouse::swift == next_id) mouse::setfree();

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -668,6 +668,15 @@ namespace netxs::input
                 blocked <<= 3;
             }
         }
+        // mouse: Sync the button state with a bitset.
+        auto sync_button_state(ui32 bitstat)
+        {
+            for (auto& b : bttns)
+            {
+                b.pressed = bitstat & 0x1;
+                bitstat >> 1;
+            }
+        }
         // mouse: Return a kinetic animator.
         template<class Law>
         auto fader(span spell)
@@ -694,6 +703,7 @@ namespace netxs::input
                 coord = m.coordxy;
                 prime = m.coordxy;
                 fire(movement); // Update mouse enter/leave state.
+                sync_button_state(m.buttons);
                 return;
             }
             if (m_buttons[leftright]) // Cancel left and right dragging if it is.
@@ -748,7 +758,11 @@ namespace netxs::input
                 fire(movement);
             }
 
-            if (!busy && fire_fast()) return;
+            if (!busy && fire_fast())
+            {
+                sync_button_state(m.buttons);
+                return;
+            }
 
             auto genptr = std::begin(bttns);
             for (auto i = 0; i < numofbuttons; i++)
@@ -780,7 +794,7 @@ namespace netxs::input
                                 // Fire a double/triple-click if delay is not expired
                                 // and the mouse is at the same position.
                                 auto& s = stamp[i];
-                                auto fired = datetime::now();
+                                auto fired = m.timecod;
                                 if (fired - s.fired < delay && s.coord == coord)
                                 {
                                     if (!genbtn.blocked)

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -286,63 +286,35 @@ namespace netxs::input
         {
             sz_t hash; // map: Key hash.
 
-            //todo combine to the single vector
-            static auto& vkey()
-            {
-                static auto v = std::vector<byte>(256);
-                return v;
-            }
-            static auto& scan()
-            {
-                static auto s = std::vector<byte>(256);
-                return s;
-            }
-            static auto& edit()
-            {
-                static auto b = std::vector<byte>(256);
-                return b;
-            }
             static auto& mask()
             {
                 static auto m = std::vector<si32>(256);
                 return m;
             }
-            static auto& mask(si32 vk)
+            static auto& mask(byte vk)
             {
-                return mask()[vk & 0xFF];
+                return mask()[vk];
             }
-            static auto& name()
+            static auto& data(byte keycode)
             {
-                static auto n = std::vector<view>(256);
-                return n;
-            }
-            static auto& name(si32 keycode)
-            {
-                return name()[keycode];
-            }
-            static auto& edit(si32 keycode)
-            {
-                return edit()[keycode];
-            }
-            static auto& vkey(si32 keycode)
-            {
-                return vkey()[keycode];
-            }
-            static auto& scan(si32 keycode)
-            {
-                return scan()[keycode];
+                struct key
+                {
+                    view name;
+                    si32 vkey;
+                    si32 scan;
+                    si32 edit;
+                };
+                static auto data = std::vector<key>(256);
+                return data[keycode];
             }
 
             map(si32 vk, si32 sc, ui32 cs)
                 : hash{ static_cast<sz_t>(mask(vk) & (vk | (sc << 8) | (cs << 16))) }
             { }
-            map(si32 vk, si32 sc, ui32 cs, si32 keymask, view keyname, byte doinput, si32 id)
+            map(si32 vk, si32 sc, ui32 cs, si32 keymask, view keyname, si32 doinput, si32 id)
             {
                 mask(vk) = keymask;
-                name(id) = keyname;
-                edit(id) = doinput;
-                vkey(id) = vk;
-                scan(id) = sc;
+                data(id) = { .name = keyname, .vkey = vk, .scan = sc, .edit = doinput };
                 hash = static_cast<sz_t>(keymask & (vk | (sc << 8) | (cs << 16)));
             }
 
@@ -950,7 +922,7 @@ namespace netxs::input
 
         auto doinput()
         {
-            return pressed && key::map::edit(keycode);
+            return pressed && key::map::data(keycode).edit;
         }
         auto generic()
         {

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -674,7 +674,7 @@ namespace netxs::input
             for (auto& b : bttns)
             {
                 b.pressed = bitstat & 0x1;
-                bitstat >> 1;
+                bitstat >>= 1;
             }
         }
         // mouse: Return a kinetic animator.

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -286,6 +286,17 @@ namespace netxs::input
         {
             sz_t hash; // map: Key hash.
 
+            //todo combine to the single vector
+            static auto& vkey()
+            {
+                static auto v = std::vector<byte>(256);
+                return v;
+            }
+            static auto& scan()
+            {
+                static auto s = std::vector<byte>(256);
+                return s;
+            }
             static auto& edit()
             {
                 static auto b = std::vector<byte>(256);
@@ -313,6 +324,14 @@ namespace netxs::input
             {
                 return edit()[keycode];
             }
+            static auto& vkey(si32 keycode)
+            {
+                return vkey()[keycode];
+            }
+            static auto& scan(si32 keycode)
+            {
+                return scan()[keycode];
+            }
 
             map(si32 vk, si32 sc, ui32 cs)
                 : hash{ static_cast<sz_t>(mask(vk) & (vk | (sc << 8) | (cs << 16))) }
@@ -322,6 +341,8 @@ namespace netxs::input
                 mask(vk) = keymask;
                 name(id) = keyname;
                 edit(id) = doinput;
+                vkey(id) = vk;
+                scan(id) = sc;
                 hash = static_cast<sz_t>(keymask & (vk | (sc << 8) | (cs << 16)));
             }
 

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1017,7 +1017,7 @@ namespace netxs::ui
 
     // richtext: Enriched text paragraph.
     class para
-        : public ansi::output::parser
+        : public ansi::parser
     {
         using corx = netxs::sptr<rich>;
 
@@ -1086,11 +1086,11 @@ namespace netxs::ui
             {
                 auto c = cluster;
                 c.attr.ucwidth = netxs::unidata::widths::slim;
-                ansi::output::parser::post(c);
+                ansi::parser::post(c);
             }
             else
             {
-                ansi::output::parser::post(cluster);
+                ansi::parser::post(cluster);
             }
         }
         void id(ui32 newid) { index = newid; }
@@ -1496,7 +1496,7 @@ namespace netxs::ui
 
     // richtext: Enriched text page.
     class page
-        : public ansi::output::parser
+        : public ansi::parser
     {
         using list = std::list<netxs::sptr<para>>;
         using iter = list::iterator;
@@ -1702,11 +1702,11 @@ namespace netxs::ui
             {
                 auto c = cluster;
                 c.attr.ucwidth = netxs::unidata::widths::slim;
-                ansi::output::parser::post(c);
+                ansi::parser::post(c);
             }
             else
             {
-                ansi::output::parser::post(cluster);
+                ansi::parser::post(cluster);
             }
         }
         void data(si32 count, grid const& proto) override

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1017,7 +1017,7 @@ namespace netxs::ui
 
     // richtext: Enriched text paragraph.
     class para
-        : public ansi::parser
+        : public ansi::output::parser
     {
         using corx = netxs::sptr<rich>;
 
@@ -1086,11 +1086,11 @@ namespace netxs::ui
             {
                 auto c = cluster;
                 c.attr.ucwidth = netxs::unidata::widths::slim;
-                ansi::parser::post(c);
+                ansi::output::parser::post(c);
             }
             else
             {
-                ansi::parser::post(cluster);
+                ansi::output::parser::post(cluster);
             }
         }
         void id(ui32 newid) { index = newid; }
@@ -1496,7 +1496,7 @@ namespace netxs::ui
 
     // richtext: Enriched text page.
     class page
-        : public ansi::parser
+        : public ansi::output::parser
     {
         using list = std::list<netxs::sptr<para>>;
         using iter = list::iterator;
@@ -1702,11 +1702,11 @@ namespace netxs::ui
             {
                 auto c = cluster;
                 c.attr.ucwidth = netxs::unidata::widths::slim;
-                ansi::parser::post(c);
+                ansi::output::parser::post(c);
             }
             else
             {
-                ansi::parser::post(cluster);
+                ansi::output::parser::post(cluster);
             }
         }
         void data(si32 count, grid const& proto) override

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4499,9 +4499,9 @@ namespace netxs::os
                 // 0x7f (DEL)   Backspace
                 //
                 // CSI final bytes: 0x40–0x7E  @A–Z[\]^_`a–z{|}~
-                // ESC O        SS3,    Sets a flag for the next char
-                // ESC [ [      CSI [,  Sets a flag for the next char
-                // CSI ~, F, G, H, Z, I, O, M, m, _, p
+                // ESC O        Alt+Shift+O
+                // ESC [        Alt+[
+                // CSI ~, A, B, C, D, F, G, H, Z, I, O, M, m, p
                 // ESC[200~  + utf8 +  ESC[201~     Clipboard paste()
 
                 enum class type

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4523,13 +4523,14 @@ namespace netxs::os
                     {
                         while (head != tail) // Looking for CSI command.
                         {
-                            c = *head++;
+                            c = *head;
                             if (c >= 0x40 && c <= 0x7E) break;
+                            head++;
                         }
                         if (head == tail) incomplete = true;
                         else
                         {
-                            auto len = std::distance(s.begin(), head);
+                            auto len = std::distance(s.begin(), head) + 1;
                             if (c == 'm' || c == 'M')
                             {
                                 if (len > 3 && s[2] == '<') t = type::mouse;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4502,6 +4502,73 @@ namespace netxs::os
                 // ESC O        SS3,    Sets a flag for the next char
                 // ESC [ [      CSI [,  Sets a flag for the next char
                 // CSI ~, F, G, H, Z, I, O, M, m, _, p
+                // ESC[200~  + utf8 +  ESC[201~     Clipboard paste()
+
+                //
+                // total += accum;
+                // while (total.size())
+                // if (flag_paste)
+                // {
+                //      looking for
+                //      if (paste end)
+                //      {
+                //          paste(p);
+                //          flag_paste = faux;
+                //      }
+                // }
+                // else if (total.size() == 1)
+                // {
+                //      detect key
+                //      send key press
+                //      send key release
+                // }
+                // else if (total.front() == '\033')
+                // {
+                //     take sequence
+                //     if (sequence incomplete) break;
+                //     else if (seq == mouse)
+                //     {
+                //          mouse(m);
+                //     }
+                //     else if (seq == focus)
+                //     {
+                //          focus(f);
+                //     }
+                //     else if (seq == style)
+                //     {
+                //          style(s);
+                //     }
+                //     else if (seq == paste)
+                //     {
+                //          set flag_paste
+                //          continue;
+                //     }
+                //     else if (seq == win32)
+                //     {
+                //          keybd(k);
+                //     }
+                //     else
+                //     {
+                //          detect key
+                //          send key press
+                //          send key release
+                //     }
+                // }
+                // else
+                // {
+                //     take cluster
+                //     if (cluster.size() == 1 && (cluster.front() < 32 || cluster.front() == 0x7f))
+                //     {
+                //         detect key
+                //     }
+                //     else
+                //     {
+                //          key = undef
+                //          key.cluster = cluster;
+                //     }
+                //     send key press
+                //     send key release
+                // }
                 auto filter = [&, total = text{}](view accum) mutable
                 {
                     if (os::linux_console && accum.starts_with("\033["sv)) // Replace Linux console specific keys.

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4634,15 +4634,14 @@ namespace netxs::os
                         { "\x1f"      , { "",     key::Slash     | hids::anyCtrl  << 8 }},
                         { "\033\x1f"  , { "",     key::Slash     | hids::anyAltGr << 8 }},
                         { "\x20"      , { " ",    key::Space      }},
-                        { "\x0D"      , { "\n",   key::Enter      }},
+                        { "\x0d"      , { "\x0a", key::Enter      }},
                         { "\x7f"      , { "\x08", key::Backspace  }},
                         { "\x09"      , { "\x09", key::Tab        }},
                         { "\x1a"      , { "",     key::Pause      }},
-                        { "\x1b"      , { "",     key::Key3      | hids::anyCtrl  << 8 }},
+                        { "\033"      , { "\033", key::Esc        }},
                         { "\x1c"      , { "",     key::Key4      | hids::anyCtrl  << 8 }},
                         { "\x1d"      , { "",     key::Key5      | hids::anyCtrl  << 8 }},
                         { "\x1e"      , { "",     key::Key6      | hids::anyCtrl  << 8 }},
-                        { "\033"      , { "\033", key::Esc        }},
                         { "\033[5~"   , { "",     key::PageUp     }},
                         { "\033[6~"   , { "",     key::PageDown   }},
                         { "\033[F"    , { "",     key::End        }},
@@ -4698,14 +4697,16 @@ namespace netxs::os
                     auto iter = vt2key.find(cluster);
                     if (iter != vt2key.end())
                     {
-                        auto key = iter->second.second;
+                        auto keys = iter->second.second;
+                        auto code = keys & 0xff;
+                        auto& rec = key::map::data(code);
                         k.cluster = iter->second.first;
-                        k.keycode = key & 0xff;
-                        k.ctlstat = key >> 8;
+                        k.keycode = code;
+                        k.ctlstat = keys >> 8;
                         k.extflag = {};
                         k.handled = {};
-                        k.virtcod = input::key::map::vkey()[k.keycode];
-                        k.scancod = input::key::map::scan()[k.keycode];
+                        k.virtcod = rec.vkey;
+                        k.scancod = rec.scan;
                         k.pressed = true; keybd(k);
                         k.pressed = faux; keybd(k);
                     }
@@ -4714,13 +4715,15 @@ namespace netxs::os
                         auto c = cluster.front();
                         if (c >= 1 || c <= 26) // Ctrl+key
                         {
+                            auto code = input::key::KeyA + c * 2;
+                            auto& rec = key::map::data(code);
                             k.extflag = {};
                             k.handled = {};
                             k.cluster = cluster;
-                            k.keycode = input::key::KeyA + c * 2;
-                            k.virtcod = input::key::map::vkey()[k.keycode];
-                            k.scancod = input::key::map::scan()[k.keycode];
-                            k.ctlstat = input::hids::anyCtrl;
+                            k.keycode = code;
+                            k.virtcod = rec.vkey;
+                            k.scancod = rec.scan;
+                            k.ctlstat = input::hids::LCtrl;
                             k.pressed = true; keybd(k);
                             k.pressed = faux; keybd(k);
                         }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4552,7 +4552,7 @@ namespace netxs::os
                             }
                             else if (c == '~')
                             {
-                                if (s.starts_with(ansi::paste_begin)) t = type::paste; // ESC [ 2 0 0 ~
+                                if (s.starts_with(ansi::paste_begin)) t = type::paste; // "\033[200~"
                             }
                             s = s.substr(0, len);
                         }
@@ -4642,7 +4642,8 @@ namespace netxs::os
                             }
                             else if (t == type::focus)
                             {
-                                //focus(f);
+                                f.state = s.back() == 'I';
+                                focus(f);
                             }
                             else if (t == type::style)
                             {

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -606,7 +606,7 @@ namespace netxs::os
                 }
 
                 struct vtparser
-                    : public ansi::parser
+                    : public ansi::output::parser
                 {
                     using redo = std::list<std::pair<deco, ansi::mark>>;
 
@@ -4462,8 +4462,41 @@ namespace netxs::os
                 // ESC ESC
                 // ESC [ I
                 // ESC [ O
-                // ESC [ < 0 ; x ; y M/m
+                // ESC [ < 0 ; x ; y m
+                // ESC [ < 0 ; x ; y M
                 // ESC [ 33 : format p
+                // ESC [ a1; ...; aN _
+                // ESC [ [ A
+                // ESC [ [ B
+                // ESC [ [ C
+                // ESC [ [ D
+                // ESC [ [ E
+                // ESC [ Z          Shit+Tab
+                // ESC [ ... H      Home
+                // ESC [ 1 ~        Home
+                // ESC [ 7 ~        Home
+                // ESC [ 2 ~        Insert
+                // ESC [ 3 ~        Delete
+                // ESC [ 4 ~        End
+                // ESC [ 8 ~        End
+                // ESC [ ... F      End
+                // ESC [ G          Keypad 5
+                // ESC [ ... ~      PgUp, PgDn, F5 ... F24
+                // ESC [ 1 0 ~  F0
+                // ESC O P      F1
+                // ESC O Q      F2
+                // ESC O R      F3
+                // ESC O S      F4
+                // ESC O t      F5
+                // ESC O u      F6
+                // ESC O v      F7
+                // ESC O l      F8
+                // ESC O w      F9
+                // ESC O x      F10
+                // ESC O y      F11
+                // ESC O z      F12
+                // 0x1a (SUB)   Pause
+                // 0x7f (DEL)   Backspace
                 auto filter = [&, total = text{}](view accum) mutable
                 {
                     if (os::linux_console && accum.starts_with("\033["sv)) // Replace Linux console specific keys.

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4458,14 +4458,14 @@ namespace netxs::os
                 }
 
                 // The following sequences are processed here:
-                // ESC
-                // ESC ESC
+                // ESC          Escape
+                // ESC ESC      Escape
                 // ESC [ I
                 // ESC [ O
-                // ESC [ < 0 ; x ; y m
-                // ESC [ < 0 ; x ; y M
+                // ESC [ < mod ; x ; y m
+                // ESC [ < mod ; x ; y M
                 // ESC [ 33 : format p
-                // ESC [ a1; ...; aN _
+                // ESC [ a1 ; ... ; aN _
                 // ESC [ [ A
                 // ESC [ [ B
                 // ESC [ [ C
@@ -4497,6 +4497,11 @@ namespace netxs::os
                 // ESC O z      F12
                 // 0x1a (SUB)   Pause
                 // 0x7f (DEL)   Backspace
+                //
+                // CSI final bytes: 0x40–0x7E  @A–Z[\]^_`a–z{|}~
+                // ESC O        SS3,    Sets a flag for the next char
+                // ESC [ [      CSI [,  Sets a flag for the next char
+                // CSI ~, F, G, H, Z, I, O, M, m, _, p
                 auto filter = [&, total = text{}](view accum) mutable
                 {
                     if (os::linux_console && accum.starts_with("\033["sv)) // Replace Linux console specific keys.

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4511,9 +4511,9 @@ namespace netxs::os
                     style,
                     paste,
                 };
+                static const auto style_cmd = "\033[" + std::to_string(ansi::ccc_stl) + ":";
                 auto take_sequence = [](qiew s) // s.size() always > 1.
                 {
-                    static const auto style_cmd = "\033[" + std::to_string(ansi::ccc_stl) + ":";
                     auto t = type::undef;
                     auto incomplete = faux;
                     auto head = s.begin() + 1; // Pop Esc.
@@ -4647,7 +4647,11 @@ namespace netxs::os
                             }
                             else if (t == type::style)
                             {
-                                //style(s);
+                                auto tmp = s.substr(style_cmd.size());
+                                if (auto format = utf::to_int<ui32>(tmp))
+                                {
+                                    style(deco{ format.value() });
+                                }
                             }
                             else if (t == type::paste)
                             {

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3371,8 +3371,6 @@ namespace netxs::os
 
         struct vtty
         {
-            using s11n = directvt::binary::s11n;
-
             flag                    attached{};
             ipc::stdcon             termlink{};
             std::thread             stdinput{};
@@ -4265,8 +4263,6 @@ namespace netxs::os
                             {
                                 k.ctlstat = kbmod;
                                 m.ctlstat = kbmod;
-                                m.doubled = faux;
-                                m.doubled = faux;
                                 m.wheeled = faux;
                                 m.hzwheel = faux;
                                 m.wheeldt = 0;
@@ -4347,7 +4343,6 @@ namespace netxs::os
                             auto changed = 0;
                             check(changed, m.ctlstat, kbmod);
                             check(changed, m.buttons, r.Event.MouseEvent.dwButtonState & 0b00011111);
-                            check(changed, m.doubled, !!(r.Event.MouseEvent.dwEventFlags & DOUBLE_CLICK));
                             check(changed, m.wheeled, !!(r.Event.MouseEvent.dwEventFlags & MOUSE_WHEELED));
                             check(changed, m.hzwheel, !!(r.Event.MouseEvent.dwEventFlags & MOUSE_HWHEELED));
                             check(changed, m.wheeldt, static_cast<si16>((0xFFFF0000 & r.Event.MouseEvent.dwButtonState) >> 16)); // dwButtonState too large when mouse scrolls
@@ -4559,7 +4554,6 @@ namespace netxs::os
                                                     auto ctl = ctrl.value();
 
                                                     m.enabled = {};
-                                                    m.doubled = {};
                                                     m.wheeled = {};
                                                     m.hzwheel = {};
                                                     m.wheeldt = {};
@@ -4665,8 +4659,6 @@ namespace netxs::os
                             {
                                 k.ctlstat = kbmod;
                                 m.ctlstat = kbmod;
-                                m.doubled = faux;
-                                m.doubled = faux;
                                 m.wheeled = faux;
                                 m.hzwheel = faux;
                                 m.wheeldt = 0;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3232,13 +3232,6 @@ namespace netxs::os
                                     | nt::console::outmode::preprocess
                                     | nt::console::outmode::vt };
                 ok(::SetConsoleMode(os::stdout_fd, outmode), "::SetConsoleMode(os::stdout_fd)", os::unexpected);
-                //todo test on win8
-                //if (!::SetConsoleMode(os::stdout_fd, outmode) || nt::RtlGetVersion().dwBuildNumber < 19041) // Windows Server 2019's conhost doesn't handle truecolor well enough.
-                //{
-                //    dtvt::mode |= ui::console::nt16; // Legacy console detected - nt::console::outmode::vt + no_auto_cr not supported.
-                //    outmode &= ~(nt::console::outmode::no_auto_cr | nt::console::outmode::vt);
-                //    ok(::SetConsoleMode(os::stdout_fd, outmode), "::SetConsoleMode(os::stdout_fd)", os::unexpected);
-                //}
                 auto size = DWORD{ os::pipebuf };
                 auto wstr = wide(size, 0);
                 ok(::GetConsoleTitleW(wstr.data(), size), "::GetConsoleTitleW(vtmode)", os::unexpected);

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4241,6 +4241,7 @@ namespace netxs::os
                     if (count == 0) continue;
                     items.resize(count);
                     if (!::ReadConsoleInputW(os::stdin_fd, items.data(), count, &count)) break;
+                    auto timecode = datetime::now();
                     auto head = items.begin();
                     auto tail = items.end();
                     while (alive && head != tail)
@@ -4266,6 +4267,7 @@ namespace netxs::os
                                 m.wheeled = faux;
                                 m.hzwheel = faux;
                                 m.wheeldt = 0;
+                                m.timecod = timecode;
                                 m.changed++;
                                 mouse(m); // Fire mouse event to update kb modifiers.
                             }
@@ -4353,6 +4355,7 @@ namespace netxs::os
                             if (changed || m.wheeled || m.hzwheel) // Don't fire the same state (conhost fires the same events every second).
                             {
                                 m.changed++;
+                                m.timecod = timecode;
                                 mouse(m);
                             }
                         }
@@ -4545,6 +4548,7 @@ namespace netxs::os
                                                 if (pos == len) { total = strv; break; } // incomlpete sequence
                                                 if (strv.at(pos) == 'M' || strv.at(pos) == 'm')
                                                 {
+                                                    auto timecode = datetime::now();
                                                     auto ispressed = (strv.at(pos) == 'M');
                                                     ++pos;
 
@@ -4572,6 +4576,7 @@ namespace netxs::os
                                                     {
                                                         m.buttons = {};
                                                         m.changed++;
+                                                        m.timecod = timecode;
                                                         mouse(m);
                                                     }
                                                     m.coordxy = { x, y };
@@ -4590,6 +4595,7 @@ namespace netxs::os
                                                             break;
                                                     }
                                                     m.changed++;
+                                                    m.timecod = timecode;
                                                     mouse(m);
                                                     unk = faux;
                                                 }
@@ -4662,6 +4668,7 @@ namespace netxs::os
                                 m.wheeled = faux;
                                 m.hzwheel = faux;
                                 m.wheeldt = 0;
+                                m.timecod = datetime::now();
                                 m.changed++;
                                 mouse(m); // Fire mouse event to update kb modifiers.
                             }
@@ -4694,6 +4701,7 @@ namespace netxs::os
                             m.coordxy = { mcoord / scale };
                             m.buttons = bttns;
                             m.ctlstat = k.ctlstat;
+                            m.timecod = datetime::now();
                             m.changed++;
                             mouse(m);
                         }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -695,7 +695,7 @@ namespace netxs::ui
 
         // term: Generic terminal buffer.
         struct bufferbase
-            : public ansi::output::parser
+            : public ansi::parser
         {
             static void set_autocr(bool autocr)
             {
@@ -6680,7 +6680,12 @@ namespace netxs::ui
             follow[axis::X] = true;
             if (bpmode)
             {
-                data = "\033[200~" + data + "\033[201~";
+                auto temp = text{};
+                temp.reserve(data.size() + ansi::paste_begin.size() + ansi::paste_end.size());
+                temp += ansi::paste_begin;
+                temp += data;
+                temp += ansi::paste_end;
+                std::swap(data, temp);
             }
             //todo paste is a special type operation like a mouse reporting.
             //todo pasting must be ready to be interruped by any pressed key (to interrupt a huge paste).
@@ -6767,8 +6772,16 @@ namespace netxs::ui
             {
                 pro::focus::set(this->This(), gear.id, pro::focus::solo::off, pro::focus::flip::off);
                 follow[axis::X] = true;
-                if (bpmode) data_out("\033[200~" + utf8 + "\033[201~");
-                else        data_out(utf8);
+                if (bpmode)
+                {
+                    auto temp = text{};
+                    temp.reserve(utf8.size() + ansi::paste_begin.size() + ansi::paste_end.size());
+                    temp += ansi::paste_begin;
+                    temp += utf8;
+                    temp += ansi::paste_end;
+                    std::swap(utf8, temp);
+                }
+                data_out(utf8);
                 gear.dismiss();
             }
         }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -293,14 +293,12 @@ namespace netxs::ui
             prot        encod; // m_tracking: Mouse encoding protocol.
             mode        state; // m_tracking: Mouse reporting mode.
             si32        smode; // m_tracking: Selection mode state backup.
-            si32        bttns; // m_tracking: Last buttons state.
 
             m_tracking(term& owner)
                 : owner{ owner                   },
                   encod{ prot::x11               },
                   state{ mode::none              },
-                  smode{ owner.config.def_selmod },
-                  bttns{ 0                       }
+                  smode{ owner.config.def_selmod }
             { }
 
             operator bool () { return state != mode::none; }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -695,7 +695,7 @@ namespace netxs::ui
 
         // term: Generic terminal buffer.
         struct bufferbase
-            : public ansi::parser
+            : public ansi::output::parser
         {
             static void set_autocr(bool autocr)
             {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7287,7 +7287,7 @@ namespace netxs::ui
                 //        " virtcod: ", gear.virtcod,
                 //        " scancod: ", gear.scancod);
                 //}
-                if (io_log) log(prompt::key, ansi::hi(input::key::map::name(gear.keycode)));
+                if (io_log) log(prompt::key, ansi::hi(input::key::map::data(gear.keycode).name));
 
                 ipccon.keybd(gear, decckm, bpmode, kbmode);
             };

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -810,7 +810,7 @@ namespace netxs::ui
                 vt.intro[ctrl::esc][esc_decdhl] = V{ p->dhl(q); };         // ESC # ...  ESC # 3, ESC # 4, ESC # 5, ESC # 6, ESC # 8
 
                 vt.intro[ctrl::esc][esc_apc   ] = V{ p->msg(esc_apc, q); }; // ESC _ ... ST  APC.
-                vt.intro[ctrl::esc][esc_dsc   ] = V{ p->msg(esc_dsc, q); }; // ESC P ... ST  DSC.
+                vt.intro[ctrl::esc][esc_dcs   ] = V{ p->msg(esc_dcs, q); }; // ESC P ... ST  DCS.
                 vt.intro[ctrl::esc][esc_sos   ] = V{ p->msg(esc_sos, q); }; // ESC X ... ST  SOS.
                 vt.intro[ctrl::esc][esc_pm    ] = V{ p->msg(esc_pm , q); }; // ESC ^ ... ST  PM.
 
@@ -1241,7 +1241,7 @@ namespace netxs::ui
                     // Unexpected
                     case ansi::esc_csi   :
                     case ansi::esc_ocs   :
-                    case ansi::esc_dsc   :
+                    case ansi::esc_dcs   :
                     case ansi::esc_sos   :
                     case ansi::esc_pm    :
                     case ansi::esc_apc   :

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -99,6 +99,8 @@ int main(int argc, char* argv[])
         }
     }
 
+    os::dtvt::checkpoint();
+
     auto denied = faux;
     auto direct = os::dtvt::active;
     auto syslog = os::tty::logger();

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -757,16 +757,18 @@ namespace netxs::app::vtm
             {
                 //todo deprecated
                 //todo unify
-                auto F12 = (gear.keycode == input::key::F12 && gear.meta(hids::anyAlt)) || gear.keystrokes == "\033[24;3~"s;
-                if (F12 && gear.pressed) // Disconnect by Alt+F12.
+                if (!gear.pressed) return;
+                auto key = gear.keycode;
+                auto AltF12 = key == input::key::F12 && gear.meta(hids::anyAlt);
+                if (AltF12) // Disconnect by Alt+F12.
                 {
                     gear.owner.SIGNAL(tier::preview, e2::conio::quit, deal, ());
                     this->bell::expire<tier::preview>();
                     gear.set_handled(true);
                     return;
                 }
-                auto F10 = gear.keycode == input::key::F10 || gear.keystrokes == "\033[21~"s;
-                if (F10 && gear.pressed)
+                auto F10 = key == input::key::F10;
+                if (F10)
                 {
                     auto window_ptr = e2::form::layout::go::item.param();
                     this->RISEUP(tier::request, e2::form::layout::go::item, window_ptr); // Take current window.
@@ -778,12 +780,9 @@ namespace netxs::app::vtm
                     }
                     return;
                 }
-                auto& keystrokes = gear.keystrokes;
-                auto pgup = keystrokes == "\033[5;5~"s
-                        || (keystrokes == "\033[5~"s && gear.meta(hids::anyCtrl));
-                auto pgdn = keystrokes == "\033[6;5~"s
-                        || (keystrokes == "\033[6~"s && gear.meta(hids::anyCtrl));
-                if (pgup || pgdn)
+                auto CtrlPgUp = key == input::key::PageUp   && gear.meta(hids::anyCtrl);
+                auto CtrlPgDn = key == input::key::PageDown && gear.meta(hids::anyCtrl);
+                if (CtrlPgUp || CtrlPgDn)
                 {
                     if (align.what.applet)
                     {
@@ -800,8 +799,8 @@ namespace netxs::app::vtm
                     {
                         window_ptr.reset();
                         owner_id = id_t{};
-                        if (pgdn) this->RISEUP(tier::request, e2::form::layout::go::prev, window_ptr); // Take prev window.
-                        else      this->RISEUP(tier::request, e2::form::layout::go::next, window_ptr); // Take next window.
+                        if (CtrlPgDn) this->RISEUP(tier::request, e2::form::layout::go::prev, window_ptr); // Take prev window.
+                        else          this->RISEUP(tier::request, e2::form::layout::go::next, window_ptr); // Take next window.
                         if (window_ptr) window_ptr->SIGNAL(tier::request, e2::form::state::maximized, owner_id);
                         maximized = owner_id == gear.owner.id;
                         if (!owner_id || maximized) break;


### PR DESCRIPTION
Changes
- Fix double clicks for both WT (https://github.com/microsoft/terminal/issues/14474) and `win<->unix` connections
- Remove unnecessary vt-sequences when outputting version, #484
- Fix keybd/mouse input on `win<->unix` connections, #483

Closes #483
Closes #484