### PR TITLE
Don't move viewport when activating a window from the taskbar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,13 @@ jobs:
             cpu: universal
             arch: any
             cxx: c++
-            flags: '-DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG -Wall -Wextra -Wno-missing-field-initializers"'
+            flags: '-DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG -Wall -Wextra -Wno-missing-field-initializers -Werror"'
           - os: windows-latest
             platform: windows
             cpu: Win32
             arch: x86
             cxx: cl
-            flags: '-DCMAKE_CXX_FLAGS_RELEASE="/MT /O2 /DNDEBUG /W4" -A '
+            flags: '-DCMAKE_CXX_FLAGS_RELEASE="/MT /O2 /DNDEBUG /W4 /warnaserror" -A '
           - os: windows-latest
             cxx: cl
           - os: ubuntu-latest
@@ -50,9 +50,9 @@ jobs:
             cxx: /bin/aarch64-linux-gnu-g++
 
           - os: ubuntu-latest
-            flags: '-DCMAKE_CXX_FLAGS_RELEASE="-static -s -O2 -DNDEBUG -Wall -Wextra -Wno-missing-field-initializers -Wno-psabi"'
+            flags: '-DCMAKE_CXX_FLAGS_RELEASE="-static -s -O2 -DNDEBUG -Wall -Wextra -Wno-missing-field-initializers -Wno-psabi -Werror"'
           - os: windows-latest
-            flags: '-DCMAKE_CXX_FLAGS_RELEASE="/MT /O2 /DNDEBUG /W4" -A '
+            flags: '-DCMAKE_CXX_FLAGS_RELEASE="/MT /O2 /DNDEBUG /W4 /warnaserror" -A '
 
           - os: ubuntu-latest
             platform: linux

--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -96,11 +96,11 @@
   </tr>
   <tr>
     <th>LeftDrag</th>
-    <td colspan="3"></td>
+    <td colspan="3">Move desktop viewport</td>
     <td colspan="3">Move window or Select text</td>
     <td colspan="1">Resize window</td>
     <td colspan="1">Move window</td>
-    <td>Panoramic workspace scrolling</td>
+    <td>Move desktop viewport</td>
   </tr>
   <tr>
     <th>RightDrag</th>
@@ -117,7 +117,7 @@
     <th>Left+RightDrag</th>
     <td colspan="3"></td>
     <td colspan="4">Move window / Restore maximized</td>
-    <td colspan="2">Panoramic workspace scrolling</td>
+    <td colspan="2">Move desktop viewport</td>
   </tr>
   <tr>
     <th>Ctrl+LeftDrag</th>

--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -36,19 +36,19 @@
   <tr>
     <th>LeftClick</th>
     <td>Run app</td>
-    <td>Minimize<br>Restore</td>
+    <td>Assign exclusive focus</td>
     <td></td>
     <td>Minimize<br>Maximize<br>Close</td>
-    <td colspan="3">Assign exclusive keyboard focus</td>
+    <td colspan="3">Assign exclusive focus</td>
     <td>Go to app</td>
     <td>Clear keyboard focus</td>
   </tr>
   <tr>
     <th>RightClick</th>
     <td>Set default app</td>
-    <td>Center app window</td>
+    <td>Toggle taskbar width</td>
     <td colspan="1"></td>
-    <td colspan="2">Assign exclusive keyboard focus</td>
+    <td colspan="2">Assign exclusive focus</td>
     <td colspan="1"></td>
     <td colspan="2">Center app window</td>
     <td></td>
@@ -72,10 +72,21 @@
     <td></td>
   </tr>
   <tr>
-    <th>double LeftClick</th>
-    <td colspan="3"></td>
+    <th>DblLeftClick</th>
+    <td colspan="1"></td>
+    <td colspan="1">Go to app window</td>
+    <td colspan="1"></td>
     <td></td>
     <td colspan="2">Maximize<br>Restore</td>
