### PR TITLE
Force vtm session to start in `Session 0` for elevated users on Windows

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -136,14 +136,14 @@ vtm renders itself at a constant frame rate into internal buffers and outputs to
 
 ## Local Usage
 
-### Run vtm desktop
+### Running vtm desktop
 
 - Run command
     ```bash
     vtm
     ```
 
-### Run built-in terminal with default shell
+### Running built-in terminal with default shell
 
 - Run command
     ```bash
@@ -155,7 +155,7 @@ vtm renders itself at a constant frame rate into internal buffers and outputs to
     # The `vtm -r` option is auto converted to the `vtm -r term`.
     ```
 
-### Run a standalone console application
+### Running a standalone console application
 
 - Run command
     ```bash
@@ -168,7 +168,7 @@ vtm renders itself at a constant frame rate into internal buffers and outputs to
     # The `vtm -r ...` option is auto converted to the `vtm -r term ...`.
     ```
 
-### Run a standalone console application without extra UI
+### Running a standalone console application without extra UI
 
 - Run command
     ```bash
@@ -184,7 +184,7 @@ When DirectVT mode is enabled, all keyboard, mouse and other input events are tr
 
 The following examples assume that the vtm is installed on both the server and client side (or vtm is accessible via PATH).
 
-### Run a standalone console application remotely via SSH
+### Running a standalone console application remotely via SSH
 
 - Server:
     - Install SSH-server
@@ -201,7 +201,7 @@ The following examples assume that the vtm is installed on both the server and c
     # The `vtm -r ...` option is auto converted to the `vtm -r term ...`.
     ```
 
-### Run vtm in DirectVT mode remotely via SSH
+### Running vtm in DirectVT mode remotely via SSH
 
 - Server:
     - Install SSH-server
@@ -218,7 +218,7 @@ The following examples assume that the vtm is installed on both the server and c
     # The `-r xlvt` option is auto added if the first command line argument starts with `ssh ...`.
     ```
 
-### Run vtm in ANSI/VT mode remotely via SSH
+### Running vtm in ANSI/VT mode remotely via SSH
 
 - Server:
     - Install SSH-server.
@@ -234,7 +234,7 @@ The following examples assume that the vtm is installed on both the server and c
     # The `ssh -t ...` option is required to allocate TTY on remote host.
     ```
 
-### Run vtm in DirectVT mode remotely via `netcat` (POSIX only, unencrypted, for private use only)
+### Running vtm in DirectVT mode remotely via `netcat` (POSIX only, unencrypted, for private use only)
 
 - Server:
     - Run command
@@ -252,7 +252,7 @@ The following examples assume that the vtm is installed on both the server and c
     # Note: Make sure `ncat` is installed.
     ```
 
-### Run vtm in DirectVT mode remotely using `inetd` (POSIX only, unencrypted, for private use only)
+### Running vtm in DirectVT mode remotely using `inetd` (POSIX only, unencrypted, for private use only)
 
 - Server:
     - Install `inetd`

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.37";
+    static const auto version = "v0.9.38";
     static const auto ipc_prefix = "vtm";
     static const auto log_suffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;

--- a/src/netxs/desktopio/logger.hpp
+++ b/src/netxs/desktopio/logger.hpp
@@ -120,42 +120,12 @@ namespace netxs
 
 namespace
 {
-    namespace
-    {
-        netxs::view crop(netxs::view& format)
-        {
-            static constexpr auto delimiter = '%';
-            auto crop = format;
-            auto head = format.find(delimiter);
-            if (head == netxs::text::npos) format = {};
-            else
-            {
-                auto tail = format.find(delimiter, head + 1);
-                if (tail != netxs::text::npos)
-                {
-                    crop = format.substr(0, head); // Take leading substring.
-                    format.remove_prefix(tail + 1);
-                }
-            }
-            return crop;
-        }
-        void print(auto& input, netxs::view& format)
-        {
-            input << format;
-        }
-        void print(auto& input, netxs::view& format, auto&& arg, auto&& ...args)
-        {
-            input << crop(format) << std::forward<decltype(arg)>(arg);
-            if (format.length()) print(input, format, std::forward<decltype(args)>(args)...);
-            else                (void)(input << ...<< std::forward<decltype(args)>(args));
-        }
-    }
     template<bool Newline = true, class ...Args>
     void log(netxs::view format, Args&&... args)
     {
         auto state = netxs::logger::globals();
         if (state.quiet) return;
-        print(state.input, format, std::forward<Args>(args)...);
+        netxs::utf::print2(state.input, format, std::forward<Args>(args)...);
         if constexpr (Newline) state.input << '\n';
         state.flush();
     }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1433,26 +1433,6 @@ namespace netxs::os
                 };
                 return std::unique_ptr<decltype(handler), decltype(deleter)>(&handler);
             };
-            auto create()
-            {
-                //
-                return true;
-            }
-            auto start()
-            {
-                //
-                return true;
-            }
-            auto stop()
-            {
-                //
-                return true;
-            }
-            auto remove()
-            {
-                //
-                return true;
-            }
 
         #else
 

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -147,8 +147,8 @@ namespace netxs::os
     template<class ...Args>
     auto fail(Args&&... msg)
     {
-        log(prompt::os, ansi::err(msg..., " (", os::error(), ") "));
-    };
+        log(prompt::os, ansi::err(utf::fprint(msg..., " (", os::error(), ") ")));
+    }
     template<bool Alert = true, class T, class ...Args>
     auto ok(T error_condition, Args&&... msg)
     {
@@ -2278,7 +2278,7 @@ namespace netxs::os
             #endif
             if (result.empty())
             {
-                os::fail("Can't get current module file path, fallback to '", process::arg0, "`");
+                os::fail("Can't get current module file path, fallback to '%arg0%`", process::arg0);
                 result = process::arg0;
             }
             if constexpr (NameOnly)
