### PR TITLE
Use user@host naming on Unix

### DIFF
--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-namespace netxs::app::about
+namespace netxs::app::info
 {
-    static constexpr auto id = "about";
+    static constexpr auto id = "info";
 }
 namespace netxs::app::ssh
 {
@@ -630,7 +630,7 @@ namespace netxs::app::shared
             args += os::env::shell(param);
             return build_DirectVT(env, cwd, args, config, patch);
         };
-        auto build_About         = [](text env, text cwd, text param, xmls& config, text patch)
+        auto build_Info          = [](text env, text cwd, text param, xmls& config, text patch)
         {
             using namespace app::shared;
 
@@ -693,7 +693,7 @@ namespace netxs::app::shared
                 {
                     utf::fprint("%%"
                         "\nDesktop"
-                         "\n"
+                        "\n"
                         "\n     Owner: %user@host%"
                         "\n   Session: %pipe%"
                         "\n     Users: %count%"
@@ -782,6 +782,6 @@ namespace netxs::app::shared
         app::shared::initialize builder_XLVT      { app::xlvt::id     , build_XLinkVT    };
         app::shared::initialize builder_ANSIVT    { app::ansivt::id   , build_ANSIVT     };
         app::shared::initialize builder_SHELL     { app::shell::id    , build_SHELL      };
-        app::shared::initialize builder_About     { app::about::id    , build_About      };
+        app::shared::initialize builder_Info      { app::info::id     , build_Info       };
     }
 }

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -519,7 +519,7 @@ namespace netxs::app::desk
                 auto active_color    = skin::globals().active;
                 auto cE = active_color;
                 auto c3 = highlight_color;
-                auto user = ui::item::ctor(escx(" &").nil().add(" ")
+                auto user = ui::item::ctor(escx(" &").nil().add(" ").wrp(wrap::off)
                         .fgx(data_src->id == my_id ? cE.fgc() : rgba{}).add(utf8).nil())
                     ->flexible()
                     ->setpad({ 1, 0, tall, tall }, { 0, 0, -tall, 0 })

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -279,7 +279,7 @@ namespace netxs::app::desk
                 auto block = apps->attach(ui::list::ctor())
                     ->shader(cell::shaders::xlight, e2::form::state::hover, head_fork)
                     ->setpad({ 0, 0, 0, 0 }, { 0, 0, -tall, 0 });
-                if (!state) block->depend_on_collection(inst_ptr_list); // Remove not pinned apps, like Info/About.
+                if (!state) block->depend_on_collection(inst_ptr_list); // Remove not pinned apps, like Info.
                 block->attach(head_fork)
                     ->active()
                     ->template plugin<pro::notes>(obj_note.empty() ? def_note : obj_note)
@@ -411,7 +411,7 @@ namespace netxs::app::desk
                 ->alignment({ snap::tail, snap::tail });
             return ui::cake::ctor()
                 ->branch(ver_label)
-                ->template plugin<pro::notes>(" About ")
+                ->template plugin<pro::notes>(" Info ")
                 ->invoke([&](auto& boss)
                 {
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear, -, (appid, label, title))
@@ -547,8 +547,8 @@ namespace netxs::app::desk
 
             window->invoke([&, menu_selected](auto& boss) mutable
             {
-                auto appid = "about"s;
-                auto label = "About"s;
+                auto appid = "info"s;
+                auto label = "Info"s;
                 auto title = ansi::jet(bias::right).add(label);
                 auto ground = background(appid, label, title); // It can't be a child - it has exclusive rendering (first of all).
                 boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent_ptr, -, (size_config_ptr/*owns ptr*/, ground, current_default = text{}, previous_default = text{}, selected = text{ menu_selected }))

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.42";
+    static const auto version = "v0.9.43";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto ipc_prefix = "vtm";
     static const auto log_suffix = "_log";

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2934,11 +2934,13 @@ namespace netxs::ui
         twod square; // post: Page area.
         text source; // post: Text source.
         bool beyond; // post: Allow vertical scrolling beyond the last line.
+        bool recent; // post: Paragraphs are not aligned.
 
     protected:
         postfx(bool scroll_beyond = faux)
             :   flow{ square        },
-              beyond{ scroll_beyond }
+              beyond{ scroll_beyond },
+              recent{               }
         {
             LISTEN(tier::release, e2::render::any, parent_canvas)
             {
@@ -2952,18 +2954,28 @@ namespace netxs::ui
         void deform(rect& new_area) override
         {
             square = new_area.size;
-            auto entry = topic.lookup(base::anchor);
             flow::reset();
-            auto publish = [&](auto& combo)
+            if (recent) // Update new paragraph's coords before resize.
             {
-                combo.coord = flow::print(combo);
-                if (combo.id() == entry.id) entry.coor.y -= combo.coord.y;
-            };
-            topic.stream(publish);
-
-            // Apply only vertical anchoring for this type of control.
-            base::anchor.y -= entry.coor.y; // Move the central point accordingly to the anchored object
-
+                auto publish = [&](auto& combo)
+                {
+                    combo.coord = flow::print(combo);
+                };
+                topic.stream(publish);
+                recent = faux;
+            }
+            else // Sync anchor.
+            {
+                auto entry = topic.lookup(base::anchor);
+                auto publish = [&](auto& combo)
+                {
+                    combo.coord = flow::print(combo);
+                    if (combo.id() == entry.id) entry.coor.y -= combo.coord.y;
+                };
+                topic.stream(publish);
+                // Apply only vertical anchoring for this type of control.
+                base::anchor.y -= entry.coor.y; // Move the central point accordingly to the anchored object
+            }
             auto& cover = flow::minmax();
             //todo move it to flow
             base::oversz = { -std::min(0, cover.l),
@@ -2995,14 +3007,15 @@ namespace netxs::ui
         // post: .
         auto upload(view utf8, si32 initial_width = 0) // Don't use cell link id here. Apply it to the parent (with a whole rect coverage).
         {
+            recent = true;
             source = utf8;
             topic = utf8;
             if (initial_width < 0)
             {
-                base::limits({ topic.limits().x + base::intpad.l + base::intpad.r, -1 });
-                initial_width = 0;
+                initial_width = topic.limits().x + base::intpad.l + base::intpad.r;
+                base::limits({ initial_width, -1 });
             }
-            base::resize(twod{ initial_width, 0 } + base::intpad);
+            base::resize(twod{ initial_width, 0 });
             base::reflow();
             return this->This();
         }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1826,10 +1826,13 @@ namespace netxs::os
 
             #else
 
+                auto chars = text(255, 0);
+                auto error = ::gethostname(chars.data(), chars.size());
                 auto usrid = ::geteuid();
                 auto pwuid = ::getpwuid(usrid);
                 auto strid = utf::concat(usrid);
                 auto login = pwuid ? pwuid->pw_name : strid;
+                if (!error) login += '@' + text{ chars.data() };
                 return std::pair{ login, strid };
 
             #endif

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -5596,7 +5596,7 @@ namespace netxs::os
                     {
                         if (!(dtvt::vtmode & ui::console::nt16) && s != dtvt::consize()) // wt issue GH #16231
                         {
-                            std::cout << prompt::os << ansi::err("Terminal is out of sync. See https://github.com/microsoft/terminal/issues/16231 for details.") << "\n";
+                            std::cout << prompt::os << ansi::err("Terminal size is out of sync. See https://github.com/microsoft/terminal/issues/16231 for details.") << "\n";
                         }
                     }
                 }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1826,12 +1826,11 @@ namespace netxs::os
 
             #else
 
-                uid_t id;
-                id = ::geteuid();
-                auto pwuid = ::getpwuid(id);
-                auto user_id = utf::concat(id);
-                auto user_name =  pwuid ? pwuid->pw_name : user_id;
-                return std::pair{ user_name, user_id };
+                auto usrid = ::geteuid();
+                auto pwuid = ::getpwuid(usrid);
+                auto strid = utf::concat(usrid);
+                auto login = pwuid ? pwuid->pw_name : strid;
+                return std::pair{ login, strid };
 
             #endif
         }

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
     auto direct = os::dtvt::active;
     auto syslog = os::tty::logger();
     auto userid = os::env::user();
-    auto prefix = vtpipe.length() ? vtpipe : utf::concat(app::shared::ipc_prefix, os::process::elevated ? "!_" : "_", userid.second);;
+    auto prefix = vtpipe.length() ? vtpipe : utf::concat(app::shared::ipc_prefix, os::process::elevated ? "!-" : "-", userid.second);;
     auto prefix_log = prefix + app::shared::log_suffix;
     auto failed = [&](auto cause)
     {


### PR DESCRIPTION
Changes
- Use user@host naming on Unix
- Fix ui::post anchoring
- Rename `About` to `Info`
- Fix user list wrapping