+    <td colspan="3"></td>
+  </tr>
+  <tr>
+    <th>Alt/Option+DblLeftClick</th>
+    <td colspan="1"></td>
+    <td colspan="1">Center app window</td>
+    <td colspan="1"></td>
+    <td></td>
+    <td colspan="2"></td>
     <td colspan="3"></td>
   </tr>
   <tr>

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -716,7 +716,8 @@ namespace netxs::app::desk
             auto apps_users = taskbar->attach(slot::_1, ui::fork::ctor(axis::Y, 0, 100));
             auto applist_area = apps_users->attach(slot::_1, ui::cake::ctor());
             auto tasks_scrl = applist_area->attach(ui::rail::ctor(axes::Y_only))
-                ->plugin<pro::notes>(" Use RightDrag or scroll wheel to slide up/down ")
+                ->plugin<pro::notes>(" Use RightDrag or scroll wheel to slide up/down \n"
+                                     " Use LeftDrag to move desktop viewport          ")
                 ->active()
                 ->invoke([&](auto& boss)
                 {

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -117,52 +117,72 @@ namespace netxs::app::desk
                     {
                         disabled = check_id(boss, gear_id);
                     };
+                    boss.LISTEN(tier::release, hids::events::mouse::button::dblclick::left, gear, -, (data_src_shadow, disabled_ptr/*owns*/))
+                    {
+                        if (disabled) { gear.dismiss(true); return; }
+                        if (auto data_src = data_src_shadow.lock())
+                        {
+                            auto& window = *data_src;
+                            if (gear.meta(hids::anyAlt)) // Pull window.
+                            {
+                                window.RISEUP(tier::preview, e2::form::layout::expose, area, ());
+                                gear.owner.SIGNAL(tier::request, e2::form::prop::viewport, viewport, ());
+                                window.SIGNAL(tier::preview, e2::form::layout::appear, viewport.center()); // Pull window.
+                                if (window.hidden) // Restore if minimized.
+                                {
+                                    window.SIGNAL(tier::release, e2::form::size::minimize, gear);
+                                }
+                                else pro::focus::set(data_src, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                            }
+                            else // Jump to window.
+                            {
+                                gear.owner.SIGNAL(tier::release, e2::form::layout::jumpto, window);
+                            }
+                            gear.dismiss();
+                        }
+                    };
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear, -, (data_src_shadow, disabled_ptr/*owns*/))
                     {
                         if (disabled) { gear.dismiss(true); return; }
                         if (auto data_src = data_src_shadow.lock())
                         {
                             auto& window = *data_src;
-                            auto  center = window.base::area().center();
-                            gear.owner.SIGNAL(tier::request, e2::form::prop::viewport, viewport, ());
-
-                            if (viewport.hittest(center)        // Minimize if visible,
-                             && !window.hidden                  // not minimized,
-                             && pro::focus::test(window, gear)) // and focused.
+                            if (gear.meta(hids::anyCtrl)) // Toggle group focus.
                             {
-                                if (gear.meta(hids::anyCtrl)) pro::focus::off(data_src, gear.id); // Remove focus if Ctrl pressed.
-                                else                          window.SIGNAL(tier::release, e2::form::size::minimize, gear);
+                                if (pro::focus::test(window, gear))
+                                {
+                                    pro::focus::off(data_src, gear.id); // Remove focus if focused.
+                                }
+                                else // Expose and set group focus.
+                                {
+                                    window.RISEUP(tier::preview, e2::form::layout::expose, area, ());
+                                    if (window.hidden) // Restore if minimized.
+                                    {
+                                        window.SIGNAL(tier::release, e2::form::size::minimize, gear);
+                                    }
+                                    pro::focus::set(data_src, gear.id, pro::focus::solo::off, pro::focus::flip::off);
+                                }
+                                gear.dismiss(true); // Suppress double click.
                             }
-                            else
+                            else if (gear.meta(hids::anyAlt)) // Skip it and wait for Alt+Dblclick.
+                            {
+                                gear.dismiss();
+                            }
+                            else // Set unique focus.
                             {
                                 window.RISEUP(tier::preview, e2::form::layout::expose, area, ());
-                                gear.owner.SIGNAL(tier::release, e2::form::layout::jumpto, window);
-                                if (window.hidden) // Restore if hidden.
+                                if (window.hidden) // Restore if minimized.
                                 {
                                     window.SIGNAL(tier::release, e2::form::size::minimize, gear);
                                 }
-                                else pro::focus::set(data_src, gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off
-                                                                                                 : pro::focus::solo::on, pro::focus::flip::off);
+                                else pro::focus::set(data_src, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                                gear.dismiss();
                             }
-                            gear.dismiss(true);
                         }
                     };
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear, -, (data_src_shadow))
                     {
-                        if (disabled) { gear.dismiss(true); return; }
-                        if (auto data_src = data_src_shadow.lock())
-                        {
-                            auto& window = *data_src;
-                            window.RISEUP(tier::preview, e2::form::layout::expose, area, ());
-                            gear.owner.SIGNAL(tier::request, e2::form::prop::viewport, viewport, ());
-                            window.SIGNAL(tier::preview, e2::form::layout::appear, viewport.center()); // Pull window.
-                            if (window.hidden) // Restore if minimized.
-                            {
-                                window.SIGNAL(tier::release, e2::form::size::minimize, gear);
-                            }
-                            else pro::focus::set(data_src, gear.id, pro::focus::solo::on, pro::focus::flip::off);
-                            gear.dismiss();
-                        }
+                        // Reserved for context menu.
                     };
                     boss.LISTEN(tier::release, e2::form::state::mouse, state, -, (data_src_shadow))
                     {

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -96,10 +96,12 @@ namespace netxs::app::desk
                         auto disabled = gear_id && gear_id != owner_id;
                         boss.SIGNAL(tier::release, e2::form::state::disabled, disabled);
                         auto& notes = boss.template plugins<pro::notes>();
-                        notes.update(disabled ? " Window is locked by another user "
-                                              : " Application window:              \n"
-                                                "   Left click to go to the window \n"
-                                                "   Right click to pull the window ");
+                        notes.update(disabled ? " Window is locked by another user      "
+                                              : " Application window:                   \n"
+                                                "   Left click to set exclusive focus   \n"
+                                                "   Ctrl+LeftClick to set group focus   \n"
+                                                "   DoubleLeftClick to go the window    \n"
+                                                "   Alt+DblLeftClick to pull the window ");
                         return disabled;
                     };
                     data_src->SIGNAL(tier::request, e2::form::state::maximized, gear_id, ());

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -100,7 +100,7 @@ namespace netxs::app::desk
                                               : " Application window:                   \n"
                                                 "   Left click to set exclusive focus   \n"
                                                 "   Ctrl+LeftClick to set group focus   \n"
-                                                "   DoubleLeftClick to go the window    \n"
+                                                "   DoubleLeftClick to go to the window \n"
                                                 "   Alt+DblLeftClick to pull the window ");
                         return disabled;
                     };

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -96,12 +96,13 @@ namespace netxs::app::desk
                         auto disabled = gear_id && gear_id != owner_id;
                         boss.SIGNAL(tier::release, e2::form::state::disabled, disabled);
                         auto& notes = boss.template plugins<pro::notes>();