@@ -2403,7 +2403,7 @@ namespace netxs::os
                     }
                     os::process::execvpe(cmd, env);
                     auto errcode = errno;
-                    if constexpr (Logs) os::fail(prompt::exec, "Failed to spawn '", cmd, "'");
+                    if constexpr (Logs) os::fail("%%Failed to spawn '%cmd%'", prompt::exec, cmd);
                     os::process::exit<true>(errcode);
                 }
                 else if (p_id > 0) // Parent branch.
@@ -2417,7 +2417,7 @@ namespace netxs::os
                 }
 
             #endif
-            if constexpr (Logs) os::fail(prompt::exec, "Failed to spawn '", cmd, "'");
+            if constexpr (Logs) os::fail("%%Failed to spawn '%cmd%'", prompt::exec, cmd);
             return faux;
         }
         auto fork(text prefix, view config)
@@ -2892,7 +2892,7 @@ namespace netxs::os
                             //       LocalSystem account, administrators, and the creator owner. They also grant read access to
                             //       members of the Everyone group and the anonymous account.
                             //       Without write access, the desktop will be inaccessible to non-owners.
-                            if (next_waiting_point == os::invalid_fd) os::fail(prompt::meet, "::CreateNamedPipe()", os::unexpected);
+                            if (next_waiting_point == os::invalid_fd) os::fail("::CreateNamedPipe()", os::unexpected);
                         }
                         else if (pipe::active) os::fail(prompt::meet, "Not active");
 

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -22,6 +22,7 @@
     #include <Windows.h>
     #include <userenv.h>                 // ::GetUserProfileDirectoryW
     #pragma comment(lib, "Userenv.lib")
+    #pragma comment(lib, "Advapi32.lib") // ::StartService() for arm arch
     #include <Psapi.h>                   // ::GetModuleFileNameEx
     #include <winternl.h>                // ::NtOpenFile
     #include <sddl.h>                    // ::ConvertSidToStringSidA()

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -25,8 +25,6 @@
     #pragma comment(lib, "Advapi32.lib") // ::GetUserNameW()
     #include <Psapi.h>                   // ::GetModuleFileNameEx
     #include <winternl.h>                // ::NtOpenFile
-    #include <WtsApi32.h>               // ::WTSGetActiveConsoleSessionId, ::WTSQueryUserToken
-    #pragma comment (lib, "Wtsapi32.lib")
 
 #else
 

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1615,6 +1615,40 @@ namespace netxs::utf
         }
         return qiew{ utf8.substr(0, crop) };
     }
