### PR TITLE
Add scripting support

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -1,13 +1,13 @@
-# Text Mode Desktop
+# Text-based desktop environment
 
-## Built-in Applications
-- `▀▄ Term`     Terminal Emulator
-- `▀▄ DirectVT` DirectVT Proxy Console
-- `▀▄ XLinkVT`  DirectVT Proxy Console with controlling terminal onboard
-- `▀▄ View`     Workspace Navigation Helper
-- `▀▄ Tile`     Tiling Window anager
+## Built-in applications
+- `▀▄ Term`     Terminal emulator
+- `▀▄ DirectVT` DirectVT proxy
+- `▀▄ XLinkVT`  DirectVT proxy with controlling terminal onboard
+- `▀▄ View`     Workspace navigation helper
+- `▀▄ Tile`     Tiling window manager
 
-## Terminal Emulator
+## Terminal emulator
 
 ### Features
 
@@ -233,7 +233,7 @@ TerminalStdioLog             | Stdin/stdout log toggle.
 </config>
 ```
 
-## DirectVT Proxy Console
+## DirectVT proxy
 
 ...
 
@@ -244,7 +244,7 @@ Example (running `vtm -r term` in dtvt-mode):
 vtm -r dtvt vtm -r term
 ```
 
-## DirectVT Proxy Console with controlling terminal onboard
+## DirectVT proxy with controlling terminal onboard
 
 This console mode is used when there is a need for interactive interaction with the user through the controlling terminal. For example, this is required when connecting via SSH with keyboard-interactive authentication or requesting a private key passphrase.
 
@@ -264,7 +264,7 @@ vtm ssh user@host vtm
 
 - Serves for quick navigation through the workspace using cyclic selection (left click on group title) in the `View` group on the taskbar. Right click to set clipboard data as region title (swap clipboard text and title).
 
-## Tiling Window Manager
+## Tiling window manager
 
 ### Features
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -337,30 +337,30 @@ The taskbar menu can be configured using a settings file `~/.config/vtm/settings
         <!-- <item*/> --> <!-- Clear default item list -->
         <item splitter label="Built-in apps"/>
 
-        <item id="Text Editor demo" type=dtvt param="vtm -r text"/>
-        <item id="Calculator demo"  type=dtvt param="vtm -r calc"/>
-        <item id="Truecolor test"   type=dtvt param="vtm -r truecolor"/>
+        <item id="Text Editor demo" type=dtvt cmd="vtm -r text"/>
+        <item id="Calculator demo"  type=dtvt cmd="vtm -r calc"/>
+        <item id="Truecolor test"   type=dtvt cmd="vtm -r truecolor"/>
 
         <item splitter label="Remote Access"/>
 
-        <item id="Run vtm in DirectVT mode remotely via SSH"    type=xlvt param="ssh user@server vtm"/>
-        <item id="Run a standalone console application via ssh" type=xlvt param="ssh user@server vtm -r /path/to/console/app"/>
-        <item id="Run application via ssh w/o extra UI"         type=xlvt param="ssh user@server vtm -r headless /path/to/console/app"/>
+        <item id="Run vtm in DirectVT mode remotely via SSH"    type=xlvt cmd="ssh user@server vtm"/>
+        <item id="Run a standalone console application via ssh" type=xlvt cmd="ssh user@server vtm -r /path/to/console/app"/>
+        <item id="Run application via ssh w/o extra UI"         type=xlvt cmd="ssh user@server vtm -r headless /path/to/console/app"/>
 
         <item splitter label="Another Examples"/>
 
-        <item id="Far Manager"             type=headless param="far"/>
-        <item id="Far Manager in terminal" type=dtvt     param="$0 -r far"/>
+        <item id="Far Manager"             type=headless cmd="far"/>
+        <item id="Far Manager in terminal" type=dtvt     cmd="$0 -r far"/>
 
-        <item id="Midnight Commander"             type=headless param="mc"/>
-        <item id="Midnight Commander in terminal" type=dtvt     param="$0 -r mc"/>
+        <item id="Midnight Commander"             type=headless cmd="mc"/>
+        <item id="Midnight Commander in terminal" type=dtvt     cmd="$0 -r mc"/>
 
-        <item id="Far Manager via ssh"     type=xlvt param="ssh user@server vtm -r headless far"/>
-        <item id="cmd in terminal via ssh" type=xlvt param="ssh user@server vtm -r term cmd"/>
-        <item id="cmd via ssh"             type=xlvt param="ssh user@server vtm -r headless cmd"/>
-        <item id="wsl via ssh"             type=xlvt param="ssh user@server vtm -r headless  wsl"/>
-        <item id="mc via ssh"              type=xlvt param="ssh user@server vtm -r headless mc"/>
-        <item id="wsl mc via ssh"          type=xlvt param="ssh user@server vtm -r headless wsl mc"/>
+        <item id="Far Manager via ssh"     type=xlvt cmd="ssh user@server vtm -r headless far"/>
+        <item id="cmd in terminal via ssh" type=xlvt cmd="ssh user@server vtm -r term cmd"/>
+        <item id="cmd via ssh"             type=xlvt cmd="ssh user@server vtm -r headless cmd"/>
+        <item id="wsl via ssh"             type=xlvt cmd="ssh user@server vtm -r headless wsl"/>
+        <item id="mc via ssh"              type=xlvt cmd="ssh user@server vtm -r headless mc"/>
+        <item id="wsl mc via ssh"          type=xlvt cmd="ssh user@server vtm -r headless wsl mc"/>
     </menu>
 </config>
 ```

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,6 +1,6 @@
-# Text Mode Desktop Architecture
+# Text-based desktop environment architecture
 
-## Process Model
+## Process model
 
 ```mermaid
 graph TB
@@ -89,7 +89,7 @@ graph TB
 - The terminal process is a fork of the original desktop server process, running as standalone terminal in DirectVT mode. Terminating this process will automatically close the application.
 - The session exists until it is explicitly shutted down.
 
-## Interprocess Communication
+## Interprocess communication
 
 Interprocess communication relies on the DirectVT binary protocol, multiplexing the following primary channels:
 - Keyboard event channel
@@ -168,9 +168,9 @@ The binary render received for output from the server side is converted by the c
 
 vtm renders itself at a constant frame rate into internal buffers and outputs to the console only when the console is ready to accept the next frame.
 
-# Usage Scenarios
+# Usage scenarios
 
-## Local Usage
+## Local usage
 
 ### Running vtm desktop
 
@@ -212,7 +212,7 @@ vtm renders itself at a constant frame rate into internal buffers and outputs to
     # The `vtm -r headless` option means to run the built-in terminal without menu and bottom bar.
     ```
 
-## Remote Access
+## Remote access
 
 In general, the local and remote platforms may be different.
 
@@ -310,7 +310,7 @@ The following examples assume that vtm is installed on both the local and remote
     # Note: Make sure `ncat` is installed.
     ```
 
-### Local Standard I/O Redirection (POSIX only)
+### Local standard I/O redirection (POSIX only)
 
 - Host side
     - Run commands
@@ -326,9 +326,9 @@ The following examples assume that vtm is installed on both the local and remote
     # Note: Make sure `socat` is installed.
     ```
 
-## More Tips
+## More tips
 
-## Desktop Taskbar Menu Customization
+## Desktop taskbar menu customization
 
 The taskbar menu can be configured using a settings file `~/.config/vtm/settings.xml` (`%USERPROFILE%\\.config\\vtm\\settings.xml`):
 ```xml
@@ -365,11 +365,11 @@ The taskbar menu can be configured using a settings file `~/.config/vtm/settings
 </config>
 ```
 
-### Tiling Window Manager
+### Tiling window manager
 
 Terminal windows can be organized using the built-in tiling window manager. Grouping can be temporary within the current session, or pre-configured using settings. See [Settings/App type `Group`](settings.md#app-type) for details.
 
-### VT Logging for Developers
+### VT logging for developers
 
 vtm allows developers to visualize standard input/output streams. Launched with the `vtm -m` option, vtm will log the event stream of each terminal window with the `Logs` switch enabled.
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -1,6 +1,6 @@
-# Text Mode Desktop
+# Text-based desktop environment
 
-## Building from Source
+## Building from source
 
 ### Unix
 

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -1,4 +1,4 @@
-# Text Mode Desktop
+# Text-based desktop environment
 
 ### Command-line options
 
@@ -23,9 +23,13 @@ No arguments                 | Connect to the desktop (autostart new if not runn
 
 ### Built-in applications
 
-Application | Description
-------------|------------------------------------------
-`Term`      | Terminal emulator (default)
-`Headless`  | Terminal emulator without UI
-`DTVT`      | DirectVT Proxy Console
-`XLVT`      | DirectVT Proxy Console with controlling terminal (Cross-linked VT)
+Application | Description                                                 | Usage
+------------|-------------------------------------------------------------|------------------------------------
+`Term`      | Terminal emulator to run cli applications.                  | `vtm -r term [cli_application]`
+`Headless`  | Terminal emulator without extra UI.                         | `vtm -r headless [cli_application]`
+`DTVT`      | DirectVT proxy to run dtvt-apps in text console.            | `vtm -r dtvt [dtvt_application]`
+`XLVT`      | DirectVT proxy with controlling terminal (Cross-linked VT), | `vtm -r xlvt ssh [user@host dtvt_application]`
+
+The following commands have a short form:"
+  - `vtm -r xlvt ssh [user@host dtvt_application]` can be shortened to `vtm ssh [user@host dtvt_application]`.
+  - `vtm -r term [cli_application]` can be shortened to `vtm -r [cli_application]`.

--- a/doc/panel.md
+++ b/doc/panel.md
@@ -1,4 +1,4 @@
-# Text Mode Desktop Live Panel
+# Live Panel
 
 In release [v0.9.9v](https://github.com/directvt/vtm/releases/tag/v0.9.9v) a slot for the desktop live panel was introduced. 
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -1,4 +1,4 @@
-# Text Mode Desktop Settings
+# Text-based desktop environment settings
 
 ```mermaid
 graph LR

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -31,7 +31,7 @@ graph LR
     <config>
         <menu>
             ...
-            <item ... type=DirectVT ... param="$0 ...">
+            <item ... type=DirectVT ... cmd="$0 ...">
                 <config> <!-- item's `<config>` subsection -->
                     ...
                 </config>
@@ -202,8 +202,8 @@ Attribute  | Description                                       | Value type | Ma
 `slimmenu` |  App window menu vertical size                    | `boolean`  |           | `no`
 `env`      |  Environment variable in "var=val" format         | `string`   |           |
 `cwd`      |  Current working directory                        | `string`   |           |
+`cmd`      |  App constructor arguments                        | `string`   |           | empty
 `type`     |  App type                                         | `string`   |           | `SHELL`
-`param`    |  App constructor arguments                        | `string`   |           | empty
 `config`   |  Configuration patch for DirectVT apps            | `xml-node` |           | empty
 
 #### Value literals
@@ -219,19 +219,19 @@ Type     | Format
 
 Type              | Parameter        | Description
 ------------------|------------------|-----------
-`DirectVT`        | `_command line_` | Run `_command line_` using DirectVT protocol. Usage example `type=DirectVT param="_command line_"`.
-`XLVT`\|`XLinkVT` | `_command line_` | Run `_command line_` using DirectVT protocol with controlling terminal attached for OpenSSH interactivity. Usage example `type=XLVT param="_command line_"`.
-`ANSIVT`          | `_command line_` | Run `_command line_` inside the built-in terminal. Usage example `type=ANSIVT param="_command line_"`. Same as `type=DirectVT param="$0 -r term _command line_"`.
-`SHELL` (default) | `_command line_` | Run `_command line_` on top of a system shell that runs inside the built-in terminal. Usage example `type=SHELL param="_command line_"`. Same as `type=DirectVT param="$0 -r term _shell_ -c _command line_"`.
-`Group`           | [[ v[`n:m:w`] \| h[`n:m:w`] ] ( id_1 \| _nested_block_ , id_2 \| _nested_block_ )] | Run tiling window manager with layout specified in `param`. Usage example `type=Group param="h1:1(Term, Term)"`.
-`Region`          | | The `param` attribute is not used, use attribute `title=_view_title_` to set region name.
+`DirectVT`        | `_command line_` | Run `_command line_` using DirectVT protocol. Usage example `type=DirectVT cmd="_command line_"`.
+`XLVT`\|`XLinkVT` | `_command line_` | Run `_command line_` using DirectVT protocol with controlling terminal attached for OpenSSH interactivity. Usage example `type=XLVT cmd="_command line_"`.
+`ANSIVT`          | `_command line_` | Run `_command line_` inside the built-in terminal. Usage example `type=ANSIVT cmd="_command line_"`. Same as `type=DirectVT cmd="$0 -r term _command line_"`.
+`SHELL` (default) | `_command line_` | Run `_command line_` on top of a system shell that runs inside the built-in terminal. Usage example `type=SHELL cmd="_command line_"`. Same as `type=DirectVT cmd="$0 -r term _shell_ -c _command line_"`.
+`Group`           | [[ v[`n:m:w`] \| h[`n:m:w`] ] ( id_1 \| _nested_block_ , id_2 \| _nested_block_ )] | Run tiling window manager with layout specified in `cmd`. Usage example `type=Group cmd="h1:1(Term, Term)"`.
+`Region`          | | The `cmd` attribute is not used, use attribute `title=_view_title_` to set region name.
 
 The following configuration items produce the same final result:
 ```
-<item …. param=‘mc’/>
-<item …. type=SHELL param=‘mc’/>
-<item …. type=ANSIVT param=‘bash -c mc’/>
-<item …. type=DirectVT param=‘$0 -r term bash -c mc’/>
+<item …. cmd=‘mc’/>
+<item …. type=SHELL cmd=‘mc’/>
+<item …. type=ANSIVT cmd=‘bash -c mc’/>
+<item …. type=DirectVT cmd=‘$0 -r term bash -c mc’/>
 ```
 
 ### Configuration Example