-                        notes.update(disabled ? " Window is locked by another user      "
-                                              : " Application window:                   \n"
-                                                "   Left click to set exclusive focus   \n"
-                                                "   Ctrl+LeftClick to set group focus   \n"
-                                                "   DoubleLeftClick to go to the window \n"
-                                                "   Alt+DblLeftClick to pull the window ");
+                        notes.update(disabled ? " Window is locked by another user "
+                                              : " Application window:                     \n"
+                                                "   LeftClick to set exclusive focus      \n"
+                                                "   Ctrl+LeftClick to set group focus     \n"
+                                                "   DoubleLeftClick to go to the window   \n"
+                                                "   Alt+DblLeftClick to pull the window   \n"
+                                                "   Use LeftDrag to move desktop viewport ");
                         return disabled;
                     };
                     data_src->SIGNAL(tier::request, e2::form::state::maximized, gear_id, ());
@@ -272,9 +273,10 @@ namespace netxs::app::desk
                     };
                 });
 
-            auto def_note = text{" Application:                                   \n"
-                                 "   Left click to start the application instance \n"
-                                 "   Right click to set as default                "};
+            auto def_note = text{" Application:                                  \n"
+                                 "   LeftClick to start the application instance \n"
+                                 "   RightClick to set as default                \n"
+                                 "   Use LeftDrag to move desktop viewport       "};
             data_src->RISEUP(tier::request, desk::events::menu, conf_list_ptr, ());
             if (!conf_list_ptr || !apps_map_ptr) return apps;
             auto& conf_list = *conf_list_ptr;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.45";
