### PR TITLE
Add nt-service to launch the vtm server in Session 0 by any users (on Windows)

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.38";
+    static const auto version = "v0.9.39";
     static const auto ipc_prefix = "vtm";
     static const auto log_suffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1080,6 +1080,8 @@ namespace netxs::os
             }
         }
 
+        auto operator ""_acl(char const* sddl, size_t size) { return nt::acl{ view{ sddl, size } }; }
+
     #else
 
         void fdscleanup() // Close all file descriptors except the standard ones.
@@ -2491,7 +2493,7 @@ namespace netxs::os
                                                          os::pipebuf,                                         // nOutBufferSize
                                                          os::pipebuf,                                         // nInBufferSize
                                                          0,                                                   // nDefaultTimeOut
-                                                         nt::acl{ "D:(A;;GRFW;;;WD)(A;;FA;;;CO)(A;;FA;;;SY)(A;;FA;;;BA)" }); // lpSecurityAttributes
+                                                         "D:(A;;GRFW;;;WD)(A;;FA;;;CO)(A;;FA;;;SY)(A;;FA;;;BA)"_acl); // lpSecurityAttributes
                 static auto starter = [](auto... args)
                 {
                     auto svcstat = SERVICE_STATUS

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1138,8 +1138,8 @@ namespace netxs::utf
             return proc(end);
         }
     }
-    template<feed Dir = feed::fwd, bool SkipEmpty = faux, class V1, class V2>
-    auto divide(V1 const& utf8, V2 const& delimiter, std::vector<view>& crop)
+    template<feed Dir = feed::fwd, bool SkipEmpty = faux, class V1, class V2, class Vector_qiew>
+    auto divide(V1 const& utf8, V2 const& delimiter, Vector_qiew& crop)
     {
         auto mark = qiew(delimiter);
         if (auto len = mark.size())
@@ -1169,7 +1169,7 @@ namespace netxs::utf
     template<feed Dir = feed::fwd, bool SkipEmpty = faux, class V1, class V2>
     auto divide(V1 const& utf8, V2 const& delimiter)
     {
-        auto crop = std::vector<view>{};
+        auto crop = std::vector<qiew>{};
         divide<Dir, SkipEmpty>(utf8, delimiter, crop);
         return crop;
     }

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -263,9 +263,7 @@ int main(int argc, char* argv[])
     {
         auto config = app::shared::load::settings(defaults, cfpath, os::dtvt::config);
         auto client = os::ipc::socket::open<os::role::client, faux>(prefix, denied);
-
-        auto ospath = os::process::memory::ref(prefix);
-        auto signal = ptr::shared<os::fire>(ospath + "started"); // Signaling that the server is ready for incoming connections.
+        auto signal = ptr::shared<os::fire>(os::process::started(prefix)); // Signaling that the server is ready for incoming connections.
 
              if (denied)                           return failed(code::noaccess);
         else if (whoami != type::client && client) return failed(code::interfer);

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -31,10 +31,17 @@ int main(int argc, char* argv[])
     {
         if (getopt.match("--svc"))
         {
-            auto process_id = getopt.next();
-            params = getopt.rest();
-            auto ok = os::process::dispatch(process_id, params);
-            return ok ? 0 : 1;
+            if (auto process_id = getopt.next())
+            {
+                params = getopt.rest();
+                auto ok = os::process::dispatch(process_id, params);
+                return ok ? 0 : 1;
+            }
+            else
+            {
+                auto ok = os::process::dispatch();
+                return ok ? 0 : 1;
+            }
         }
         else if (getopt.match("-r", "--runapp"))
         {

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -31,17 +31,8 @@ int main(int argc, char* argv[])
     {
         if (getopt.match("--svc"))
         {
-            if (auto process_id = getopt.next())
-            {
-                params = getopt.rest();
-                auto ok = os::process::dispatch(process_id, params);
-                return ok ? 0 : 1;
-            }
-            else
-            {
-                auto ok = os::process::dispatch();
-                return ok ? 0 : 1;
-            }
+            auto ok = os::process::dispatch();
+            return ok ? 0 : 1;
         }
         else if (getopt.match("-r", "--runapp"))
         {


### PR DESCRIPTION
Changes (on Windows)
- Add nt-service (by installation `vtm -i`) to launch the vtm server in Session 0 by any users, #507
  ``` 
  service
    name: vtm
    desc: Text-based desktop environment.
    path: %SystemRoot%\vtm.exe
    user: LocalSystem
    type: Auto
  ```
- Remove the option to run in Session 0 without installed nt-service.

Related to #461
Closes #507