### PR TITLE
Add menu splitters support `vtm.set(splitter id=<id> label=<label>)`

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.58";
+    static const auto version = "v0.9.59";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1513,7 +1513,7 @@ namespace netxs::app::vtm
             window_ptr->SIGNAL(tier::anycast, e2::form::upon::started, this->This());
             return window_ptr;
         }
-        auto loadspec(auto& conf_rec, auto& fallback, auto& item, text menuid, text alias = {}, bool splitter = {})
+        auto loadspec(auto& conf_rec, auto& fallback, auto& item, text menuid, bool splitter = {}, text alias = {})
         {
             conf_rec.splitter   = splitter;
             conf_rec.menuid     = menuid;
@@ -1641,7 +1641,7 @@ namespace netxs::app::vtm
                 {
                     auto& conf_rec = proto;
                     conf_rec.fixed = true;
-                    hall::loadspec(conf_rec, conf_rec, item, menuid, alias, splitter);
+                    hall::loadspec(conf_rec, conf_rec, item, menuid, splitter, alias);
                     expand(conf_rec);
                 }
                 else // New item.
@@ -1650,7 +1650,7 @@ namespace netxs::app::vtm
                     conf_rec.fixed = true;
                     auto& dflt = alias.size() ? find(alias) // New based on alias_id.
                                               : dflt_spec;  // New item.
-                    hall::loadspec(conf_rec, dflt, item, menuid, alias, splitter);
+                    hall::loadspec(conf_rec, dflt, item, menuid, splitter, alias);
                     expand(conf_rec);
                     if (conf_rec.hidden) temp_list.emplace_back(std::move(conf_rec.menuid), std::move(conf_rec));
                     else                 free_list.emplace_back(std::move(conf_rec.menuid), std::move(conf_rec));
@@ -1972,7 +1972,8 @@ namespace netxs::app::vtm
                     }
                     else
                     {
-                        hall::loadspec(appspec, appspec, *itemptr, menuid);
+                        auto splitter = itemptr->take(attr::splitter, faux);
+                        hall::loadspec(appspec, appspec, *itemptr, menuid, splitter);
                         if (!appspec.hidden)
                         {
                             auto& [stat, list] = dbase.apps[menuid];


### PR DESCRIPTION
Changes
- Add menu splitters support `vtm.set(splitter id=<id> label=<label>)`

Example
```
printf "vtm.del()\nvtm.set(splitter id=s2 label=Group1)\nvtm.set(id=mc cmd=mc)\nvtm.set(splitter id=s1 label=Group2)\nvtm.set(id=htop cmd=htop)\nvtm.selected(mc)" | vtm
```