@@ -245,7 +245,7 @@ Note: The following configuration sections are not implemented yet:
 ```xml
 <config>
     <menu selected=Term item*>  <!-- Use asterisk to remove previous/existing items from the list. -->
-        <item id=Term/>  <!-- title=id type=SHELL param=os_default_shell -->
+        <item id=Term/>  <!-- title=id type=SHELL cmd=os_default_shell -->
     </menu>
 </config>
 ```
@@ -267,7 +267,7 @@ Note: Hardcoded settings are built from the [/src/vtm.xml](../src/vtm.xml) sourc
             </notes>
         </item>
         <item* hidden=no fgc=whitedk bgc=0x00000000 winsize=0,0 wincoor=0,0 winform=undefined /> <!-- winform: undefined | maximized | minimized -->
-        <item id=Term label="Term" type=DirectVT title="Terminal Emulator" notes=" Terminal Emulator " param="$0 -r term">
+        <item id=Term label="Term" type=DirectVT title="Terminal Emulator" notes=" Terminal Emulator " cmd="$0 -r term">
             <config>   <!-- The following config partially overrides the base configuration. It is valid for DirectVT apps only. -->
                 <term>
                     <scrollback>
@@ -293,13 +293,13 @@ Note: Hardcoded settings are built from the [/src/vtm.xml](../src/vtm.xml) sourc
                 </term>
             </config>
         </item>
-        <item id=PowerShell label="PowerShell" type=DirectVT title="Windows PowerShell"          param="$0 -r term powershell" fgc=15 bgc=0xFF562401 notes=" Windows PowerShell "/>
-   <!-- <item id=WSL        label="WSL"        type=DirectVT title="Windows Subsystem for Linux" param="$0 -r term wsl"                              notes=" Default WSL profile session "/> -->
-   <!-- <item id=Far        label="Far"        type=SHELL    title="Far Manager"                 param="far"                                         notes=" Far Manager in its own window "/> -->
-   <!-- <item id=mc         label="mc"         type=SHELL    title="Midnight Commander"    param="mc"               notes=" Midnight Commander in its own window "/> -->
-        <item id=Tile       label="Tile"       type=Group    title="Tiling Window Manager" param="h1:1(Term, Term)" notes=" Tiling window manager with two terminals attached "/>
-        <item id=View       label=View         type=Region   title="\e[11:3pView: Region"  winform=maximized        notes=" Desktop region marker "/>
-        <item id=Logs       label=Logs         type=DirectVT title="Logs"            param="$0 -q -r term $0 -m" notes=" Log monitor "/>
+        <item id=PowerShell label="PowerShell" type=DirectVT title="Windows PowerShell"          cmd="$0 -r term powershell" fgc=15 bgc=0xFF562401 notes=" Windows PowerShell "/>
+   <!-- <item id=WSL        label="WSL"        type=DirectVT title="Windows Subsystem for Linux" cmd="$0 -r term wsl"                              notes=" Default WSL profile session "/> -->
+   <!-- <item id=Far        label="Far"        type=SHELL    title="Far Manager"                 cmd="far"                                         notes=" Far Manager in its own window "/> -->
+   <!-- <item id=mc         label="mc"         type=SHELL    title="Midnight Commander"    cmd="mc"                  notes=" Midnight Commander in its own window "/> -->
+        <item id=Tile       label="Tile"       type=Group    title="Tiling Window Manager" cmd="h1:1(Term, Term)"    notes=" Tiling window manager with two terminals attached "/>
+        <item id=View       label=View         type=Region   title="\e[11:3pView: Region"  winform=maximized         notes=" Desktop region marker "/>
+        <item id=Logs       label=Logs         type=DirectVT title="Logs"                  cmd="$0 -q -r term $0 -m" notes=" Log monitor "/>
         <autorun item*>  <!-- Autorun specified menu items      -->
             <!--  <item* id=Term winsize=80,25 />               -->
             <!--  <item wincoor=92,31 winform=minimized />      --> <!-- Autorun supports minimized winform only. -->

--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -1,4 +1,4 @@
-# Text Mode Desktop User Interface
+# Text-based desktop environment user interface
 
 <table>
 <thead>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Text Mode Desktop
+# Text-based desktop environment
 
 <a href="https://www.youtube.com/watch?v=kofkoxGjFWQ">
   <img width="400" alt="Demo on YouTube" src="https://user-images.githubusercontent.com/11535558/146906370-c9705579-1bbb-4e9e-8977-47312f551cc8.gif">
@@ -6,9 +6,9 @@
 
 ---
 
-vtm is a text-based desktop environment allowing remote access over tunneling protocols such as SSH. Along with plain-text console I/O, vtm uses binary DirectVT I/O mode to maximize efficiency and minimize cross-platform issues. For remote desktop access between two hosts with vtm and ssh installed on both, all you need is the command: `vtm ssh user@host vtm`.
+vtm is a text-based desktop environment allowing remote access over tunneling protocols such as SSH. Along with plain-text console I/O, vtm uses binary DirectVT I/O mode to maximize efficiency and minimize cross-platform issues.
 
-# Supported Platforms
+# Supported platforms
 
 - Windows
   - Core/Desktop
@@ -23,7 +23,7 @@ vtm is a text-based desktop environment allowing remote access over tunneling pr
 
 [Tested Terminals](https://github.com/directvt/vtm/discussions/72)
 
-# Binary Downloads
+# Binary downloads
 
 ![Linux](.resources/status/linux.svg)     [![Intel 64-bit](.resources/status/arch_x86_64.svg)](https://github.com/directvt/vtm/releases/latest/download/vtm_linux_x86_64.zip) [![Intel 32-bit](.resources/status/arch_x86.svg)](https://github.com/directvt/vtm/releases/latest/download/vtm_linux_x86.zip) [![ARM 64-bit](.resources/status/arch_arm64.svg)](https://github.com/directvt/vtm/releases/latest/download/vtm_linux_arm64.zip) [![ARM 32-bit](.resources/status/arch_arm32.svg)](https://github.com/directvt/vtm/releases/latest/download/vtm_linux_arm32.zip)  
 ![Windows](.resources/status/windows.svg) [![Intel 64-bit](.resources/status/arch_x86_64.svg)](https://github.com/directvt/vtm/releases/latest/download/vtm_windows_x86_64.zip)  [![Intel 32-bit](.resources/status/arch_x86.svg)](https://github.com/directvt/vtm/releases/latest/download/vtm_windows_x86.zip)  [![ARM 64-bit](.resources/status/arch_arm64.svg)](https://github.com/directvt/vtm/releases/latest/download/vtm_windows_arm64.zip)  [![ARM 32-bit](.resources/status/arch_arm32.svg)](https://github.com/directvt/vtm/releases/latest/download/vtm_windows_arm32.zip)  

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -673,7 +673,7 @@ namespace netxs::app::shared
                                 ->active()
                                 ->colors(whitedk, 0xFF0f0f0f)
                                 ->limits({ -1,-1 }, { -1,-1 });
-            static auto data = []
+            static const auto data = []
             {
                 auto [days, hours, mins, secs] = datetime::breakdown(datetime::now() - os::process::id.second);
                 auto uptime = (days  ? std::to_string(days)  + "d " : ""s)
@@ -712,7 +712,7 @@ namespace netxs::app::shared
                         os::process::elevated ? "Yes" : "No"),
                 };
             };
-            static auto update = [](auto& boss)
+            auto update = [](auto& boss)
             {
                 auto body = data();
                 auto iter = body.begin();
@@ -735,9 +735,9 @@ namespace netxs::app::shared
                     ->shader(cell::shaders::xlight, e2::form::state::hover);
                     //->shader(cell::shaders::color(c3), e2::form::state::keybd::focus::count);
             }
-            items->invoke([](auto& boss)
+            items->invoke([&](auto& boss)
             {
-                boss.LISTEN(tier::release, hids::events::mouse::button::down::any, gear)
+                boss.LISTEN(tier::release, hids::events::mouse::button::down::any, gear, -, (update)) //todo MS VS2019 can't capture static 'auto update =...'.
                 {
                     update(boss);
                 };
@@ -745,7 +745,7 @@ namespace netxs::app::shared
             window->invoke([&](auto& boss)
             {
                 auto& items_inst = *items;
-                boss.LISTEN(tier::release, hids::events::keybd::key::any, gear)
+                boss.LISTEN(tier::release, hids::events::keybd::key::any, gear, -, (update)) //todo MS VS2019 can't capture static 'auto update =...'.
                 {
                     if (!gear.keybd::pressed) return;
                     if (gear.chord(input::key::F10)

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -85,7 +85,7 @@ namespace netxs::app::shared
 {
     namespace
     {
-        auto build_Strobe        = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
+        auto build_Strobe        = [](eccc /*appcfg*/, xmls& /*config*/)
         {
             auto window = ui::cake::ctor();
             auto strob = window->plugin<pro::focus>(pro::focus::mode::focused)
@@ -111,7 +111,7 @@ namespace netxs::app::shared
             };
             return window;
         };
-        auto build_Settings      = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
+        auto build_Settings      = [](eccc /*appcfg*/, xmls& /*config*/)
         {
             auto window = ui::cake::ctor();
             window->plugin<pro::focus>(pro::focus::mode::focused)
@@ -134,7 +134,7 @@ namespace netxs::app::shared
                   });
             return window;
         };
-        auto build_Empty         = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
+        auto build_Empty         = [](eccc /*appcfg*/, xmls& /*config*/)
         {
             auto window = ui::cake::ctor();
             window->plugin<pro::focus>(pro::focus::mode::focused)
@@ -156,7 +156,7 @@ namespace netxs::app::shared
                                 ->active();
             return window;
         };
-        auto build_Truecolor     = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& config)
+        auto build_Truecolor     = [](eccc /*appcfg*/, xmls& config)
         {
             //todo put all ansi art into external files
             auto r_grut00 = ansi::wrp(wrap::off).rlf(feed::fwd).jet(bias::center).add(
@@ -300,7 +300,7 @@ namespace netxs::app::shared
 {
     namespace
     {
-        auto build_Region        = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
+        auto build_Region        = [](eccc /*appcfg*/, xmls& /*config*/)
         {
             auto window = ui::cake::ctor();
             window->invoke([&](auto& boss)
@@ -359,7 +359,7 @@ namespace netxs::app::shared
                     });
             return window;
         };
-        auto build_Headless      = [](text env, text cwd, text param, text /*patch*/, xmls& config)
+        auto build_Headless      = [](eccc appcfg, xmls& config)
         {
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;
@@ -383,8 +383,7 @@ namespace netxs::app::shared
                                 ->limits(dot_11, { 400,200 });
                     auto scroll = layers->attach(ui::rail::ctor())
                                         ->limits({ 10,1 }); // mc crashes when window is too small
-                    auto cmd = param.empty() ? os::env::shell() + " -i"
-                                             : param;
+                    if (appcfg.cmd.empty()) appcfg.cmd = os::env::shell() + " -i";
                     auto inst = scroll->attach(ui::term::ctor(config))
                                       ->plugin<pro::focus>(pro::focus::mode::focused)
                                       ->colors(whitelt, blackdk) //todo apply settings
@@ -442,11 +441,11 @@ namespace netxs::app::shared
                                             {
                                                 boss.set_align(align);
                                             };
-                                            boss.LISTEN(tier::release, e2::form::upon::started, root, -, (cmd, cwd, env))
+                                            boss.LISTEN(tier::release, e2::form::upon::started, root, -, (appcfg))
                                             {
                                                 if (root) // root is empty when d_n_d.
                                                 {
-                                                    boss.start(cmd, cwd, env);
+                                                    boss.start(appcfg.cmd, appcfg.cwd, appcfg.env);
                                                 }
                                             };
                                             boss.LISTEN(tier::anycast, e2::form::upon::started, root)
@@ -469,21 +468,21 @@ namespace netxs::app::shared
                 layers->attach(app::shared::scroll_bars(scroll));
             return window;
         };
-        auto build_DirectVT      = [](text env, text cwd, text cmd, text patch, xmls& /*config*/)
+        auto build_DirectVT      = [](eccc appcfg, xmls& /*config*/)
         {
             return ui::dtvt::ctor()
                 ->plugin<pro::focus>(pro::focus::mode::active)
                 ->limits(dot_11)
                 ->invoke([&](auto& boss)
                 {
-                    boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (cmd, cwd, env, patch))
+                    boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (appcfg))
                     {
                         if (root) // root is empty when d_n_d.
                         {
-                            boss.start(patch, [cmd, cwd, env](auto fds)
+                            boss.start(appcfg.cfg, [appcfg](auto fds)
                             {
-                                os::dtvt::connect(cmd, cwd, env, fds);
-                                return cmd;
+                                os::dtvt::connect(appcfg.cmd, appcfg.cwd, appcfg.env, fds);
+                                return appcfg.cmd;
                             });
                         }
                     };
@@ -501,7 +500,7 @@ namespace netxs::app::shared
                     };
                 });
         };
-        auto build_XLinkVT       = [](text env, text cwd, text cmd, text patch, xmls& config)
+        auto build_XLinkVT       = [](eccc appcfg, xmls& config)
         {
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;
@@ -567,14 +566,14 @@ namespace netxs::app::shared
                 {
                     auto& dtvt_inst = *dtvt;
                     auto& term_inst = *inst;
-                    boss.LISTEN(tier::release, e2::form::upon::started, root, -, (cmd, cwd, env, patch))
+                    boss.LISTEN(tier::release, e2::form::upon::started, root, -, (appcfg))
                     {
                         if (root) // root is empty when d_n_d.
                         {
-                            dtvt_inst.start(patch, [&, cmd, cwd, env](auto fds)
+                            dtvt_inst.start(appcfg.cfg, [&, appcfg](auto fds)
                             {
-                                term_inst.start(cmd, cwd, env, fds);
-                                return cmd;
+                                term_inst.start(appcfg.cmd, appcfg.cwd, appcfg.env, fds);
+                                return appcfg.cmd;
                             });
                         }
                     };
@@ -609,25 +608,20 @@ namespace netxs::app::shared
                 });
             return window;
         };
-        auto build_ANSIVT        = [](text env, text cwd, text param, text patch, xmls& config)
+        auto build_ANSIVT        = [](eccc appcfg, xmls& config)
         {
-            if (param.empty()) log(prompt::apps, "Nothing to run, use 'type=SHELL' to run instance without arguments");
-
-            auto args = os::process::binary();
-            if (args.find(' ') != text::npos) args = "\"" + args + "\"";
-            args += " -r term ";
-            args += param;
-            return build_DirectVT(env, cwd, args, patch, config);
+            if (appcfg.cmd.empty()) log(prompt::apps, "Nothing to run, use 'type=SHELL' to run instance without arguments");
+            auto args = os::process::binary() + " -r term " + appcfg.cmd;
+            appcfg.cmd = args;
+            return build_DirectVT(appcfg, config);
         };
-        auto build_SHELL         = [](text env, text cwd, text param, text patch, xmls& config)
+        auto build_SHELL         = [](eccc appcfg, xmls& config)
         {
-            auto args = os::process::binary();
-            if (args.find(' ') != text::npos) args = "\"" + args + "\"";
-            args += " -r term ";
-            args += os::env::shell(param);
-            return build_DirectVT(env, cwd, args, patch, config);
+            auto args = os::process::binary() + " -r term " + os::env::shell(appcfg.cmd);
+            appcfg.cmd = args;
+            return build_DirectVT(appcfg, config);
         };
-        auto build_Info          = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
+        auto build_Info          = [](eccc /*appcfg*/, xmls& /*config*/)
         {
             using namespace app::shared;
 

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -85,7 +85,7 @@ namespace netxs::app::shared
 {
     namespace
     {
-        auto build_Strobe        = [](text /*env*/, text /*cwd*/, text /*v*/, xmls& /*config*/, text /*patch*/)
+        auto build_Strobe        = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
         {
             auto window = ui::cake::ctor();
             auto strob = window->plugin<pro::focus>(pro::focus::mode::focused)
@@ -111,7 +111,7 @@ namespace netxs::app::shared
             };
             return window;
         };
-        auto build_Settings      = [](text /*env*/, text /*cwd*/, text /*v*/, xmls& /*config*/, text /*patch*/)
+        auto build_Settings      = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
         {
             auto window = ui::cake::ctor();
             window->plugin<pro::focus>(pro::focus::mode::focused)
@@ -134,7 +134,7 @@ namespace netxs::app::shared
                   });
             return window;
         };
-        auto build_Empty         = [](text /*env*/, text /*cwd*/, text /*v*/, xmls& /*config*/, text /*patch*/)
+        auto build_Empty         = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
         {
             auto window = ui::cake::ctor();
             window->plugin<pro::focus>(pro::focus::mode::focused)
@@ -156,7 +156,7 @@ namespace netxs::app::shared
                                 ->active();
             return window;
         };
-        auto build_Truecolor     = [](text /*env*/, text /*cwd*/, text /*v*/, xmls& config, text /*patch*/)
+        auto build_Truecolor     = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& config)
         {
             //todo put all ansi art into external files
             auto r_grut00 = ansi::wrp(wrap::off).rlf(feed::fwd).jet(bias::center).add(
@@ -300,7 +300,7 @@ namespace netxs::app::shared
 {
     namespace
     {
-        auto build_Region        = [](text /*env*/, text /*cwd*/, text /*v*/, xmls& /*config*/, text /*patch*/)
+        auto build_Region        = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
         {
             auto window = ui::cake::ctor();
             window->invoke([&](auto& boss)
@@ -359,7 +359,7 @@ namespace netxs::app::shared
                     });
             return window;
         };
-        auto build_Headless      = [](text env, text cwd, text param, xmls& config, text /*patch*/)
+        auto build_Headless      = [](text env, text cwd, text param, text /*patch*/, xmls& config)
         {
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;
@@ -469,7 +469,7 @@ namespace netxs::app::shared
                 layers->attach(app::shared::scroll_bars(scroll));
             return window;
         };
-        auto build_DirectVT      = [](text env, text cwd, text cmd,   xmls& /*config*/, text patch)
+        auto build_DirectVT      = [](text env, text cwd, text cmd, text patch, xmls& /*config*/)
         {
             return ui::dtvt::ctor()
                 ->plugin<pro::focus>(pro::focus::mode::active)
@@ -501,7 +501,7 @@ namespace netxs::app::shared
                     };
                 });
         };
-        auto build_XLinkVT       = [](text env, text cwd, text cmd,   xmls& config, text patch)
+        auto build_XLinkVT       = [](text env, text cwd, text cmd, text patch, xmls& config)
         {
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;
@@ -609,7 +609,7 @@ namespace netxs::app::shared
                 });
             return window;
         };
-        auto build_ANSIVT        = [](text env, text cwd, text param, xmls& config, text patch)
+        auto build_ANSIVT        = [](text env, text cwd, text param, text patch, xmls& config)
         {
             if (param.empty()) log(prompt::apps, "Nothing to run, use 'type=SHELL' to run instance without arguments");
 
@@ -617,17 +617,17 @@ namespace netxs::app::shared
             if (args.find(' ') != text::npos) args = "\"" + args + "\"";
             args += " -r term ";
             args += param;
-            return build_DirectVT(env, cwd, args, config, patch);
+            return build_DirectVT(env, cwd, args, patch, config);
         };
-        auto build_SHELL         = [](text env, text cwd, text param, xmls& config, text patch)
+        auto build_SHELL         = [](text env, text cwd, text param, text patch, xmls& config)
         {
             auto args = os::process::binary();
             if (args.find(' ') != text::npos) args = "\"" + args + "\"";
             args += " -r term ";
             args += os::env::shell(param);
-            return build_DirectVT(env, cwd, args, config, patch);
+            return build_DirectVT(env, cwd, args, patch, config);
         };
-        auto build_Info          = [](text /*env*/, text /*cwd*/, text /*v*/, xmls& /*config*/, text /*patch*/)
+        auto build_Info          = [](text /*env*/, text /*cwd*/, text /*v*/, text /*patch*/, xmls& /*config*/)
         {
             using namespace app::shared;
 

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -445,7 +445,7 @@ namespace netxs::app::shared
                                             {
                                                 if (root) // root is empty when d_n_d.
                                                 {
-                                                    boss.start(appcfg.cmd, appcfg.cwd, appcfg.env);
+                                                    boss.start(appcfg);
                                                 }
                                             };
                                             boss.LISTEN(tier::anycast, e2::form::upon::started, root)
@@ -481,7 +481,7 @@ namespace netxs::app::shared
                         {
                             boss.start(appcfg.cfg, [appcfg](auto fds)
                             {
-                                os::dtvt::connect(appcfg.cmd, appcfg.cwd, appcfg.env, fds);
+                                os::dtvt::connect(appcfg, fds);
                                 return appcfg.cmd;
                             });
                         }
@@ -572,7 +572,7 @@ namespace netxs::app::shared
                         {
                             dtvt_inst.start(appcfg.cfg, [&, appcfg](auto fds)
                             {
-                                term_inst.start(appcfg.cmd, appcfg.cwd, appcfg.env, fds);
+                                term_inst.start(appcfg, fds);
                                 return appcfg.cmd;
                             });
                         }

--- a/src/netxs/apps/calc.cpp
+++ b/src/netxs/apps/calc.cpp
@@ -10,6 +10,7 @@ int main(int argc, char* argv[])
     auto defaults = 
     #include "calc.xml"
 
+    os::dtvt::initialize();
     auto syslog = os::tty::logger();
     auto banner = []{ log(app::calc::desc, ' ', app::shared::version); };
     auto cfonly = faux;

--- a/src/netxs/apps/calc.hpp
+++ b/src/netxs/apps/calc.hpp
@@ -317,7 +317,7 @@ namespace netxs::app::calc
             }
             return std::tuple{ cellatix_rows, cellatix_cols, cellatix_text };
         };
-        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, text /*patch*/, xmls& config)
+        auto build = [](eccc /*appcfg*/, xmls& config)
         {
             auto highlight_color = skin::globals().highlight;
             auto label_color     = skin::globals().label;

--- a/src/netxs/apps/calc.hpp
+++ b/src/netxs/apps/calc.hpp
@@ -317,7 +317,7 @@ namespace netxs::app::calc
             }
             return std::tuple{ cellatix_rows, cellatix_cols, cellatix_text };
         };
-        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, xmls& config, text /*patch*/)
+        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, text /*patch*/, xmls& config)
         {
             auto highlight_color = skin::globals().highlight;
             auto label_color     = skin::globals().label;

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -26,11 +26,8 @@ namespace netxs::app::desk
         bool slimmenu{};
         bool splitter{};
         text   hotkey{};
-        text      env{}; // Environment var list delimited by \0.
-        text      cwd{};
+        eccc   appcfg{};
         text     type{};
-        text    param{};
-        text    patch{};
         bool   folded{};
         bool notfound{};
     };
