### PR TITLE
Fix tiling windows manager: broken drag&drop (regression)

### DIFF
--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -26,7 +26,7 @@
     <td colspan="9">Disconnect all users and shutdown if there are no apps running</td>
   </tr>
   <tr>
-    <th>Alt/Option+F12</th>
+    <th>Shift+F7</th>
     <td colspan="9">Leave current session</td>
   </tr>
   <tr>

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -427,7 +427,10 @@ namespace netxs::app::shared
                                             };
                                             boss.LISTEN(tier::release, e2::form::upon::started, root, -, (cmd, cwd, env))
                                             {
-                                                boss.start(cmd, cwd, env);
+                                                if (root) // root is empty when d_n_d.
+                                                {
+                                                    boss.start(cmd, cwd, env);
+                                                }
                                             };
                                             boss.LISTEN(tier::anycast, e2::form::upon::started, root)
                                             {
@@ -458,11 +461,14 @@ namespace netxs::app::shared
                 {
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (cmd, cwd, env, patch))
                     {
-                        boss.start(patch, [cmd, cwd, env](auto fds)
+                        if (root) // root is empty when d_n_d.
                         {
-                            os::dtvt::connect(cmd, cwd, env, fds);
-                            return cmd;
-                        });
+                            boss.start(patch, [cmd, cwd, env](auto fds)
+                            {
+                                os::dtvt::connect(cmd, cwd, env, fds);
+                                return cmd;
+                            });
+                        }
                     };
                     boss.LISTEN(tier::preview, e2::config::plugins::sizer::alive, state)
                     {
@@ -546,11 +552,14 @@ namespace netxs::app::shared
                     auto& term_inst = *inst;
                     boss.LISTEN(tier::release, e2::form::upon::started, root, -, (cmd, cwd, env, patch))
                     {
-                        dtvt_inst.start(patch, [&, cmd, cwd, env](auto fds)
+                        if (root) // root is empty when d_n_d.
                         {
-                            term_inst.start(cmd, cwd, env, fds);
-                            return cmd;
-                        });
+                            dtvt_inst.start(patch, [&, cmd, cwd, env](auto fds)
+                            {
+                                term_inst.start(cmd, cwd, env, fds);
+                                return cmd;
+                            });
+                        }
                     };
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root)
                     {

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -515,7 +515,7 @@ namespace netxs::app::tile
                             auto gear_id_list = pro::focus::get(what.applet);
                             auto app = app_window(what);
                             boss.attach(app);
-                            app->SIGNAL(tier::anycast, e2::form::upon::started, app);
+                            app->SIGNAL(tier::anycast, e2::form::upon::started, empty, ());
                             pro::focus::set(what.applet, gear_id_list, pro::focus::solo::mix, pro::focus::flip::off, true);
                         }
                     };
@@ -575,7 +575,7 @@ namespace netxs::app::tile
                             auto& item = *item_ptr;
                             if (item.base::root())
                             {
-                                item.SIGNAL(tier::anycast, e2::form::upon::started, item_ptr);
+                                item.SIGNAL(tier::anycast, e2::form::upon::started, root);
                             }
                         }
                     };

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.32";
+    static const auto version = "v0.9.33";
     static const auto ipc_prefix = "vtm";
     static const auto log_suffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -758,7 +758,7 @@ namespace netxs::app::vtm
                 //todo deprecated
                 //todo unify
                 if (!gear.keybd::pressed) return;
-                if (gear.chord(input::key::F12, hids::anyAlt)) // Disconnect by Alt+F12.
+                if (gear.chord(input::key::F7, hids::anyShift)) // Disconnect by Shift+F7.
                 {
                     gear.owner.SIGNAL(tier::preview, e2::conio::quit, deal, ());
                     this->bell::expire<tier::preview>();

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1762,7 +1762,7 @@ namespace netxs::app::vtm
                 slot->attach(what.applet);
                 log("%%Attach type=%itemtype% menuid=%id%", prompt::hall, utf::debase(cfg.type), utf::debase(what.menuid));
                 this->branch(what.menuid, slot, !cfg.hidden);
-                slot->SIGNAL(tier::anycast, e2::form::upon::started, this->This());
+                slot->SIGNAL(tier::anycast, e2::form::upon::started, empty, ());
                 what.applet = slot;
             };
             LISTEN(tier::release, hids::events::keybd::key::any, gear) // Last resort for unhandled kb event.


### PR DESCRIPTION
Changes
- Fix tiling windows manager: broken drag&drop (regression)
- Replace the key binding Alt+F12 with Shift+F7 (Leave current session)