+    void print2(auto& input, view& format)
+    {
+        input << format;
+    }
+    void print2(auto& input, view& format, auto&& arg, auto&& ...args)
+    {
+        auto crop = [](view& format)
+        {
+            static constexpr auto delimiter = '%';
+            auto crop = format;
+            auto head = format.find(delimiter);
+            if (head == netxs::text::npos) format = {};
+            else
+            {
+                auto tail = format.find(delimiter, head + 1);
+                if (tail != netxs::text::npos)
+                {
+                    crop = format.substr(0, head); // Take leading substring.
+                    format.remove_prefix(tail + 1);
+                }
+            }
+            return crop;
+        };
+        input << crop(format) << std::forward<decltype(arg)>(arg);
+        if (format.length()) print2(input, format, std::forward<decltype(args)>(args)...);
+        else                 (void)(input << ...<< std::forward<decltype(args)>(args));
+    }
+    template<class ...Args>
+    auto fprint(view format, Args&&... args)
+    {
+        auto input = flux{};
+        print2(input, format, std::forward<Args>(args)...);
+        return input.str();
+    }
 }
 
 namespace netxs

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -31,11 +31,10 @@ int main(int argc, char* argv[])
     {
         if (getopt.match("--svc"))
         {
-            auto userid = getopt.next();
+            auto process_id = getopt.next();
             params = getopt.rest();
-            os::sleep(10s);
-            //todo
-            return 0;
+            auto ok = os::process::dispatch(process_id, params);
+            return ok ? 0 : 1;
         }
         else if (getopt.match("-r", "--runapp"))
         {

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -29,7 +29,15 @@ int main(int argc, char* argv[])
     }
     else while (getopt)
     {
-        if (getopt.match("-r", "--runapp"))
+        if (getopt.match("--svc"))
+        {
+            auto userid = getopt.next();
+            params = getopt.rest();
+            os::sleep(10s);
+            //todo
+            return 0;
+        }
+        else if (getopt.match("-r", "--runapp"))
         {
             whoami = type::runapp;
             params = getopt ? getopt.rest() : text{ app::term::id };
@@ -121,7 +129,7 @@ int main(int argc, char* argv[])
     auto direct = os::dtvt::active;
     auto syslog = os::tty::logger();
     auto userid = os::env::user();
-    auto prefix = vtpipe.length() ? vtpipe : utf::concat(app::shared::ipc_prefix, os::process::elevated ? "!_" : "_", userid);;
+    auto prefix = vtpipe.length() ? vtpipe : utf::concat(app::shared::ipc_prefix, os::process::elevated ? "!_" : "_", userid.second);;
     auto prefix_log = prefix + app::shared::log_suffix;
     auto failed = [&](auto cause)
     {
@@ -266,7 +274,7 @@ int main(int argc, char* argv[])
         else if (whoami != type::client && client) return failed(code::interfer);
         else if (whoami == type::client && !client)
         {
-            log("%%New vtm session for [%userid%]", prompt::main, userid);
+            log("%%New vtm session for [%userid%]", prompt::main, userid.first);
             auto [success, successor] = os::process::fork(prefix, config.utf8());
             if (successor)
             {
@@ -285,7 +293,7 @@ int main(int argc, char* argv[])
             signal.reset();
             if (client || (client = os::ipc::socket::open<os::role::client>(prefix, denied)))
             {
-                os::tty::stream.init.send(client, userid, os::dtvt::vtmode, os::dtvt::win_sz, config.utf8());
+                os::tty::stream.init.send(client, userid.first, os::dtvt::vtmode, os::dtvt::win_sz, config.utf8());
                 os::tty::splice(client);
                 return 0;
             }
@@ -335,7 +343,7 @@ int main(int argc, char* argv[])
 
         log("%%Session started"
           "\n      user: %userid%"
-          "\n      pipe: %prefix%", prompt::main, userid, prefix);
+          "\n      pipe: %prefix%", prompt::main, userid.first, prefix);
 
         auto stdlog = std::thread{ [&]
         {
@@ -363,7 +371,7 @@ int main(int argc, char* argv[])
                                           [&]{ domain->SIGNAL(tier::general, e2::shutdown, msg, (utf::concat(prompt::main, "Shutdown on signal"))); });
         while (auto client = server->meet())
         {
-            if (client->auth(userid))
+            if (client->auth(userid.second))
             {
                 domain->run([&, client, settings](auto session_id)
                 {


### PR DESCRIPTION
Changes (on Windows)
- Use username@domain instead of plain username
- Force vtm session to start in `Session 0` for elevated users, #461
  Now, a vtm session started by an elevated user can be shared via ssh and can survive the user's logoff.

Closes #461