@@ -466,7 +463,6 @@ namespace netxs::app::desk
                         m.type = appid;
                         m.label = label;
                         m.title = title;
-                        m.param = {};
                         m.hidden = true;
                         menu_list[menuid];
 
@@ -479,7 +475,7 @@ namespace netxs::app::desk
                 });
         };
 
-        auto build = [](text /*env*/, text /*cwd*/, text v, text /*patch*/, xmls& config)
+        auto build = [](eccc appcfg, xmls& config)
         {
             auto tall = si32{ skin::globals().menuwide };
             //auto highlight_color = skin::globals().highlight;
@@ -505,16 +501,19 @@ namespace netxs::app::desk
             auto panel = window->attach(slot::_1, ui::cake::ctor());
             if (panel_cmd.size())
             {
+                auto panel_cfg = eccc{ .env = panel_env,
+                                       .cwd = panel_cwd,
+                                       .cmd = panel_cmd };
                 panel_top = std::max(1, panel_top);
                 panel->limits({ -1, panel_top }, { -1, panel_top })
-                     ->attach(app::shared::builder(app::headless::id)(panel_env, panel_cwd, panel_cmd, ""s, config));
+                     ->attach(app::shared::builder(app::headless::id)(panel_cfg, config));
             }
             auto my_id = id_t{};
 
-            auto user_info = utf::divide(v, ";");
+            auto user_info = utf::divide(appcfg.cmd, ";");
             if (user_info.size() < 2)
             {
-                log(prompt::desk, "Bad window arguments: args=", utf::debase(v));
+                log(prompt::desk, "Bad window arguments: args=", utf::debase(appcfg.cmd));
                 return window;
             }
             auto& user_id__view = user_info[0];

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -30,6 +30,7 @@ namespace netxs::app::desk
         text     type{};
         bool   folded{};
         bool notfound{};
+        id_t   gearid{};
     };
 
     using menu = std::unordered_map<text, spec>;
@@ -40,10 +41,11 @@ namespace netxs::app::desk
     {
         EVENTPACK( events, ui::e2::extra::slot2 )
         {
-            EVENT_XS( usrs, netxs::sptr<desk::usrs> ), // list of connected users.
-            EVENT_XS( apps, netxs::sptr<desk::apps> ), // list of running apps.
-            EVENT_XS( menu, netxs::sptr<desk::menu> ), // list of registered apps.
-            EVENT_XS( quit, bool                    ), // request to close all instances.
+            EVENT_XS( usrs, netxs::sptr<desk::usrs> ), // List of connected users.
+            EVENT_XS( apps, netxs::sptr<desk::apps> ), // List of running apps.
+            EVENT_XS( menu, netxs::sptr<desk::menu> ), // List of registered apps.
+            EVENT_XS( exec, spec                    ), // Request to run app.
+            EVENT_XS( quit, bool                    ), // Request to close all instances.
             GROUP_XS( ui  , text                    ),
 
             SUBSET_XS( ui )
@@ -435,41 +437,11 @@ namespace netxs::app::desk
                 ->template plugin<pro::notes>(" Info ")
                 ->invoke([&](auto& boss)
                 {
-                    boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear, -, (appid, label, title))
+                    auto infospec = spec{ .hidden = true, .label = label, .title = title, .type = appid };
+                    boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear, -, (infospec))
                     {
-                        static auto offset = dot_00;
-                        auto& gate = gear.owner;
-                        gear.owner.SIGNAL(tier::request, e2::form::prop::viewport, viewport, ());
-                        offset = (offset + dot_21 * 2) % (viewport.size * 7 / 32);
-                        gear.slot.coor = viewport.coor + offset + viewport.size * 1 / 32;
-                        gear.slot.size = viewport.size * 3 / 4;
-                        gear.slot_forced = faux;
-
-                        gate.RISEUP(tier::request, desk::events::apps, menu_list_ptr, ());
-                        gate.RISEUP(tier::request, desk::events::menu, conf_list_ptr, ());
-                        auto& menu_list = *menu_list_ptr;
-                        auto& conf_list = *conf_list_ptr;
-
-                        auto menuid = label;
-                        if (conf_list.contains(menuid) && !conf_list[menuid].hidden) // Check for id availability.
-                        {
-                            auto i = 1;
-                            auto testid = text{};
-                            do testid = menuid + " (" + std::to_string(++i) + ")";
-                            while (conf_list.contains(testid) && !conf_list[menuid].hidden);
-                            std::swap(testid, menuid);
-                        }
-                        auto& m = conf_list[menuid];
-                        m.type = appid;
-                        m.label = label;
-                        m.title = title;
-                        m.hidden = true;
-                        menu_list[menuid];
-
-                        gate.SIGNAL(tier::request, e2::data::changed, lastid, ());
-                        gate.SIGNAL(tier::release, e2::data::changed, menuid);
-                        gate.RISEUP(tier::request, e2::form::proceed::createby, gear);
-                        gate.SIGNAL(tier::release, e2::data::changed, lastid);
+                        infospec.gearid = gear.id;
+                        gear.owner.RISEUP(tier::request, desk::events::exec, infospec);
                         gear.dismiss(true);
                     };
                 });

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -479,7 +479,7 @@ namespace netxs::app::desk
                 });
         };
 