+    static const auto version = "v0.9.46";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto ipc_prefix = "vtm";
     static const auto log_suffix = "_log";

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -2347,7 +2347,6 @@ struct impl : consrv
     }
     auto api_system_langid_get               ()
     {
-        log(prompt, "GetConsoleLangId");
         struct payload : drvpacket<payload>
         {
             struct
@@ -2357,11 +2356,15 @@ struct impl : consrv
             reply;
         };
         auto& packet = payload::cast(upload);
+        auto& client = *(clnt*)packet.client;
+        log(prompt, "GetConsoleLangId",
+            "\n\tcurexe: ", client.detail.curexe,
+            "\n\tprocid: ", client.procid);
         auto winuicp = ::GetACP();
         if (winuicp != 65001 && langmap().contains(winuicp))
         {
             packet.reply.langid = (ui16)netxs::map_or(langmap(), outenc->codepage, 65001);
-            log("\tlang id: ", utf::to_hex_0x(packet.reply.langid));
+            log("\tlangid: ", utf::to_hex_0x(packet.reply.langid));
         }
         else
         {

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1072,6 +1072,7 @@ struct impl : consrv
                     {
                         auto& term = server.uiterm;
                         term.ondata("(Ctrl+C = Y) ");
+                        return true;
                     });
                 }
                 lock.lock();
@@ -1314,6 +1315,7 @@ struct impl : consrv
                                 }
                             }
                             data.crop(size);
+                            return true;
                         });
                     }
                     else
@@ -2207,8 +2209,8 @@ struct impl : consrv
         {
             if (handle_ptr->link == &uiterm.target)
             {
-                     if (uiterm.target == &uiterm.normal) uiterm.update([&] { proc(uiterm.normal); });
-                else if (uiterm.target == &uiterm.altbuf) uiterm.update([&] { proc(uiterm.altbuf); });
+                     if (uiterm.target == &uiterm.normal) uiterm.update([&] { proc(uiterm.normal); return faux; });
+                else if (uiterm.target == &uiterm.altbuf) uiterm.update([&] { proc(uiterm.altbuf); return faux; });
                 return true;
             }
             else
@@ -2225,7 +2227,7 @@ struct impl : consrv
                         if (auto iter2 = std::find_if(client.alters.begin(), client.alters.end(), [&](auto& altbuf){ return link == &altbuf; });
                             iter2 != client.alters.end()) // Buffer exists.
                         {
-                            uiterm.update([&] { proc(*iter2); });
+                            uiterm.update([&] { proc(*iter2); return faux; });
                             return true;
                         }
                     }
@@ -2368,6 +2370,7 @@ struct impl : consrv
         }
         else
         {
+            //packet.reply.langid = MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US);
             answer.status = nt::status::not_supported;
             log("\tlang id not supported");
         }
@@ -3060,6 +3063,7 @@ struct impl : consrv
         }
         else log("\tunexpected: packet.packsz=%val1% answer.readoffset=%val2%", packet.packsz, answer.readoffset());
         answer.report = packet.reply.count;
+        if (packet.reply.count) unsync = true;
     }
     auto api_scrollback_write_data           ()
     {
@@ -3200,6 +3204,7 @@ struct impl : consrv
             }
             packet.reply.count = count;
         }
