### PR TITLE
Fix cmd.exe history reset (cmd.exe)

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.53";
+    static const auto version = "v0.9.54";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto ipc_prefix = "vtm";
     static const auto log_suffix = "_log";

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1126,36 +1126,35 @@ struct impl : consrv
                         if (c == 0x7f && v == 0) v = VK_BACK;
                         switch (v)
                         {
-                            case VK_CONTROL:
-                            case VK_SHIFT:
-                            case VK_MENU:/*Alt*/
-                            case VK_PAUSE:
-                            case VK_LWIN:
-                            case VK_RWIN:
-                            case VK_APPS:
-                            case VK_NUMLOCK:
-                            case VK_CAPITAL:
-                            case VK_SCROLL:
-                            case VK_CLEAR:/*NUMPAD 5*/
-                            case VK_F2:  //todo menu
-                            case VK_F4:  //todo menu
+                            case VK_CONTROL: break;
+                            case VK_SHIFT:   break;
+                            case VK_MENU:    break; /*Alt*/
+                            case VK_PAUSE:   break;
+                            case VK_LWIN:    break;
+                            case VK_RWIN:    break;
+                            case VK_APPS:    break;
+                            case VK_NUMLOCK: break;
+                            case VK_CAPITAL: break;
+                            case VK_SCROLL:  break;
+                            case VK_CLEAR:   break; /*NUMPAD 5*/
+                            case VK_F2:      break; //todo menu
+                            case VK_F4:      break; //todo menu
+                            case VK_F9:      break; //todo menu
+                            case VK_F11:     break;
+                            case VK_F12:     break;
                             case VK_F7:
-                            if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
-                            {
-                                hist = {};
-                                if (server.io_log) log("%%Cleared command history for process '%procname%'", prompt::cin, nameview);
+                                if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
+                                {
+                                    hist = {};
+                                    if (server.io_log) log("%%Cleared command history for process '%procname%'", prompt::cin, nameview);
+                                }
                                 break;
-                            }
-                            case VK_F9:  //todo menu
                             case VK_F10:
-                            if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
-                            {
-                                off_aliases(nameview);
-                                if (server.io_log) log("%%Removed DOSKEY aliases for process '%procname%'", prompt::cin, nameview);
-                                break;
-                            }
-                            case VK_F11:
-                            case VK_F12:
+                                if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
+                                {
+                                    off_aliases(nameview);
+                                    if (server.io_log) log("%%Removed DOSKEY aliases for process '%procname%'", prompt::cin, nameview);
+                                }
                                 break;
                             case VK_INSERT: burn(); mode(!mode);                                                                   break;
                             case VK_F6:     burn(); hist.save(line);               line.insert(cell{}.c0_to_txt('Z' - '@'), mode); break;
@@ -1186,11 +1185,11 @@ struct impl : consrv
                             case VK_NUMPAD7:
                             case VK_NUMPAD8:
                             case VK_NUMPAD9:
-                            if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)) // Process Alt+Numpad input.
-                            {
-                                while (n--) nums = nums * 10 + v - VK_NUMPAD0;
-                                break;
-                            }
+                                if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)) // Process Alt+Numpad input.
+                                {
+                                    while (n--) nums = nums * 10 + v - VK_NUMPAD0;
+                                    break;
+                                }
                             default:
                             {
                                 n--;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2756,7 +2756,6 @@ namespace netxs::os
                 {
                     log("Process image has been copied to '%path%'.", dest.string());
                     #if defined(_WIN32)
-
                         // Create service.
                         auto svcname = utf::to_utf(os::service::name);
                         auto svcdesc = utf::to_utf(os::service::desc);
@@ -2786,7 +2785,8 @@ namespace netxs::os
                         service && ::StartServiceW(service, 0, NULL);
                         ::CloseServiceHandle(service);
                         ::CloseServiceHandle(manager);
-
+                    #else
+                        ok(::chmod(dest.string().c_str(), 0755), "Failed to set a file's mode bits for '%path%'.", dest.string());
                     #endif
                 }
                 else log("Failed to copy process image to '%path%'.", dest.string());


### PR DESCRIPTION
Changes (Windows)
- Fix cmd.exe history reset, #537
- Set the file mode bits for `/usr/local/bin/vtm` to 0755 (octal) when installing (on Unix)

Closes #537