-        auto build = [](text /*env*/, text /*cwd*/, text v, xmls& config, text /*patch*/)
+        auto build = [](text /*env*/, text /*cwd*/, text v, text /*patch*/, xmls& config)
         {
             auto tall = si32{ skin::globals().menuwide };
             //auto highlight_color = skin::globals().highlight;
@@ -507,7 +507,7 @@ namespace netxs::app::desk
             {
                 panel_top = std::max(1, panel_top);
                 panel->limits({ -1, panel_top }, { -1, panel_top })
-                     ->attach(app::shared::builder(app::headless::id)(panel_env, panel_cwd, panel_cmd, config, ""s));
+                     ->attach(app::shared::builder(app::headless::id)(panel_env, panel_cwd, panel_cmd, ""s, config));
             }
             auto my_id = id_t{};
 

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -185,7 +185,7 @@ namespace netxs::app::shop
             return std::tuple{ appstore_head, appstore_body, desktopio_body };
         };
 
-        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, xmls& config, text /*patch*/)
+        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, text /*patch*/, xmls& config)
         {
             auto highlight_color = skin::color(tone::highlight);
             auto c3 = highlight_color;

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -185,7 +185,7 @@ namespace netxs::app::shop
             return std::tuple{ appstore_head, appstore_body, desktopio_body };
         };
 
-        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, text /*patch*/, xmls& config)
+        auto build = [](eccc /*appcfg*/, xmls& config)
         {
             auto highlight_color = skin::color(tone::highlight);
             auto c3 = highlight_color;

--- a/src/netxs/apps/term.cpp
+++ b/src/netxs/apps/term.cpp
@@ -10,6 +10,7 @@ int main(int argc, char* argv[])
     auto defaults = 
     #include "term.xml"
 
+    os::dtvt::initialize();
     auto syslog = os::tty::logger();
     auto banner = []{ log(app::term::desc, ' ', app::shared::version); };
     auto cfonly = faux;

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -620,7 +620,7 @@ namespace netxs::app::term
 
     namespace
     {
-        auto build = [](text env, text cwd, text arg, text /*patch*/, xmls& config)
+        auto build = [](eccc appcfg, xmls& config)
         {
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;
@@ -681,8 +681,7 @@ namespace netxs::app::term
                     };
                 });
 
-            auto shell = os::env::shell() + " -i";
-            auto cmd = arg.empty() ? shell : arg;
+            if (appcfg.cmd.empty()) appcfg.cmd = os::env::shell() + " -i";
             auto inst = scroll->attach(ui::term::ctor(config))
                               ->plugin<pro::focus>(pro::focus::mode::focused);
             auto sb = layers->attach(ui::fork::ctor());
@@ -835,9 +834,9 @@ namespace netxs::app::term
                     {
                         boss.set_align(align);
                     };
-                    boss.LISTEN(tier::release, e2::form::upon::started, root, -, (cmd, cwd, env))
+                    boss.LISTEN(tier::release, e2::form::upon::started, root, -, (appcfg))
                     {
-                        boss.start(cmd, cwd, env);
+                        boss.start(appcfg.cmd, appcfg.cwd, appcfg.env);
                     };
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root)
                     {

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -620,7 +620,7 @@ namespace netxs::app::term
 
     namespace
     {
-        auto build = [](text env, text cwd, text arg, xmls& config, text /*patch*/)
+        auto build = [](text env, text cwd, text arg, text /*patch*/, xmls& config)
         {
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -836,7 +836,7 @@ namespace netxs::app::term
                     };
                     boss.LISTEN(tier::release, e2::form::upon::started, root, -, (appcfg))
                     {
-                        boss.start(appcfg.cmd, appcfg.cwd, appcfg.env);
+                        boss.start(appcfg);
                     };
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root)
                     {

--- a/src/netxs/apps/test.hpp
+++ b/src/netxs/apps/test.hpp
@@ -416,7 +416,7 @@ namespace netxs::app::test
 
             return topic;
         };
-        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, xmls& config, text /*patch*/)
+        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, text /*patch*/, xmls& config)
         {
             auto topic = get_text();
             auto window = ui::cake::ctor()

--- a/src/netxs/apps/test.hpp
+++ b/src/netxs/apps/test.hpp
@@ -416,7 +416,7 @@ namespace netxs::app::test
 
             return topic;
         };
-        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, text /*patch*/, xmls& config)
+        auto build = [](eccc /*appcfg*/, xmls& config)
         {
             auto topic = get_text();
             auto window = ui::cake::ctor()

--- a/src/netxs/apps/text.hpp
+++ b/src/netxs/apps/text.hpp
@@ -75,7 +75,7 @@ displaying the requested definition in a popup window or temporary buffer. Some 
 
 )";
 
-        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, text /*patch*/, xmls& config)
+        auto build = [](eccc /*appcfg*/, xmls& config)
         {
             auto highlight_color = skin::color(tone::highlight);
 

--- a/src/netxs/apps/text.hpp
+++ b/src/netxs/apps/text.hpp
@@ -75,7 +75,7 @@ displaying the requested definition in a popup window or temporary buffer. Some 
 
 )";
 
-        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, xmls& config, text /*patch*/)
+        auto build = [](text /*env*/, text /*cwd*/, text /*arg*/, text /*patch*/, xmls& config)
         {
             auto highlight_color = skin::color(tone::highlight);
 

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -788,9 +788,9 @@ namespace netxs::app::tile
             }
             return slot;
         };
-        auto build_inst = [](text /*env*/, text cwd, text arg, text /*patch*/, xmls& config) -> sptr
+        auto build_inst = [](eccc appcfg, xmls& config) -> sptr
         {
-            auto param = view{ arg };
+            auto param = view{ appcfg.cmd };
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;
             //auto highlight_color = skin::color(tone::highlight);
@@ -945,12 +945,12 @@ namespace netxs::app::tile
                     parent_canvas.fill([&](cell& c) { c.fgc(fgc).txt(bar).link(bar); });
                 };
             });
-            if (cwd.size())
+            if (appcfg.cwd.size())
             {
                 auto err = std::error_code{};
-                fs::current_path(cwd, err);
-                if (err) log("%%Failed to change current directory to '%cwd%', error code: %error%", prompt::tile, cwd, err.value());
-                else     log("%%Change current directory to '%cwd%'", prompt::tile, cwd);
+                fs::current_path(appcfg.cwd, err);
+                if (err) log("%%Failed to change current directory to '%cwd%', error code: %error%", prompt::tile, appcfg.cwd, err.value());
+                else     log("%%Change current directory to '%cwd%'", prompt::tile, appcfg.cwd);
             }
 
             object->attach(slot::_2, parse_data(parse_data, param, ui::fork::min_ratio))

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -788,8 +788,9 @@ namespace netxs::app::tile
             }
             return slot;
         };
-        auto build_inst = [](text /*env*/, text cwd, view param, xmls& config, text /*patch*/) -> sptr
+        auto build_inst = [](text /*env*/, text cwd, text arg, text /*patch*/, xmls& config) -> sptr
         {
+            auto param = view{ arg };
             auto menu_white = skin::color(tone::menu_white);
             auto cB = menu_white;
             //auto highlight_color = skin::color(tone::highlight);

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -19,6 +19,18 @@ namespace netxs::app
     namespace fs = std::filesystem;
     using namespace std::placeholders;
     using namespace netxs::ui;
+    
+    namespace arg
+    {
+        enum arg_list
+        {
+            env,
+            cwd,
+            cmd,
+            cfg,
+            count,
+        };
+    }
 }
 
 namespace netxs::app::shared
@@ -110,7 +122,7 @@ namespace netxs::app::shared
         gear.dismiss(true);
     };
 