+        if (packet.reply.count) unsync = true;
     }
     auto api_scrollback_write_block          ()
     {
@@ -3384,6 +3389,7 @@ struct impl : consrv
           "\n\tinput.rect: ", view,
           "\n\treply.rect: ", crop,
           "\n\twrite data:\n\t", utf::change(ansi::s11n((rich&)mirror, crop), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));
+        if (crop) unsync = true;
     }
     auto api_scrollback_attribute_set        ()
     {
@@ -3554,6 +3560,7 @@ struct impl : consrv
             }
         }
         packet.reply.count = count;
+        if (count) unsync = true;
     }
     auto api_scrollback_read_data            ()
     {
@@ -3905,6 +3912,7 @@ struct impl : consrv
                 }
             }
         }
+        unsync = true;
     }
     auto api_scrollback_cursor_coor_set      ()
     {
@@ -3927,6 +3935,7 @@ struct impl : consrv
                 console_ptr->cup0(caretpos);
             }
         }
+        unsync = true;
     }
     auto api_scrollback_cursor_info_get      ()
     {
@@ -4132,6 +4141,7 @@ struct impl : consrv
                 *head++ = rgbpalette[m] | 0xFF000000; // conhost crashed if alpha non zero.
             }
         }
+        unsync = true;
     }
     auto api_scrollback_size_set             ()
     {
@@ -4166,6 +4176,7 @@ struct impl : consrv
             packet.input.buffersz_x = (si16)(viewport.x);
             packet.input.buffersz_y = (si16)(viewport.y);
         }
+        unsync = true;
     }
     auto api_scrollback_viewport_get_max_size()
     {
@@ -4251,6 +4262,7 @@ struct impl : consrv
         auto& packet = payload::cast(upload);
         auto window_ptr = select_buffer(packet.target);
         if (!window_ptr) return;
+        unsync = true;
         if constexpr (isreal())
         {
             auto& window_inst = *window_ptr;
@@ -4887,6 +4899,7 @@ struct impl : consrv
     para        celler; // consrv: Buffer for converting raw text to cells.
     xlat        inpenc; // consrv: Current code page decoder for input stream.
     xlat        outenc; // consrv: Current code page decoder for output stream.
+    bool        unsync; // consrv: The terminal must be updated.
 
     auto& create_window()
     {
@@ -4980,6 +4993,12 @@ struct impl : consrv
                         {
                             auto lock = std::lock_guard{ events.locker };
                             (this->*proc)();
+                            if (unsync)
+                            {
+                                unsync = faux;
+                                return true;
+                            }
+                            else return faux;
                         });
                         break;
                     }
@@ -5076,7 +5095,8 @@ struct impl : consrv
           altmod{ faux                                           },
           prompt{ utf::concat(win32prompt)                       },
           inpenc{ std::make_shared<decoder>(*this, os::codepage) },
-          outenc{ inpenc                                         }
+          outenc{ inpenc                                         },
+          unsync{ faux                                           }
     {
         apimap.resize(0xFF, &impl::api_unsupported);
         apimap[0x38] = &impl::api_system_langid_get;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -3211,7 +3211,7 @@ namespace netxs::ui
             };
             LISTEN(tier::release, e2::form::animate::stop, task_id)
             {
-                switch (id)
+                switch (task_id)
                 {
                     case Y: manual[Y] = true; /*scroll<Y>();*/ break;
                     case X: manual[X] = true; /*scroll<X>();*/ break;


### PR DESCRIPTION
Changes
- Don't move viewport when activating a window from the taskbar, #521
  - RightClick: Toggle taskbar width / Reserved for context menu
  - LeftClick: Set exclusive focus (+restore if minimized)
  - Ctrl+LeftClick: Set/reset group focus
  - DblLeftClick: Jump to window (move viewport)
  - Alt+DblLeftClick: Pull window to viewport center (move window)
- Update `/doc/user-interface.md`
- Fix regression from commit: f14c484321763efb7fea2179bdcd2c1a3b3a1a18 (broken scrolling)
- Reduce idle updates of the built-in terminal in case of xlvt-connection

Closes #521