-    using builder_t = std::function<ui::sptr(text, text, text, xmls&, text)>;
+    using builder_t = std::function<ui::sptr(text, text, text, text, xmls&)>;
 
     namespace winform
     {
@@ -414,7 +426,7 @@ namespace netxs::app::shared
     auto& builder(text app_typename)
     {
         static builder_t empty =
-        [&](text, text, text, xmls&, text) -> ui::sptr
+        [&](text, text, text, text, xmls&) -> ui::sptr
         {
             auto window = ui::cake::ctor()
                 ->plugin<pro::focus>()
@@ -546,7 +558,7 @@ namespace netxs::app::shared
         auto domain = ui::host::ctor(server, config)
             ->plugin<scripting::host>();
         auto direct = os::dtvt::active;
-        auto applet = app::shared::builder(aclass)("", "", params, config, /*patch*/(direct ? ""s : "<config simple=1/>"s));
+        auto applet = app::shared::builder(aclass)("", "", params, /*patch*/(direct ? ""s : "<config simple=1/>"s), config);
         domain->invite(server, applet, vtmode, winsz);
         domain->stop();
         server->shut();

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -19,18 +19,6 @@ namespace netxs::app
     namespace fs = std::filesystem;
     using namespace std::placeholders;
     using namespace netxs::ui;
-    
-    namespace arg
-    {
-        enum arg_list
-        {
-            env,
-            cwd,
-            cmd,
-            cfg,
-            count,
-        };
-    }
 }
 
 namespace netxs::app::shared
@@ -122,7 +110,7 @@ namespace netxs::app::shared
         gear.dismiss(true);
     };
 
-    using builder_t = std::function<ui::sptr(text, text, text, text, xmls&)>;
+    using builder_t = std::function<ui::sptr(eccc, xmls&)>;
 
     namespace winform
     {
@@ -426,7 +414,7 @@ namespace netxs::app::shared
     auto& builder(text app_typename)
     {
         static builder_t empty =
-        [&](text, text, text, text, xmls&) -> ui::sptr
+        [&](eccc, xmls&) -> ui::sptr
         {
             auto window = ui::cake::ctor()
                 ->plugin<pro::focus>()
@@ -558,7 +546,9 @@ namespace netxs::app::shared
         auto domain = ui::host::ctor(server, config)
             ->plugin<scripting::host>();
         auto direct = os::dtvt::active;
-        auto applet = app::shared::builder(aclass)("", "", params, /*patch*/(direct ? ""s : "<config simple=1/>"s), config);
+        auto appcfg = eccc{ .cmd = params,
+                            .cfg = direct ? ""s : "<config simple=1/>"s };
+        auto applet = app::shared::builder(aclass)(appcfg, config);
         domain->invite(server, applet, vtmode, winsz);
         domain->stop();
         server->shut();

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -534,7 +534,7 @@ namespace netxs::app::shared
         }
     };
 
-    void start(text params, text aclass, si32 vtmode, twod winsz, xmls& config)
+    void start(text cmd, text aclass, si32 vtmode, twod winsz, xmls& config)
     {
         auto [client, server] = os::ipc::xlink();
         auto thread = std::thread{[&, &client = client] //todo clang 15.0.0 still disallows capturing structured bindings (wait for clang 16.0.0)
@@ -546,7 +546,7 @@ namespace netxs::app::shared
         auto domain = ui::host::ctor(server, config)
             ->plugin<scripting::host>();
         auto direct = os::dtvt::active;
-        auto appcfg = eccc{ .cmd = params,
+        auto appcfg = eccc{ .cmd = cmd,
                             .cfg = direct ? ""s : "<config simple=1/>"s };
         auto applet = app::shared::builder(aclass)(appcfg, config);
         domain->invite(server, applet, vtmode, winsz);

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -548,8 +548,7 @@ namespace netxs::app::shared
         auto domain = ui::host::ctor(server, config)
             ->plugin<scripting::host>();
         auto direct = os::dtvt::active;
-        os::dtvt::isolated = !direct;
-        auto applet = app::shared::builder(aclass)("", "", params, config, /*patch*/(direct ? ""s : "<config isolated=1/>"s));
+        auto applet = app::shared::builder(aclass)("", "", params, config, /*patch*/(direct ? ""s : "<config simple=1/>"s));
         domain->invite(server, applet, vtmode, winsz);
         domain->stop();
         server->shut();

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.55";
+    static const auto version = "v0.9.56";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -25,8 +25,6 @@ namespace netxs::app::shared
 {
     static const auto version = "v0.9.55";
     static const auto repository = "https://github.com/directvt/vtm";
-    static const auto ipc_prefix = "vtm";
-    static const auto log_suffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;
 

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -165,7 +165,6 @@ namespace netxs::events::userland
                 EVENT_XS( quit    , const si32      ), // release: quit, arg: si32 - quit reason.
                 EVENT_XS( pointer , const bool      ), // release: mouse pointer visibility.
                 EVENT_XS( logs    , const text      ), // logs output.
-                EVENT_XS( readline, text            ), // Standard input (scripting).
                 //EVENT_XS( menu  , si32 ),
             };
             SUBSET_XS( data )

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -13,6 +13,7 @@ namespace netxs::ui
         static constexpr auto mouse   = 1 << 0;
         static constexpr auto nt      = 1 << 5; // Use win32 console api for input.
         static constexpr auto onlylog = 1 << 6;
+        static constexpr auto redirio = 1 << 7;
         //todo make 3-bit field for color mode
         static constexpr auto vtrgb   = 0;
         static constexpr auto nt16    = 1 << 1;
@@ -1030,8 +1031,8 @@ namespace netxs::ui
               local{ true },
               yield{ faux }
         {
-            auto isolated = config.take("/config/isolated", faux); // DTVT proxy console case.
-            config.set("/config/isolated", faux);
+            auto simple = config.take("/config/simple", faux); // DTVT proxy console case.
+            config.set("/config/simple", faux);
 
             base::root(true);
             base::limits(dot_11);
@@ -1327,7 +1328,7 @@ namespace netxs::ui
                     check_tooltips(now);
                 };
             }
-            if (direct && !isolated) // Forward unhandled events outside.
+            if (direct && !simple) // Forward unhandled events outside.
             {
                 LISTEN(tier::release, e2::form::size::minimize, gear, tokens)
                 {

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -11,7 +11,7 @@ namespace netxs::ui
     {
         static auto id = std::pair<ui32, time>{};
         static constexpr auto mouse   = 1 << 0;
-        static constexpr auto nt      = 1 << 5;
+        static constexpr auto nt      = 1 << 5; // Use win32 console api for input.
         static constexpr auto onlylog = 1 << 6;
         //todo make 3-bit field for color mode
         static constexpr auto vtrgb   = 0;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -46,7 +46,7 @@ struct consrv
         return inst;
     }
     template<class Term, class Proc>
-    auto attach(Term& terminal, eccc cfg, twod win, Proc trailer, fdrw fdlink)
+    auto attach(Term& terminal, eccc cfg, Proc trailer, fdrw fdlink)
     {
         auto err_code = 0;
         auto startinf = STARTUPINFOEXW{ sizeof(STARTUPINFOEXW) };
@@ -83,8 +83,8 @@ struct consrv
         startinf.StartupInfo.dwY = 0;
         startinf.StartupInfo.dwXCountChars = 0;
         startinf.StartupInfo.dwYCountChars = 0;
-        startinf.StartupInfo.dwXSize = win.x;
-        startinf.StartupInfo.dwYSize = win.y;
+        startinf.StartupInfo.dwXSize = cfg.win.x;
+        startinf.StartupInfo.dwYSize = cfg.win.y;
         startinf.StartupInfo.dwFillAttribute = 1;
         startinf.StartupInfo.dwFlags = STARTF_USESTDHANDLES
                                      | STARTF_USESIZE
@@ -5209,7 +5209,7 @@ struct consrv : ipc::stdcon
         return ptr::shared<consrv>(terminal);
     }
     template<class Term, class Proc>
-    auto attach(Term& terminal, eccc cfg, twod win, Proc trailer, fdrw fdlink)
+    auto attach(Term& terminal, eccc cfg, Proc trailer, fdrw fdlink)
     {
         auto fdm = os::syscall{ ::posix_openpt(O_RDWR | O_NOCTTY) }; // Get master TTY.
         auto rc1 = os::syscall{ ::grantpt(fdm.value)              }; // Grant master TTY file access.
@@ -5226,7 +5226,7 @@ struct consrv : ipc::stdcon
             auto rc3 = os::syscall{ ::setsid() }; // Open new session and new process group in it.
             auto fds = os::syscall{ ::open(::ptsname(fdm.value), O_RDWR | O_NOCTTY) }; // Open slave TTY via string ptsname(fdm) (BSD doesn't auto assign controlling terminal: we should assign it explicitly).
             auto rc4 = os::syscall{ ::ioctl(fds.value, TIOCSCTTY, 0) }; // Assign it as a controlling TTY (in order to receive WINCH and other signals).
-            winsz(win); // TTY resize can be done only after assigning a controlling TTY (BSD-requirement).
+            winsz(cfg.win); // TTY resize can be done only after assigning a controlling TTY (BSD-requirement).
             os::dtvt::active = faux; // Logger update.
             os::dtvt::client = {};   //
             if (fdlink)

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -5084,7 +5084,7 @@ struct impl : consrv
           outmod{                                                },
           altmod{ faux                                           },
           prompt{ utf::concat(win32prompt)                       },
-          inpenc{ std::make_shared<decoder>(*this, os::codepage) },
+          inpenc{ std::make_shared<decoder>(*this, ::GetOEMCP()) },
           outenc{ inpenc                                         },
           unsync{ faux                                           }
     {

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -513,8 +513,8 @@ namespace netxs::directvt
         class wrapper
         {
             friend struct access;
-            using utex = std::mutex;
-            using cond = std::condition_variable;
+            using utex = std::recursive_mutex;
+            using cond = std::condition_variable_any;
             using Lock = std::unique_lock<utex>;
 
             utex mutex; // wrapper: Accesss mutex.

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -378,6 +378,12 @@ namespace netxs::directvt
                 }
             }
             // stream: .
+            template<class T, class P>
+            static void reading_loop(netxs::sptr<T> link_ptr, P&& proc)
+            {
+                reading_loop(*link_ptr, proc);
+            }
+            // stream: .
             auto length() const
             {
                 return static_cast<sz_t>(block.length());

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -799,7 +799,7 @@ namespace netxs::directvt
         STRUCT_macro(header_request,    (id_t, window_id))
         STRUCT_macro(footer_request,    (id_t, window_id))
         STRUCT_macro(warping,           (id_t, window_id) (dent, warpdata))
-        STRUCT_macro(vt_command,        (text, command))
+        STRUCT_macro(command,           (text, utf8))
         STRUCT_macro(logs,              (ui32, id) (time, guid) (text, data))
         STRUCT_macro(fatal,             (text, err_msg))
         STRUCT_macro(minimize,          (id_t, gear_id))
@@ -1326,7 +1326,7 @@ namespace netxs::directvt
             X(warping          ) /* Warp resize.                                  */\
             X(minimize         ) /* Minimize window.                              */\
             X(expose           ) /* Bring window to the front.                    */\
-            X(vt_command       ) /* Parse following vt-sequences in UTF-8 format. */\
+            X(command          ) /* Interactive command/result in UTF-8 format.   */\
             X(frames           ) /* Received frames.                              */\
             X(tooltip_element  ) /* Tooltip text.                                 */\
             X(jgc_element      ) /* jumbo GC: gc.token + gc.view.                 */\

--- a/src/netxs/desktopio/events.hpp
+++ b/src/netxs/desktopio/events.hpp
@@ -451,12 +451,13 @@ namespace netxs::events
             static constexpr auto root_event = type_clue<root, si32, 0>{};
             EVENTPACK( root, root_event )
             {
-                EVENT_XS( dtor   , const id_t ),
-                EVENT_XS( cascade, ftor ),
-                EVENT_XS( base   , root ),
-                EVENT_XS( hids   , root ),
-                EVENT_XS( custom , root ),
-                EVENT_XS( cleanup, ref_count_t ), // Garbage collection.
+                EVENT_XS( dtor     , const id_t ),
+                EVENT_XS( cascade  , ftor ),
+                EVENT_XS( base     , root ),
+                EVENT_XS( hids     , root ),
+                EVENT_XS( scripting, root ),
+                EVENT_XS( custom   , root ),
+                EVENT_XS( cleanup  , ref_count_t ), // Garbage collection.
             };
         };
     }

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -12,7 +12,7 @@ namespace netxs::scripting
     {
         EVENTPACK( events, netxs::events::userland::root::scripting )
         {
-            EVENT_XS( readline, eccc ), // Standard input (scripting).
+            EVENT_XS( invoke, eccc ), // Invoke script.
         };
     };
 
@@ -197,11 +197,11 @@ namespace netxs::scripting
                 if (run.size()) write(run);
                 config.popd();
             }
-            owner.LISTEN(tier::release, scripting::events::readline, request, skill::memo)
+            owner.LISTEN(tier::release, scripting::events::invoke, script, skill::memo)
             {
                 if (engine)
                 {
-                    write(request.cmd);
+                    write(script.cmd);
                     owner.bell::template expire<tier::release>();
                 }
             };

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -191,8 +191,11 @@ namespace netxs::scripting
             }
             owner.LISTEN(tier::release, e2::conio::readline, utf8, skill::memo)
             {
-                if (engine) write(utf8);
-                else        log(prompt::repl, utf::debase<faux, faux>(utf8));
+                if (engine)
+                {
+                    write(utf8);
+                    owner.bell::template expire<tier::release>();
+                }
             };
         }
     };

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -138,14 +138,14 @@ namespace netxs::scripting
             engine->write(data + '\n');
         }
         // scripting::host: Start a new process.
-        void runapp(eccc cfg, twod win)
+        void runapp(eccc cfg)
         {
             if (!engine) return;
             appcfg = cfg;
             if (!engine->connected())
             {
-                engine->runapp(appcfg, win, [&](auto utf8_shadow) { ondata(utf8_shadow); },
-                                            [&](auto code, auto msg) { onexit(code, msg); });
+                engine->runapp(appcfg, [&](auto utf8_shadow) { ondata(utf8_shadow); },
+                                       [&](auto code, auto msg) { onexit(code, msg); });
             }
         }
         void shut()
@@ -174,7 +174,8 @@ namespace netxs::scripting
                 auto win = os::ttysize;
                 auto cfg = eccc{ .env = env,
                                  .cwd = cwd,
-                                 .cmd = cmd };
+                                 .cmd = cmd,
+                                 .win = win };
                 if (tty)
                 {
                     engine = ptr::shared<os::runspace::tty<scripting::host>>(*this);
@@ -183,7 +184,7 @@ namespace netxs::scripting
                 {
                     engine = ptr::shared<os::runspace::raw<scripting::host>>(*this);
                 }
-                runapp(cfg, win);
+                runapp(cfg);
                 //todo run integration script
                 if (run.size()) write(run);
                 config.popd();

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -8,6 +8,14 @@ namespace netxs::scripting
 {
     using namespace ui;
 
+    struct events
+    {
+        EVENTPACK( events, netxs::events::userland::root::scripting )
+        {
+            EVENT_XS( readline, eccc ), // Standard input (scripting).
+        };
+    };
+
     namespace path
     {
         static constexpr auto scripting = "/config/scripting/";
@@ -189,11 +197,11 @@ namespace netxs::scripting
                 if (run.size()) write(run);
                 config.popd();
             }
-            owner.LISTEN(tier::release, e2::conio::readline, utf8, skill::memo)
+            owner.LISTEN(tier::release, scripting::events::readline, request, skill::memo)
             {
                 if (engine)
                 {
-                    write(utf8);
+                    write(request.cmd);
                     owner.bell::template expire<tier::release>();
                 }
             };

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1505,7 +1505,7 @@ namespace netxs::os
     namespace service
     {
         static auto name = "vtm"sv;
-        static auto desc = "Text mode desktop."sv;
+        static auto desc = "Text-based desktop environment."sv;
     }
 
     namespace io

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1769,7 +1769,7 @@ namespace netxs::os
         // os::env: Get list of envvars using wildcard.
         auto list(text&& var)
         {
-            auto crop = std::vector<text>{};
+            auto crop = txts{};
             auto list = environ;
             while (*list)
             {

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4478,10 +4478,10 @@ namespace netxs::os
 
             struct logger : s11n
             {
-                using func = std::function<void(text&)>;
+                using func = std::function<void(logger&, text&)>;
                 func proc;
 
-                void handle(s11n::xs::command lock) { proc(lock.thing.utf8); }
+                void handle(s11n::xs::command lock) { proc(*this, lock.thing.utf8); }
                 void handle(s11n::xs::logs    lock) { log<faux>(lock.thing.data); }
 
                 logger(func proc)

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1842,6 +1842,13 @@ namespace netxs::os
 
             #endif
         }
+        // os::env: Get current working directory.
+        auto cwd()
+        {
+            auto err = std::error_code{};
+            auto cwd = std::filesystem::current_path(err).string();
+            return cwd;
+        }
     }
 
     namespace path

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3334,9 +3334,15 @@ namespace netxs::os
 
     namespace dtvt
     {
-        static auto isolated = faux; // Standalone app in legacy console.
-        static auto vtmode = ui::console::vtrgb; // tty: VT-mode bit set.
-        static auto scroll = faux; // Viewport/scrollback selector for windows console.
+        static auto vtmode = ui::console::vtrgb; // dtvt: VT-mode bit set.
+        static auto scroll = faux;   // dtvt: Viewport/scrollback selector for windows console.
+        static auto active = faux;   // dtvt: DirectVT mode is active.
+        static auto config = text{}; // dtvt: DirectVT configuration XML data.
+        static auto header = text{}; // dtvt: Extra read block from stdin.
+        static auto backup = tios{}; // dtvt: Saved console state to restore at exit.
+        static auto win_sz = twod{}; // dtvt: Initial window size.
+        static auto client = xipc{}; // dtvt: Internal IO link.
+
         auto consize()
         {
             static constexpr auto winsz_fallback = twod{ 132, 60 };
@@ -3366,13 +3372,6 @@ namespace netxs::os
             }
             return winsz;
         }
-        static auto config = text{}; // dtvt: DirectVT configuration XML data.
-        static auto backup = tios{}; // dtvt: Saved console state to restore at exit.
-        static auto header = text{}; // dtvt: Extra read block from stdin.
-        static auto win_sz = twod{}; // dtvt: Initial window size.
-        static auto client = xipc{}; // dtvt: Internal IO link.
-        static auto active = faux;   // dtvt: DirectVT mode is active.
-
         auto initialize()
         {
             #if defined(_WIN32)
@@ -4441,7 +4440,7 @@ namespace netxs::os
                 { }
             };
 
-            struct logger : public s11n
+            struct logger : s11n
             {
                 using func = std::function<void(text&)>;
                 func proc;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -73,6 +73,16 @@
 
 #endif
 
+namespace netxs
+{
+    struct eccc
+    {
+        text env; // eccc: Environment var list delimited by \0.
+        text cwd; // eccc: Current working directory.
+        text cmd; // eccc: Command line to run.
+        text cfg; // eccc: Configuration patch.
+    };
+}
 namespace netxs::os
 {
     namespace fs = std::filesystem;
@@ -1769,7 +1779,7 @@ namespace netxs::os
         // os::env: Get list of envvars using wildcard.
         auto list(text&& var)
         {
-            auto crop = txts{};
+            auto crop = std::vector<text>{};
             auto list = environ;
             while (*list)
             {

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4483,10 +4483,10 @@ namespace netxs::os
                 if (utf8.empty()) return;
                 if (dtvt::active || dtvt::client)
                 {
-                    auto lock = tty::stream.logs.freeze();
-                    lock.thing.set(os::process::id.first, os::process::id.second, utf8);
-                    dtvt::active ? lock.thing.sendfx(dtvt_output)   // Send logs to the dtvt-app hoster.
-                                 : lock.thing.sendby(dtvt::client); // Send logs to the dtvt-app.
+                    static auto logs = netxs::directvt::binary::logs_t{};
+                    logs.set(os::process::id.first, os::process::id.second, utf8);
+                    dtvt::active ? logs.sendfx(dtvt_output)   // Send logs to the dtvt-app hoster.
+                                 : logs.sendby(dtvt::client); // Send logs to the dtvt-app.
                 }
                 else if (os::is_daemon())
                 {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -6542,15 +6542,15 @@ namespace netxs::ui
         {
             update([&]
             {
-                auto console_ptr = target_buffer ? target_buffer : this->target;
                 if (data.size())
                 {
                     if (io_log) log(prompt::cout, "\n\t", utf::change(ansi::hi(utf::debase(data)), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));
-                    ansi::parse(data, console_ptr);
+                    ansi::parse(data, target_buffer ? target_buffer : this->target);
                     return true;
                 }
                 else
                 {
+                    auto console_ptr = target_buffer ? target_buffer : this->target;
                     console_ptr->parser::flush(); // Update line style, etc.
                     return Forced;
                 }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -426,7 +426,7 @@ namespace netxs::ui
             // w_tracking: Set terminal window property.
             void set(text const& property, qiew txt)
             {
-                if (txt.empty()) txt = owner.cmdarg; // Deny empty titles.
+                if (txt.empty()) txt = owner.appcfg.cmd; // Deny empty titles.
                 owner.target->flush();
                 if (property == ansi::osc_label_title)
                 {
@@ -6216,9 +6216,7 @@ namespace netxs::ui
         si32       altscr; // term: Alternate scroll mode.
         prot       kbmode; // term: Keyboard input mode.
         escx       w32key; // term: win32-input-mode forward buffer.
-        text       envvar; // term: Environment block.
-        text       curdir; // term: Current working directory.
-        text       cmdarg; // term: Startup command line arguments.
+        eccc       appcfg; // term: Application startup config.
         os::fdrw   fdlink; // term: Optional DirectVT uplink.
         hook       onerun; // term: One-shot token for restart session.
         vtty       ipccon; // term: IPC connector. Should be destroyed first.
@@ -7120,15 +7118,13 @@ namespace netxs::ui
         {
             RISEUP(tier::release, e2::form::upon::started, This());
         }
-        void start(text cmd, text cwd, text env, os::fdrw fds = {})
+        void start(eccc cfg, os::fdrw fds = {})
         {
-            cmdarg = cmd;
-            curdir = cwd;
-            envvar = env;
+            appcfg = cfg;
             fdlink = fds;
             if (!ipccon)
             {
-                ipccon.runapp(*this, cmdarg, curdir, envvar, target->panel, fdlink);
+                ipccon.runapp(*this, appcfg, target->panel, fdlink);
             }
         }
         void restart()

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7594,11 +7594,6 @@ namespace netxs::ui
                     master.RISEUP(tier::preview, e2::form::layout::swarp, warp);
                 });
             }
-            void handle(s11n::xs::vt_command        /*lock*/)
-            {
-                //auto& w = lock.thing;
-                //todo implement
-            }
             void handle(s11n::xs::fps                 lock)
             {
                 netxs::events::enqueue(master.This(), [&, fps = lock.thing.frame_rate](auto& /*boss*/) mutable

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -405,10 +405,10 @@ namespace netxs::ui
         // term: Terminal title tracking functionality.
         struct w_tracking
         {
-            term&                owner; // w_tracking: Terminal object reference.
-            std::map<text, text> props;
-            std::map<text, txts> stack;
-            escx                 queue;
+            term&                             owner; // w_tracking: Terminal object reference.
+            std::map<text, text>              props;
+            std::map<text, std::vector<text>> stack;
+            escx                              queue;
 
             w_tracking(term& owner)
                 : owner{ owner }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -405,10 +405,10 @@ namespace netxs::ui
         // term: Terminal title tracking functionality.
         struct w_tracking
         {
-            term&                             owner; // w_tracking: Terminal object reference.
-            std::map<text, text>              props;
-            std::map<text, std::vector<text>> stack;
-            escx                              queue;
+            term&                owner; // w_tracking: Terminal object reference.
+            std::map<text, text> props;
+            std::map<text, txts> stack;
+            escx                 queue;
 
             w_tracking(term& owner)
                 : owner{ owner }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7124,7 +7124,8 @@ namespace netxs::ui
             fdlink = fds;
             if (!ipccon)
             {
-                ipccon.runapp(*this, appcfg, target->panel, fdlink);
+                appcfg.win = target->panel;
+                ipccon.runapp(*this, appcfg, fdlink);
             }
         }
         void restart()

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -6542,15 +6542,15 @@ namespace netxs::ui
         {
             update([&]
             {
+                auto& console_ptr = target_buffer ? target_buffer : this->target;
                 if (data.size())
                 {
                     if (io_log) log(prompt::cout, "\n\t", utf::change(ansi::hi(utf::debase(data)), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));
-                    ansi::parse(data, target_buffer ? target_buffer : this->target);
+                    ansi::parse(data, console_ptr);
                     return true;
                 }
                 else
                 {
-                    auto console_ptr = target_buffer ? target_buffer : this->target;
                     console_ptr->parser::flush(); // Update line style, etc.
                     return Forced;
                 }

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -21,7 +21,6 @@ namespace netxs
 {
     using view = std::string_view;
     using text = std::string;
-    using txts = std::vector<text>;
     using wide = std::wstring;
     using wiew = std::wstring_view;
     using wchr = wchar_t;

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1512,17 +1512,26 @@ namespace netxs::utf
         utf8.remove_prefix(str.size());
         return str;
     }
-    auto get_word(view& utf8, char delim = ' ')
+    auto get_word(view& utf8, view delims = " ")
     {
-        return get_tail<faux>(utf8, view{ &delim, 1 });
+        return get_tail<faux>(utf8, delims);
     }
-    auto get_token(view& utf8)
+    auto get_token(view& utf8) // Preserve quotes.
     {
         if (utf8.empty()) return utf8;
         auto c = utf8.front();
         auto item = (c == '\'' || c == '"') ? utf::get_quote(utf8)
                                             : utf::get_word(utf8);
         utf::trim_front(utf8);
+        return item;
+    }
+    auto get_token(view& utf8, view delims) // Drop quotes.
+    {
+        if (utf8.empty()) return utf8;
+        auto c = utf8.front();
+        auto item = (c == '\'' || c == '"') ? utf::get_quote(utf8, view{ &c, 1 })
+                                            : utf::get_word(utf8, delims);
+        utf::trim_front(utf8, delims);
         return item;
     }
     auto eat_tail(view& utf8, view delims)

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -21,6 +21,7 @@ namespace netxs
 {
     using view = std::string_view;
     using text = std::string;
+    using txts = std::vector<text>;
     using wide = std::wstring;
     using wiew = std::wstring_view;
     using wchr = wchar_t;

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -123,7 +123,6 @@ int main(int argc, char* argv[])
     os::dtvt::checkpoint();
 
     auto denied = faux;
-    //auto direct = os::dtvt::active;
     auto syslog = os::tty::logger();
     auto userid = os::env::user();
     auto prefix = vtpipe.length() ? vtpipe : utf::concat(app::shared::ipc_prefix, os::process::elevated ? "!-" : "-", userid.second);;

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -143,7 +143,7 @@ int main(int argc, char* argv[])
     if (errmsg.size())
     {
         failed(code::errormsg);
-        log("\nText Mode Desktop " + text{ app::shared::version } +
+        log("\nText-based desktop environment " + text{ app::shared::version } +
             "\n"
             "\n  Syntax:"
             "\n"
@@ -177,10 +177,14 @@ int main(int argc, char* argv[])
             "\n"
             "\n  Built-in applications:"
             "\n"
-            "\n    Term      Terminal emulator (default)"
-            "\n    Headless  Terminal emulator without UI"
-            "\n    DTVT      DirectVT Proxy Console"
-            "\n    XLVT      DTVT with controlling terminal (for OpenSSH interactivity)"
+            "\n    Term      Terminal emulator to run cli applications.       'vtm -r term [cli_application]'"
+            "\n    Headless  Terminal emulator without UI.                    'vtm -r headless [cli_application]'"
+            "\n    DTVT      DirectVT proxy to run dtvt-apps in text console. 'vtm -r dtvt [dtvt_application]'"
+            "\n    XLVT      DTVT with controlling terminal.                  'vtm -r xlvt ssh [user@host dtvt_application]'"
+            "\n"
+            "\n  The following commands have a short form:"
+            "\n    'vtm -r xlvt ssh [user@host dtvt_application]' can be shortened to 'vtm ssh [user@host dtvt_application]'."
+            "\n    'vtm -r term [cli_application]' can be shortened to 'vtm -r [cli_application]'."
             "\n"
             );
     }

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -234,7 +234,7 @@ int main(int argc, char* argv[])
                     auto sync = std::lock_guard{ locker };
                     std::swap(stream, iolink);
                     events.command.send(stream, utf::concat(os::process::id.first)); // First command is the monitor id.
-                    events.command.send(stream, os::env::add("VTM=1\0"));
+                    events.command.send(stream, os::env::add());
                     events.command.send(stream, os::env::cwd());
                     for (auto& line : buffer)
                     {

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -377,19 +377,22 @@ int main(int argc, char* argv[])
                 {
                     auto id = text{};
                     auto active = faux;
-                    auto envars = text{};
-                    auto curdir = text{};
                     auto tokens = subs{};
+                    auto request = eccc{};
                     auto events = os::tty::binary::logger{ [&, init = 0](auto& cmd) mutable
                     {
-                        if (active) domain->SIGNAL(tier::release, e2::conio::readline, cmd);
+                        if (active)
+                        {
+                            request.cmd = cmd;
+                            domain->SIGNAL(tier::release, scripting::events::readline, request);
+                        }
                         else
                         {
                                  if (init == 0) id = cmd;
-                            else if (init == 1) envars = cmd;
+                            else if (init == 1) request.env = cmd;
                             else if (init == 2)
                             {
-                                curdir = cmd;
+                                request.cwd = cmd;
                                 active = true;
                                 log("%%Monitor [%id%] connected", prompt::logs, id);
                             }
@@ -410,7 +413,7 @@ int main(int argc, char* argv[])
         }};
 
         auto settings = config.utf8();
-        auto readline = os::tty::readline([&](auto line){ domain->SIGNAL(tier::release, e2::conio::readline, line); },
+        auto readline = os::tty::readline([&](auto line){ domain->SIGNAL(tier::release, scripting::events::readline, request, ({ .cmd = line })); },
                                           [&]{ domain->SIGNAL(tier::general, e2::shutdown, msg, (utf::concat(prompt::main, "Shutdown on signal"))); });
         while (auto user = server->meet())
         {

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -70,6 +70,7 @@ int main(int argc, char* argv[])
         }
         else if (getopt.match("-u", "--uninstall"))
         {
+            os::dtvt::initialize();
             netxs::logger::wipe();
             auto syslog = os::tty::logger();
             auto ok = os::process::uninstall();
@@ -78,6 +79,7 @@ int main(int argc, char* argv[])
         }
         else if (getopt.match("-i", "--install"))
         {
+            os::dtvt::initialize();
             netxs::logger::wipe();
             auto syslog = os::tty::logger();
             auto ok = os::process::install();
@@ -100,6 +102,7 @@ int main(int argc, char* argv[])
         }
         else if (getopt.match("-v", "--version"))
         {
+            os::dtvt::initialize();
             netxs::logger::wipe();
             auto syslog = os::tty::logger();
             log(app::shared::version);
@@ -120,6 +123,7 @@ int main(int argc, char* argv[])
         }
     }
 
+    os::dtvt::initialize();
     os::dtvt::checkpoint();
 
     auto denied = faux;

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -234,7 +234,7 @@ int main(int argc, char* argv[])
                     auto sync = std::lock_guard{ locker };
                     std::swap(stream, iolink);
                     events.command.send(stream, utf::concat(os::process::id.first)); // First command is the monitor id.
-                    events.command.send(stream, os::env::add());
+                    events.command.send(stream, os::env::add("VTM=1\0"));
                     events.command.send(stream, os::env::cwd());
                     for (auto& line : buffer)
                     {

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -291,7 +291,8 @@ int main(int argc, char* argv[])
             signal.reset();
             if (client || (client = os::ipc::socket::open<os::role::client>(prefix, denied)))
             {
-                os::tty::stream.init.send(client, userid.first, os::dtvt::vtmode, os::dtvt::win_sz, config.utf8());
+                auto userinit = directvt::binary::init{};
+                userinit.send(client, userid.first, os::dtvt::vtmode, os::dtvt::win_sz, config.utf8());
                 os::tty::splice(client);
                 return 0;
             }
@@ -376,7 +377,8 @@ int main(int argc, char* argv[])
             {
                 domain->run([&, user, settings](auto session_id)
                 {
-                    if (auto packet = os::tty::stream.init.recv(user))
+                    auto userinit = directvt::binary::init{};
+                    if (auto packet = userinit.recv(user))
                     {
                         auto id = utf::concat(*user);
                         if constexpr (debugmode) log("%%Client connected %id%", prompt::user, id);

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -126,11 +126,16 @@ int main(int argc, char* argv[])
     os::dtvt::initialize();
     os::dtvt::checkpoint();
 
+    if (os::dtvt::vtmode & ui::console::redirio
+     && (whoami == type::runapp || whoami == type::client))
+    {
+        whoami = type::logger;
+    }
     auto denied = faux;
     auto syslog = os::tty::logger();
     auto userid = os::env::user();
-    auto prefix = vtpipe.length() ? vtpipe : utf::concat(app::shared::ipc_prefix, os::process::elevated ? "!-" : "-", userid.second);;
-    auto prefix_log = prefix + app::shared::log_suffix;
+    auto prefix = vtpipe.length() ? vtpipe : utf::concat(os::path::ipc_prefix, os::process::elevated ? "!-" : "-", userid.second);;
+    auto prefix_log = prefix + os::path::log_suffix;
     auto failed = [&](auto cause)
     {
         os::fail(cause == code::noaccess ? "Access denied"

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -378,22 +378,22 @@ int main(int argc, char* argv[])
                     auto id = text{};
                     auto active = faux;
                     auto tokens = subs{};
-                    auto request = eccc{};
+                    auto script = eccc{};
                     auto events = os::tty::binary::logger{ [&, init = 0](auto& cmd) mutable
                     {
                         if (active)
                         {
-                            request.cmd = cmd;
-                            domain->SIGNAL(tier::release, scripting::events::readline, request);
+                            script.cmd = cmd;
+                            domain->SIGNAL(tier::release, scripting::events::invoke, script);
                         }
                         else
                         {
                                  if (init == 0) id = cmd;
-                            else if (init == 1) request.env = cmd;
+                            else if (init == 1) script.env = cmd;
                             else if (init == 2)
                             {
-                                request.cwd = cmd;
                                 active = true;
+                                script.cwd = cmd;
                                 log("%%Monitor [%id%] connected", prompt::logs, id);
                             }
                             init++;
@@ -413,7 +413,7 @@ int main(int argc, char* argv[])
         }};
 
         auto settings = config.utf8();
-        auto readline = os::tty::readline([&](auto line){ domain->SIGNAL(tier::release, scripting::events::readline, request, ({ .cmd = line })); },
+        auto readline = os::tty::readline([&](auto cmd){ domain->SIGNAL(tier::release, scripting::events::invoke, script, ({ .cmd = cmd })); },
                                           [&]{ domain->SIGNAL(tier::general, e2::shutdown, msg, (utf::concat(prompt::main, "Shutdown on signal"))); });
         while (auto user = server->meet())
         {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1813,6 +1813,7 @@ namespace netxs::app::vtm
                         auto& cfg = dbase.menu[what.menuid];
                              if (cfg.winform == shared::winform::maximized) window->SIGNAL(tier::preview, e2::form::size::enlarge::maximize, gear);
                         else if (cfg.winform == shared::winform::minimized) window->SIGNAL(tier::preview, e2::form::size::minimize, gear);
+                        appspec.appcfg.cmd = utf::concat("object.id: ", window->id);
                     }
                 }
                 else
@@ -1823,6 +1824,7 @@ namespace netxs::app::vtm
                     if (auto window = create(what))
                     {
                         pro::focus::set(window, id_t{}, pro::focus::solo::on, pro::focus::flip::off);
+                        appspec.appcfg.cmd = utf::concat("object.id: ", window->id);
                     }
                 }
             };
@@ -1942,6 +1944,7 @@ namespace netxs::app::vtm
                     appspec.label = cmd;
                     appspec.notes = cmd;
                     this->SIGNAL(tier::request, desk::events::exec, appspec);
+                    script.cmd = appspec.appcfg.cmd;
                 }
                 else if (expression(vtm_run, cmd))
                 {
@@ -1962,6 +1965,7 @@ namespace netxs::app::vtm
                     if (appspec.label.empty()) appspec.label = title;
                     if (appspec.notes.empty()) appspec.notes = menu_id;
                     this->SIGNAL(tier::request, desk::events::exec, appspec);
+                    script.cmd = appspec.appcfg.cmd;
                 }
                 else log(prompt::repl, utf::debase<faux, faux>(script.cmd));
             };

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1810,8 +1810,17 @@ namespace netxs::app::vtm
             LISTEN(tier::release, e2::conio::readline, utf8)
             {
                 static auto vtm_run = "vtm.run("sv;
+                static auto vtm_exit = "vtm.exit("sv;
+                static auto vtm_close = "vtm.close("sv;
+                static auto vtm_shutdown = "vtm.shutdown("sv;
                 auto cmd = qiew{ utf8 };
-                if (cmd.starts_with(vtm_run))
+                if (cmd.starts_with(vtm_exit)
+                 || cmd.starts_with(vtm_close)
+                 || cmd.starts_with(vtm_shutdown))
+                {
+                    this->SIGNAL(tier::general, e2::shutdown, msg, (utf::concat(prompt::repl, "Server shutdown")));
+                }
+                else if (cmd.starts_with(vtm_run))
                 {
                     log(ansi::clr(yellowlt, utf::debase<faux, faux>(utf::trim(utf8, "\n\r"))));
                     cmd.remove_prefix(vtm_run.size());

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1542,7 +1542,7 @@ namespace netxs::app::vtm
                 if (test.size())
                 {
                     conf_rec.appcfg.cmd = test;
-                    log(ansi::clr(yellowlt, "settings: The 'param' attribute is deprecated, please use 'cmd' instead:"), " <... param=", test, " .../>");
+                    log(ansi::clr(yellowlt, "settings: The 'param=' attribute is deprecated, please use 'cmd=' instead:"), " <... param=", test, " .../>");
                 }
                 else conf_rec.appcfg.cmd = fallback.appcfg.cmd;
 

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1665,7 +1665,7 @@ namespace netxs::app::vtm
             {
                 auto& setup = dbase.menu[what.menuid];
                 auto& maker = app::shared::builder(setup.type);
-                what.applet = maker(setup.env, setup.cwd, setup.param, host::config, setup.patch);
+                what.applet = maker(setup.env, setup.cwd, setup.param, setup.patch, host::config);
                 what.header = setup.title;
                 what.footer = setup.footer;
                 if (setup.bgc     ) what.applet->SIGNAL(tier::anycast, e2::form::prop::colors::bg,   setup.bgc);
@@ -1836,7 +1836,7 @@ namespace netxs::app::vtm
                     auto env = text{};
                     auto cwd = text{};
                     auto patch = text{};
-                    auto applet = maker(env, cwd, text{ param }, host::config, patch);
+                    auto applet = maker(env, cwd, text{ param }, patch, host::config);
                     auto what = link{ .header = "test", .footer = "test" };
                     auto window_ptr = hall::window(what);
                     window_ptr->extend({{ 10,5 }, { 80, 25+2 }});
@@ -1932,7 +1932,7 @@ namespace netxs::app::vtm
             };
             //todo make it configurable
             auto patch = ""s;
-            auto deskmenu = app::shared::builder(app::desk::id)("", "", utf::concat(user->id, ";", user->props.os_user_id, ";", user->props.selected), app_config, patch);
+            auto deskmenu = app::shared::builder(app::desk::id)("", "", utf::concat(user->id, ";", user->props.os_user_id, ";", user->props.selected), patch, app_config);
             user->attach(deskmenu);
             user->base::resize(winsz);
             if (vport) user->base::moveto(vport); // Restore user's last position.

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1807,6 +1807,31 @@ namespace netxs::app::vtm
                     gear.owner.SIGNAL(tier::preview, hids::events::keybd::focus::set, seed);
                 }
             };
+            LISTEN(tier::release, e2::conio::readline, utf8)
+            {
+                static auto vtm_run = "vtm.run("sv;
+                auto cmd = qiew{ utf8 };
+                if (cmd.starts_with(vtm_run))
+                {
+                    log(ansi::clr(yellowlt, utf::debase<faux, faux>(utf::trim(utf8, "\n\r"))));
+                    cmd.remove_prefix(vtm_run.size());
+                    auto kind = utf::get_tail(cmd, "\t ,");
+                    auto param = utf::get_quote(cmd, "\"");
+                    auto& maker = app::shared::builder(kind);
+                    auto env = text{};
+                    auto cwd = text{};
+                    auto patch = text{};
+                    auto applet = maker(env, cwd, text{ param }, host::config, patch);
+                    auto what = link{ .header = "test", .footer = "test" };
+                    auto window_ptr = hall::window(what);
+                    window_ptr->extend({{ 10,5 }, { 80, 25+2 }});
+                    window_ptr->attach(applet);
+                    auto menuid = kind;
+                    this->branch(menuid, window_ptr, true);
+                    window_ptr->SIGNAL(tier::anycast, e2::form::upon::started, this->This());
+                }
+                else log(prompt::repl, utf::debase<faux, faux>(utf8));
+            };
         }
 
     public:

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1552,65 +1552,65 @@ namespace netxs::app::vtm
                 auto alias = item.take(attr::alias, ""s);
                 auto merge = [&](auto& conf_rec, auto& fallback)
                 {
-                    conf_rec.splitter = splitter;
-                    conf_rec.alias    = alias;
-                    conf_rec.menuid   = menuid;
-                    conf_rec.label    = item.take(attr::label,    fallback.label   );
+                    conf_rec.splitter   = splitter;
+                    conf_rec.alias      = alias;
+                    conf_rec.menuid     = menuid;
+                    conf_rec.label      = item.take(attr::label,    fallback.label   );
                     if (conf_rec.label.empty()) conf_rec.label = conf_rec.menuid;
-                    conf_rec.hidden   = item.take(attr::hidden,   fallback.hidden  );
-                    conf_rec.notes    = item.take(attr::notes,    fallback.notes   );
-                    conf_rec.title    = item.take(attr::title,    fallback.title   );
-                    conf_rec.footer   = item.take(attr::footer,   fallback.footer  );
-                    conf_rec.bgc      = item.take(attr::bgc,      fallback.bgc     );
-                    conf_rec.fgc      = item.take(attr::fgc,      fallback.fgc     );
-                    conf_rec.winsize  = item.take(attr::winsize,  fallback.winsize );
-                    conf_rec.wincoor  = item.take(attr::wincoor,  fallback.wincoor );
-                    conf_rec.winform  = item.take(attr::winform,  fallback.winform, shared::winform::options);
-                    conf_rec.slimmenu = item.take(attr::slimmenu, fallback.slimmenu);
-                    conf_rec.hotkey   = item.take(attr::hotkey,   fallback.hotkey  ); //todo register hotkey
-                    conf_rec.cwd      = item.take(attr::cwd,      fallback.cwd     );
-                    conf_rec.param    = item.take(attr::param,    fallback.param   );
-                    conf_rec.type     = item.take(attr::type,     fallback.type    );
-                    auto patch        = item.list(attr::config);
+                    conf_rec.hidden     = item.take(attr::hidden,   fallback.hidden  );
+                    conf_rec.notes      = item.take(attr::notes,    fallback.notes   );
+                    conf_rec.title      = item.take(attr::title,    fallback.title   );
+                    conf_rec.footer     = item.take(attr::footer,   fallback.footer  );
+                    conf_rec.bgc        = item.take(attr::bgc,      fallback.bgc     );
+                    conf_rec.fgc        = item.take(attr::fgc,      fallback.fgc     );
+                    conf_rec.winsize    = item.take(attr::winsize,  fallback.winsize );
+                    conf_rec.wincoor    = item.take(attr::wincoor,  fallback.wincoor );
+                    conf_rec.winform    = item.take(attr::winform,  fallback.winform, shared::winform::options);
+                    conf_rec.slimmenu   = item.take(attr::slimmenu, fallback.slimmenu);
+                    conf_rec.hotkey     = item.take(attr::hotkey,   fallback.hotkey  ); //todo register hotkey
+                    conf_rec.appcfg.cwd = item.take(attr::cwd,      fallback.appcfg.cwd);
+                    conf_rec.appcfg.cmd = item.take(attr::param,    fallback.appcfg.cmd);
+                    conf_rec.type       = item.take(attr::type,     fallback.type    );
+                    auto patch          = item.list(attr::config);
                     if (patch.size())
                     {
-                        if (fallback.patch.empty() && patch.size() == 1)
+                        if (fallback.appcfg.cfg.empty() && patch.size() == 1)
                         {
-                            conf_rec.patch = patch.front()->snapshot();
+                            conf_rec.appcfg.cfg = patch.front()->snapshot();
                         }
                         else // Merge new configurations with the previous one if it is.
                         {
                             auto head = patch.begin();
                             auto tail = patch.end();
-                            auto settings = xml::settings{ fallback.patch.size() ? fallback.patch
-                                                                                 : (*head++)->snapshot() };
+                            auto settings = xml::settings{ fallback.appcfg.cfg.size() ? fallback.appcfg.cfg
+                                                                                      : (*head++)->snapshot() };
                             while (head != tail)
                             {
                                 auto& p = *head++;
                                 settings.fuse(p->snapshot());
                             }
-                            conf_rec.patch = settings.utf8();
+                            conf_rec.appcfg.cfg = settings.utf8();
                         }
                     }
                     auto envar        = item.list(attr::env);
-                    if (envar.empty()) conf_rec.env = fallback.env;
+                    if (envar.empty()) conf_rec.appcfg.env = fallback.appcfg.env;
                     else for (auto& v : envar)
                     {
                         auto value = v->value();
                         if (value.size())
                         {
-                            conf_rec.env += value + '\0';
+                            conf_rec.appcfg.env += value + '\0';
                         }
                     }
-                    if (conf_rec.title.empty()) conf_rec.title = conf_rec.menuid + (conf_rec.param.empty() ? ""s : ": " + conf_rec.param);
+                    if (conf_rec.title.empty()) conf_rec.title = conf_rec.menuid + (conf_rec.appcfg.cmd.empty() ? ""s : ": " + conf_rec.appcfg.cmd);
 
                     utf::to_low(conf_rec.type);
-                    utf::change(conf_rec.title,  "$0", current_module_file);
-                    utf::change(conf_rec.footer, "$0", current_module_file);
-                    utf::change(conf_rec.label,  "$0", current_module_file);
-                    utf::change(conf_rec.notes,  "$0", current_module_file);
-                    utf::change(conf_rec.param,  "$0", current_module_file);
-                    utf::change(conf_rec.env,    "$0", current_module_file);
+                    utf::change(conf_rec.title,      "$0", current_module_file);
+                    utf::change(conf_rec.footer,     "$0", current_module_file);
+                    utf::change(conf_rec.label,      "$0", current_module_file);
+                    utf::change(conf_rec.notes,      "$0", current_module_file);
+                    utf::change(conf_rec.appcfg.cmd, "$0", current_module_file);
+                    utf::change(conf_rec.appcfg.env, "$0", current_module_file);
                 };
 
                 auto& proto = find(menuid);
@@ -1665,7 +1665,7 @@ namespace netxs::app::vtm
             {
                 auto& setup = dbase.menu[what.menuid];
                 auto& maker = app::shared::builder(setup.type);
-                what.applet = maker(setup.env, setup.cwd, setup.param, setup.patch, host::config);
+                what.applet = maker(setup.appcfg, host::config);
                 what.header = setup.title;
                 what.footer = setup.footer;
                 if (setup.bgc     ) what.applet->SIGNAL(tier::anycast, e2::form::prop::colors::bg,   setup.bgc);
@@ -1836,7 +1836,11 @@ namespace netxs::app::vtm
                     auto env = text{};
                     auto cwd = text{};
                     auto patch = text{};
-                    auto applet = maker(env, cwd, text{ param }, patch, host::config);
+                    auto appcfg = eccc{ .env = env,
+                                        .cwd = cwd,
+                                        .cmd = text{ param },
+                                        .cfg = patch };
+                    auto applet = maker(appcfg, host::config);
                     auto what = link{ .header = "test", .footer = "test" };
                     auto window_ptr = hall::window(what);
                     window_ptr->extend({{ 10,5 }, { 80, 25+2 }});
@@ -1930,9 +1934,8 @@ namespace netxs::app::vtm
             {
                 user->rebuild_scene(*this, true);
             };
-            //todo make it configurable
-            auto patch = ""s;
-            auto deskmenu = app::shared::builder(app::desk::id)("", "", utf::concat(user->id, ";", user->props.os_user_id, ";", user->props.selected), patch, app_config);
+            auto appcfg = eccc{ .cmd = utf::concat(user->id, ";", user->props.os_user_id, ";", user->props.selected) };
+            auto deskmenu = app::shared::builder(app::desk::id)(appcfg, app_config);
             user->attach(deskmenu);
             user->base::resize(winsz);
             if (vport) user->base::moveto(vport); // Restore user's last position.

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1807,13 +1807,13 @@ namespace netxs::app::vtm
                     gear.owner.SIGNAL(tier::preview, hids::events::keybd::focus::set, seed);
                 }
             };
-            LISTEN(tier::release, e2::conio::readline, utf8)
+            LISTEN(tier::release, scripting::events::readline, request)
             {
                 static auto vtm_run = "vtm.run("sv;
                 static auto vtm_exit = "vtm.exit("sv;
                 static auto vtm_close = "vtm.close("sv;
                 static auto vtm_shutdown = "vtm.shutdown("sv;
-                auto cmd = utf::trim(view{ utf8 }, "\r\n\t ");
+                auto cmd = utf::trim(view{ request.cmd }, "\r\n\t ");
                 if (cmd.empty()) return;
                 if (cmd.size() > 2 && cmd.front() == '\"' && cmd.back() == '\"')
                 {
@@ -1827,19 +1827,15 @@ namespace netxs::app::vtm
                 }
                 else if (cmd.starts_with(vtm_run))
                 {
-                    log(ansi::clr(yellowlt, utf::debase<faux, faux>(utf::trim(utf8, "\n\r"))));
+                    log(ansi::clr(yellowlt, utf::debase<faux, faux>(utf::trim(request.cmd, "\n\r"))));
                     cmd.remove_prefix(vtm_run.size());
                     auto delims = " \t,"sv;
                     auto kind = utf::get_token(cmd, delims);
                     auto param = utf::get_token(cmd, delims);
                     auto& maker = app::shared::builder(text{ kind });
-                    auto env = text{};
-                    auto cwd = text{};
-                    auto patch = text{};
-                    auto appcfg = eccc{ .env = env,
-                                        .cwd = cwd,
-                                        .cmd = text{ param },
-                                        .cfg = patch };
+                    auto appcfg = eccc{ .env = request.env,
+                                        .cwd = request.cwd,
+                                        .cmd = text{ param } };
                     auto applet = maker(appcfg, host::config);
                     auto what = link{ .header = "test", .footer = "test" };
                     auto window_ptr = hall::window(what);
@@ -1849,7 +1845,7 @@ namespace netxs::app::vtm
                     this->branch(menuid, window_ptr, true);
                     window_ptr->SIGNAL(tier::anycast, e2::form::upon::started, this->This());
                 }
-                else log(prompt::repl, utf::debase<faux, faux>(utf8));
+                else log(prompt::repl, utf::debase<faux, faux>(request.cmd));
             };
         }
 

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1569,7 +1569,11 @@ namespace netxs::app::vtm
                     conf_rec.slimmenu   = item.take(attr::slimmenu, fallback.slimmenu);
                     conf_rec.hotkey     = item.take(attr::hotkey,   fallback.hotkey  ); //todo register hotkey
                     conf_rec.appcfg.cwd = item.take(attr::cwd,      fallback.appcfg.cwd);
-                    conf_rec.appcfg.cmd = item.take(attr::cmd,      fallback.appcfg.cmd);
+                    //todo Soft transition (period 01/21/2024) from 'param' to 'cmd'
+                    //conf_rec.appcfg.cmd = item.take(attr::cmd,      fallback.appcfg.cmd);
+                    conf_rec.appcfg.cmd = item.take(attr::cmd, ""s);
+                    if (conf_rec.appcfg.cmd.empty()) conf_rec.appcfg.cmd = item.take("param", fallback.appcfg.cmd);
+
                     conf_rec.type       = item.take(attr::type,     fallback.type    );
                     auto patch          = item.list(attr::config);
                     if (patch.size())

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1536,7 +1536,17 @@ namespace netxs::app::vtm
             //todo Soft transition (period 01/21/2024) from 'param' to 'cmd'
             //conf_rec.appcfg.cmd = item.take(attr::cmd,      fallback.appcfg.cmd);
             conf_rec.appcfg.cmd = item.take(attr::cmd, ""s);
-            if (conf_rec.appcfg.cmd.empty()) conf_rec.appcfg.cmd = item.take("param", fallback.appcfg.cmd);
+            if (conf_rec.appcfg.cmd.empty())
+            {
+                auto test = item.take("param", ""s);
+                if (test.size())
+                {
+                    conf_rec.appcfg.cmd = test;
+                    log(ansi::clr(yellowlt, "settings: The 'param' attribute is deprecated, please use 'cmd' instead:"), " <... param=", test, " .../>");
+                }
+                else conf_rec.appcfg.cmd = fallback.appcfg.cmd;
+
+            }
 
             conf_rec.type       = item.take(attr::type,     fallback.type    );
             utf::to_low(conf_rec.type);

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1807,13 +1807,13 @@ namespace netxs::app::vtm
                     gear.owner.SIGNAL(tier::preview, hids::events::keybd::focus::set, seed);
                 }
             };
-            LISTEN(tier::release, scripting::events::readline, request)
+            LISTEN(tier::release, scripting::events::invoke, script)
             {
                 static auto vtm_run = "vtm.run("sv;
                 static auto vtm_exit = "vtm.exit("sv;
                 static auto vtm_close = "vtm.close("sv;
                 static auto vtm_shutdown = "vtm.shutdown("sv;
-                auto cmd = utf::trim(view{ request.cmd }, "\r\n\t ");
+                auto cmd = utf::trim(view{ script.cmd }, "\r\n\t ");
                 if (cmd.empty()) return;
                 if (cmd.size() > 2 && cmd.front() == '\"' && cmd.back() == '\"')
                 {
@@ -1827,14 +1827,14 @@ namespace netxs::app::vtm
                 }
                 else if (cmd.starts_with(vtm_run))
                 {
-                    log(ansi::clr(yellowlt, utf::debase<faux, faux>(utf::trim(request.cmd, "\n\r"))));
+                    log(ansi::clr(yellowlt, utf::debase<faux, faux>(utf::trim(script.cmd, "\n\r"))));
                     cmd.remove_prefix(vtm_run.size());
                     auto delims = " \t,"sv;
                     auto kind = utf::get_token(cmd, delims);
                     auto param = utf::get_token(cmd, delims);
                     auto& maker = app::shared::builder(text{ kind });
-                    auto appcfg = eccc{ .env = request.env,
-                                        .cwd = request.cwd,
+                    auto appcfg = eccc{ .env = script.env,
+                                        .cwd = script.cwd,
                                         .cmd = text{ param } };
                     auto applet = maker(appcfg, host::config);
                     auto what = link{ .header = "test", .footer = "test" };
@@ -1845,7 +1845,7 @@ namespace netxs::app::vtm
                     this->branch(menuid, window_ptr, true);
                     window_ptr->SIGNAL(tier::anycast, e2::form::upon::started, this->This());
                 }
-                else log(prompt::repl, utf::debase<faux, faux>(request.cmd));
+                else log(prompt::repl, utf::debase<faux, faux>(script.cmd));
             };
         }
 

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -41,9 +41,9 @@ namespace netxs::app::vtm
         static constexpr auto slimmenu = "slimmenu";
         static constexpr auto hotkey   = "hotkey";
         static constexpr auto type     = "type";
-        static constexpr auto cwd      = "cwd";
         static constexpr auto env      = "env";
-        static constexpr auto param    = "param";
+        static constexpr auto cwd      = "cwd";
+        static constexpr auto cmd      = "cmd";
         static constexpr auto splitter = "splitter";
         static constexpr auto config   = "config";
     }
@@ -1569,7 +1569,7 @@ namespace netxs::app::vtm
                     conf_rec.slimmenu   = item.take(attr::slimmenu, fallback.slimmenu);
                     conf_rec.hotkey     = item.take(attr::hotkey,   fallback.hotkey  ); //todo register hotkey
                     conf_rec.appcfg.cwd = item.take(attr::cwd,      fallback.appcfg.cwd);
-                    conf_rec.appcfg.cmd = item.take(attr::param,    fallback.appcfg.cmd);
+                    conf_rec.appcfg.cmd = item.take(attr::cmd,      fallback.appcfg.cmd);
                     conf_rec.type       = item.take(attr::type,     fallback.type    );
                     auto patch          = item.list(attr::config);
                     if (patch.size())
@@ -1829,7 +1829,7 @@ namespace netxs::app::vtm
                 {
                     log(ansi::clr(yellowlt, utf::debase<faux, faux>(utf::trim(script.cmd, "\n\r"))));
                     cmd.remove_prefix(vtm_run.size());
-                    auto delims = " \t,"sv;
+                    auto delims = " \t,)"sv;
                     auto kind = utf::get_token(cmd, delims);
                     auto param = utf::get_token(cmd, delims);
                     auto& maker = app::shared::builder(text{ kind });

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -10,7 +10,7 @@ R"==(<config>
             </run>
         </javascript>
     </scripting>
-    <isolated=0/>  <!-- For internal use only. -->
+    <simple=0/>  <!-- For internal use only. -->
     <menu wide=off selected=Term>  <!-- wide: Set wide or compact menu layout; selected: Set selected menu item id. -->
         <item*/>  <!-- Use asterisk at the end of the element name to set defaults.
                        Using an asterisk with the parameter name of the first element in the list without any other nested elements

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -25,11 +25,11 @@ R"==(<config>
 )=="
 #if defined(_WIN32)
 R"==(
-        <item id=Term label="cmd" type=DirectVT title="Command Prompt" notes=" Windows Command Prompt " param="$0 -r term">
+        <item id=Term label="cmd" type=DirectVT title="Command Prompt" notes=" Windows Command Prompt " cmd="$0 -r term">
 )=="
 #else
 R"==(
-        <item id=Term label="Term" type=DirectVT title="Terminal Emulator" notes=" Terminal Emulator " param="$0 -r term">
+        <item id=Term label="Term" type=DirectVT title="Terminal Emulator" notes=" Terminal Emulator " cmd="$0 -r term">
 )=="
 #endif
 R"==(
@@ -63,13 +63,13 @@ R"==(
 )=="
 #if defined(_WIN32)
 R"==(
-        <item id=PowerShell label="PowerShell" type=DirectVT title="Windows PowerShell"          param="$0 -r term powershell" fgc=15 bgc=0xFF562401 notes=" Windows PowerShell "/>
+        <item id=PowerShell label="PowerShell" type=DirectVT title="Windows PowerShell"    cmd="$0 -r term powershell" fgc=15 bgc=0xFF562401 notes=" Windows PowerShell "/>
 )=="
 #endif
 R"==(
-        <item id=Tile       label="Tile"       type=Group    title="Tiling Window Manager" param="h1:1(Term, Term)"    notes=" Tiling window manager with two terminals attached "/>
-        <item id=View       label=View         type=Region   title="\e[11:3pView: Region"  winform=maximized           notes=" Desktop region marker "/>
-        <item id=Logs       label=Logs         type=DirectVT title="Logs"                  param="$0 -q -r term $0 -m" notes=" Log monitor ">
+        <item id=Tile       label="Tile"       type=Group    title="Tiling Window Manager" cmd="h1:1(Term, Term)"    notes=" Tiling window manager with two terminals attached "/>
+        <item id=View       label=View         type=Region   title="\e[11:3pView: Region"  winform=maximized         notes=" Desktop region marker "/>
+        <item id=Logs       label=Logs         type=DirectVT title="Logs"                  cmd="$0 -q -r term $0 -m" notes=" Log monitor ">
             <config>
                 <term>
                     <logs=off/>


### PR DESCRIPTION
Changes
- Fix regression from commit efc7db11d8e036af39bd86269b31cb3f3e0573ee (broken mc panels).
- Replace `param=` with `cmd=` in menu item definitions in settings.xml, currently both tags are accepted to smooth the transition.
- Add support for launching application windows in vtm desktop through command line, #544.

Now it is possible to launch apps inside the vtm desktop using command line by piping console output or typing commands inside the interactive monitor sessions. The current working directory and environment variables are auto synced when piping console output is used.

This feature is not yet documented. This needs to be tested.

Supported commands:
- `vtm.run(_attr_list_)` Launches an application window created using a list of the same attributes that are used in defining the taskbar menu item in the settings.xml.
- `vtm.dtvt(_command_line_)` Launches a dtvt-application. E.g. `vtm.dtvt(vtm -r term)` runs built-in terminal.
- `vtm.shutdown()` Disconnects all users and shuts down the desktop.

There is an issue when several users launch something at the same time (race condition - undefined/stolen keybd focus), we have not yet figured out how to beat this. There is also a synchronization bug when doing things like `printf "vtm.exit()\nvtm.run()" | vtm`.

### Examples

bash
```
printf "vtm.run()" | vtm
printf "vtm.run()\nvtm.run()" | vtm
printf "vtm.run(cmd=mc)" | vtm
printf "vtm.run(type=dtvt cmd='vtm -r term')" | vtm
printf "vtm.dtvt(vtm -r term)" | vtm
printf "vtm.run(type=headless cmd='mc')" | vtm
printf "vtm.run(type=headless cmd='mc' winsize=80x25)" | vtm
printf "vtm.run(type=group cmd='h(Term, Term)' winsize=80x29)" | vtm

# Shutdown desktop
printf "vtm.shutdown()" | vtm
```