### PR TITLE
Implement `vtm --script <body>` option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,14 +115,14 @@ jobs:
 
     - name: Upload Artifact (POSIX)
       if: matrix.os != 'windows-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@main
       with:
         name: vtm_${{ matrix.platform }}_${{ matrix.arch }}
         path: vtm_${{ matrix.platform }}_${{ matrix.arch }}.tar
 
     - name: Upload Artifact (Windows)
       if: matrix.os == 'windows-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@main
       with:
         name: vtm_${{ matrix.platform }}_${{ matrix.arch }}
         path: ${{ steps.strings.outputs.bin }}/Release/vtm.exe

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -8,7 +8,7 @@ Option                       | Description
 -----------------------------|-------------------------------------------------------
 No arguments                 | Connect to the desktop (autostart new if not running).
 ` -c `, ` --config <file> `  | Load the specified settings file.
-` -p `, ` --pipe <pipe> `    | Specify the desktop session connection point."
+` -p `, ` --pipe <name> `    | Specify the desktop session connection point."
 ` -q `, ` --quiet `          | Disable logging.
 ` -l `, ` --listconfig `     | Print configuration.
 ` -m `, ` --monitor `        | Desktop session log.
@@ -19,7 +19,8 @@ No arguments                 | Connect to the desktop (autostart new if not runn
 ` -u `, ` --uninstall `      | System-wide deinstallation.
 ` -v `, ` --version `        | Print version.
 ` -? `, ` -h `, ` --help `   | Print command-line options.
-` --onlylog  `               | Disable interactive user input for desktop server.
+` --onlylog `                | Disable interactive user input for desktop server.
+` --script <body> `          | Run the specified script on ready.
 
 ### Built-in applications
 

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -609,9 +609,10 @@ namespace netxs::app::desk
                         owner_id = parent.id;
                     };
                     auto oneshot = ptr::shared(hook{});
-                    parent.LISTEN(tier::release, e2::conio::focus, f, *oneshot, (oneshot, usrcfg))
+                    parent.LISTEN(tier::release, hids::events::focus::any, gear, *oneshot, (oneshot, usrcfg))
                     {
                         usrcfg.win = {};
+                        usrcfg.hid = gear.id;
                         auto script = std::move(usrcfg.cmd);
                         utf::split<true>(utf::dequote(script), '\n', [&](auto onecmd)
                         {

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -491,7 +491,7 @@ namespace netxs::app::desk
             }
             auto my_id = id_t{};
 
-            auto user_info = utf::divide(appcfg.cmd, ";");
+            auto user_info = utf::split(appcfg.cmd, ";");
             if (user_info.size() < 2)
             {
                 log(prompt::desk, "Bad window arguments: args=", utf::debase(appcfg.cmd));

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.59";
+    static const auto version = "v0.9.60";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -183,7 +183,7 @@ namespace netxs::ui
                     if (item.data.size())
                     {
                         auto data = escx{};
-                        utf::divide(item.data, '\n', [&](auto line)
+                        utf::split(item.data, '\n', [&](auto line)
                         {
                             data.add(netxs::prompt::pads, item.id, ": ", line, '\n');
                         });

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -654,7 +654,7 @@ struct impl : consrv
             if (iter == src_map.end()) return;
 
             auto tail = utf::trim_back(rest, "\r\n");
-            auto args = utf::divide<feed::fwd, true>(rest, ' ');
+            auto args = utf::split<true>(rest, ' ');
             auto data = qiew{ iter->second };
             auto result = text{};
             while (data)

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -846,7 +846,7 @@ namespace netxs::directvt
         STRUCT_macro(bgc,               (rgba, color))
         STRUCT_macro(fgc,               (rgba, color))
         STRUCT_macro(slimmenu,          (bool, menusize))
-        STRUCT_macro(init,              (text, user) (si32, mode) (twod, winsz) (text, config))
+        STRUCT_macro(init,              (text, user) (si32, mode) (text, env) (text, cwd) (text, cmd) (text, cfg) (twod, win))
 
         #undef STRUCT_macro
         #undef STRUCT_macro_lite

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -21,6 +21,7 @@ namespace netxs::prompt
 
     #define prompt_list \
         X(apps) /* */ \
+        X(args) /* */ \
         X(base) /* */ \
         X(calc) /* */ \
         X(desk) /* */ \

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2453,7 +2453,7 @@ namespace netxs::os
 
             #endif
         }
-        auto fork([[maybe_unused]] text prefix, [[maybe_unused]] view config)
+        auto fork([[maybe_unused]] text prefix, [[maybe_unused]] view config, [[maybe_unused]] view script = {})
         {
             auto msg = [](auto& success)
             {
@@ -2477,7 +2477,7 @@ namespace netxs::os
                 {
                     auto cfpath = utf::concat(prefix, os::path::cfg_suffix);
                     auto handle = process::memory::set(cfpath, config);
-                    auto cmdarg = utf::to_utf(utf::concat(os::process::binary(), " -s --onlylog -p ", prefix, " -c :", cfpath));
+                    auto cmdarg = utf::to_utf(utf::concat(os::process::binary(), " -s --onlylog -p ", prefix, " -c :", cfpath, script.size() ? utf::concat(" --script ", script) : ""s));
                     if (os::nt::runas(cmdarg))
                     {
                         success.reset(handle); // Do not close until confirmation from the server process is received.

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1720,7 +1720,7 @@ namespace netxs::os
             auto env_map = std::map<text, text>{};
             auto combine = [&](auto subset)
             {
-                utf::divide(subset, '\0', [&](qiew rec)
+                utf::split(subset, '\0', [&](qiew rec)
                 {
                     if (rec.empty()) return;
                     auto var = utf::cutoff(rec, '=', true, 1); // 1: Skip the first char to support cmd.exe's strange subdirs like =A:=A:\Dir.
@@ -2257,11 +2257,15 @@ namespace netxs::os
                 return result;
             }
             // args: Return current argument and step forward.
-            template<class ...Args>
-            auto next()
+            auto next(bool dequote = faux)
             {
-                return iter != data.end() ? qiew{ *iter++ }
-                                          : qiew{};
+                auto item = qiew{};
+                if (iter != data.end())
+                {
+                    item = { *iter++ };
+                    if (dequote) utf::dequote(item);
+                }
+                return item;
             }
             // args: Return the rest of the command line arguments.
             auto rest()
@@ -2436,7 +2440,7 @@ namespace netxs::os
                     }
                     argv.push_back(nullptr);
                     auto envp = std::vector<char*>{};
-                    for (auto& c : utf::divide<feed::fwd, true>(env, '\0'))
+                    for (auto& c : utf::split<true>(env, '\0'))
                     {
                         envp.push_back((char*)c.data());
                     }
@@ -2583,7 +2587,7 @@ namespace netxs::os
                                     else break;
                                 }
                                 if (size == 0)
-                                if (auto blocks = utf::divide(data, '\xFF'); blocks.size() == 3)
+                                if (auto blocks = utf::split(data, '\xFF'); blocks.size() == 3)
                                 {
                                     auto prefix = blocks[0];
                                     auto config = blocks[1];

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -77,11 +77,12 @@ namespace netxs
 {
     struct eccc
     {
-        text env; // eccc: Environment var list delimited by \0.
-        text cwd; // eccc: Current working directory.
-        text cmd; // eccc: Command line to run.
-        text cfg; // eccc: Configuration patch.
-        twod win; // eccc: Console window size.
+        text env{}; // eccc: Environment var list delimited by \0.
+        text cwd{}; // eccc: Current working directory.
+        text cmd{}; // eccc: Command line to run.
+        text cfg{}; // eccc: Configuration patch.
+        twod win{}; // eccc: Console window size.
+        id_t hid{}; // eccc: Gear id.
     };
 }
 namespace netxs::os

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7611,7 +7611,7 @@ namespace netxs::ui
                     else
                     {
                         prompt.add(netxs::prompt::pads, lock.thing.id, ": "); // Local host pid and remote host pid can be different. It is different if sshed.
-                        utf::divide(utf8, '\n', [&](auto line)
+                        utf::split(utf8, '\n', [&](auto line)
                         {
                             output.add(prompt, line, '\n');
                         });

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1527,24 +1527,6 @@ namespace netxs::utf
     {
         return get_tail<faux>(utf8, delims);
     }
-    auto get_token(view& utf8) // Preserve quotes.
-    {
-        if (utf8.empty()) return utf8;
-        auto c = utf8.front();
-        auto item = (c == '\'' || c == '"') ? utf::get_quote(utf8)
-                                            : utf::get_word(utf8);
-        utf::trim_front(utf8);
-        return item;
-    }
-    auto get_token(view& utf8, view delims) // Drop quotes.
-    {
-        if (utf8.empty()) return utf8;
-        auto c = utf8.front();
-        auto item = (c == '\'' || c == '"') ? utf::get_quote(utf8, view{ &c, 1 })
-                                            : utf::get_word(utf8, delims);
-        utf::trim_front(utf8, delims);
-        return item;
-    }
     auto quote(text utf8)
     {
         if (utf8.empty() || utf8.find(' ') != text::npos)
@@ -1593,24 +1575,19 @@ namespace netxs::utf
         return utf8;
     }
     // utf: Split text line into quoted tokens.
-    auto tokenize(view line, auto&& args, bool dequote = faux)
+    auto tokenize(view utf8, auto&& args, bool dequote = faux)
     {
-        line = utf::trim(line);
-        if (dequote)
+        utf8 = utf::trim(utf8);
+        while (utf8.size())
         {
-            while (line.size())
+            auto c = utf8.front();
+            if (c == '\'' || c == '"')
             {
-                auto item = utf::get_token(line, " ");
-                args.emplace_back(item);
+                args.emplace_back(dequote ? utf::get_quote(utf8, view{ &c, 1 })
+                                          : utf::get_quote(utf8));
             }
-        }
-        else
-        {
-            while (line.size())
-            {
-                auto item = utf::get_token(line);
-                if (item.size()) args.emplace_back(item);
-            }
+            else args.emplace_back(utf::get_word(utf8));
+            utf::trim_front(utf8);
         }
         return args;
     }

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1596,11 +1596,21 @@ namespace netxs::utf
     auto tokenize(view line, auto&& args, bool dequote = faux)
     {
         line = utf::trim(line);
-        while (line.size())
+        if (dequote)
         {
-            auto item = dequote ? utf::get_token(line, " ")
-                                : utf::get_token(line);
-            if (item.size()) args.emplace_back(item);
+            while (line.size())
+            {
+                auto item = utf::get_token(line, " ");
+                args.emplace_back(item);
+            }
+        }
+        else
+        {
+            while (line.size())
+            {
+                auto item = utf::get_token(line);
+                if (item.size()) args.emplace_back(item);
+            }
         }
         return args;
     }

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1101,7 +1101,7 @@ namespace netxs::utf
             return crop;
         }
     }
-    template<feed Direction = feed::fwd, bool SkipEmpty = faux, class P, bool Plain = std::is_same_v<void, std::invoke_result_t<P, view>>>
+    template<bool SkipEmpty = faux, feed Direction = feed::fwd, class P, bool Plain = std::is_same_v<void, std::invoke_result_t<P, view>>>
     auto split(view utf8, char delimiter, P proc)
     {
         if constexpr (Direction == feed::fwd)
@@ -1117,7 +1117,14 @@ namespace netxs::utf
                 cur = pos + 1;
             }
             auto end = view{ utf8.data() + cur, utf8.size() - cur };
-            if constexpr (SkipEmpty) if (end.empty()) return true;
+            if constexpr (SkipEmpty)
+            {
+                if (end.empty())
+                {
+                    if constexpr (Plain) return;
+                    else                 return true;
+                }
+            }
             return proc(end);
         }
         else
@@ -1134,7 +1141,14 @@ namespace netxs::utf
                 cur = pos;
             }
             auto end = view{ utf8.data(), cur };
-            if constexpr (SkipEmpty) if (end.empty()) return true;
+            if constexpr (SkipEmpty)
+            {
+                if (end.empty())
+                {
+                    if constexpr (Plain) return;
+                    else                 return true;
+                }
+            }
             return proc(end);
         }
     }

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -446,7 +446,7 @@ namespace netxs::xml
                 auto anchor = this;
                 auto crop = vect{}; //auto& items = config.root->hive["menu"][0]->hive["item"]...;
                 auto temp = text{};
-                auto path = utf::divide(path_str, '/');
+                auto path = utf::split(path_str, '/');
                 if (path.size())
                 {
                     auto head = path.begin();

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -350,7 +350,12 @@ int main(int argc, char* argv[])
             if (client || (client = os::ipc::socket::open<os::role::client>(prefix, denied)))
             {
                 auto userinit = directvt::binary::init{};
-                userinit.send(client, userid.first, os::dtvt::vtmode, os::dtvt::win_sz, config.utf8());
+                auto env = os::env::add();
+                auto cwd = os::env::cwd();
+                auto cmd = script;
+                auto cfg = config.utf8();
+                auto win = os::dtvt::win_sz;
+                userinit.send(client, userid.first, os::dtvt::vtmode, env, cwd, cmd, cfg, win);
                 os::tty::splice(client);
                 return 0;
             }
@@ -463,9 +468,10 @@ int main(int argc, char* argv[])
                     {
                         auto id = utf::concat(*user);
                         if constexpr (debugmode) log("%%Client connected %id%", prompt::user, id);
+                        auto usrcfg = eccc{ .env = packet.env, .cwd = packet.cwd, .cmd = packet.cmd, .win = packet.win };
                         auto config = xmls{ settings };
-                        config.fuse(packet.config);
-                        domain->invite(user, packet.user, packet.mode, packet.winsz, config, session_id);
+                        config.fuse(packet.cfg);
+                        domain->invite(user, packet.user, packet.mode, usrcfg, config, session_id);
                         if constexpr (debugmode) log("%%Client disconnected %id%", prompt::user, id);
                     }
                 });

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -115,7 +115,7 @@ int main(int argc, char* argv[])
         }
         else if (getopt.match("--script"))
         {
-            script = getopt.next(true);
+            script = getopt.next();
         }
         else if (getopt.match("--"))
         {
@@ -154,6 +154,7 @@ int main(int argc, char* argv[])
     };
 
     log(prompt::vtm, app::shared::version);
+    log(getopt.show());
     if (errmsg.size())
     {
         failed(code::errormsg);
@@ -223,7 +224,7 @@ int main(int argc, char* argv[])
         auto active = flag{ faux };
         auto locker = std::mutex{};
         auto syncio = std::unique_lock{ locker };
-        auto buffer = utf::split<true, std::list<text>>(script, '\n');
+        auto buffer = utf::split<true, std::list<text>>(utf::dequote(script), '\n');
         auto stream = sptr<os::ipc::socket>{};
         auto readln = os::tty::readline([&](auto line)
         {
@@ -449,7 +450,7 @@ int main(int argc, char* argv[])
         auto settings = config.utf8();
         auto execline = [&](qiew line){ domain->SIGNAL(tier::release, scripting::events::invoke, onecmd, ({ .cmd = line })); };
         auto shutdown = [&]{ domain->SIGNAL(tier::general, e2::shutdown, msg, (utf::concat(prompt::main, "Shutdown on signal"))); };
-        utf::split<true>(script, '\n', execline);
+        utf::split<true>(utf::dequote(script), '\n', execline);
         auto readline = os::tty::readline(execline, shutdown);
         while (auto user = server->meet())
         {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1946,7 +1946,9 @@ namespace netxs::app::vtm
                 }
                 else if (expression(vtm_dtvt, cmd))
                 {
-                    auto appspec = desk::spec{ .hidden = true, .type = app::dtvt::id };
+                    auto appspec = desk::spec{ .hidden = true,
+                                               .type   = app::dtvt::id,
+                                               .gearid = onecmd.hid };
                     appspec.appcfg.env = onecmd.env;
                     appspec.appcfg.cwd = onecmd.cwd;
                     appspec.appcfg.cmd = cmd;
@@ -2028,7 +2030,8 @@ namespace netxs::app::vtm
                     auto appspec = desk::spec{ .hidden   = true,
                                                .winform  = shared::winform::undefined,
                                                .slimmenu = host::config.take(path::menuslim, true),
-                                               .type     = app::shell::id };
+                                               .type     = app::shell::id,
+                                               .gearid   = onecmd.hid };
                     auto menuid = itemptr->take(attr::id, ""s);
                     if (dbase.menu.contains(menuid))
                     {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1546,7 +1546,6 @@ namespace netxs::app::vtm
                     log(ansi::clr(yellowlt, "settings: The 'param=' attribute is deprecated, please use 'cmd=' instead:"), " <... param=", test, " .../>");
                 }
                 else conf_rec.appcfg.cmd = fallback.appcfg.cmd;
-
             }
 
             conf_rec.type       = item.take(attr::type,     fallback.type    );
@@ -2142,7 +2141,7 @@ namespace netxs::app::vtm
             this->SIGNAL(tier::release, desk::events::apps, dbase.apps_ptr);
         }
         // hall: Create a new user gate.
-        auto invite(xipc client, view userid, si32 vtmode, twod winsz, xmls app_config, si32 session_id)
+        auto invite(xipc client, view userid, si32 vtmode, eccc usrcfg, xmls app_config, si32 session_id)
         {
             if (selected_item.size()) app_config.set("/config/menu/selected", selected_item);
             auto lock = netxs::events::unique_lock();
@@ -2156,10 +2155,10 @@ namespace netxs::app::vtm
             {
                 user->rebuild_scene(*this, true);
             };
-            auto appcfg = eccc{ .cmd = utf::concat(user->id, ";", user->props.os_user_id, ";", user->props.selected) };
-            auto deskmenu = app::shared::builder(app::desk::id)(appcfg, app_config);
+            usrcfg.cfg = utf::concat(user->id, ";", user->props.os_user_id, ";", user->props.selected);
+            auto deskmenu = app::shared::builder(app::desk::id)(usrcfg, app_config);
             user->attach(deskmenu);
-            user->base::resize(winsz);
+            user->base::resize(usrcfg.win);
             if (vport) user->base::moveto(vport); // Restore user's last position.
             lock.unlock();
             user->launch();

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1911,7 +1911,7 @@ namespace netxs::app::vtm
                     gear.owner.SIGNAL(tier::preview, hids::events::keybd::focus::set, seed);
                 }
             };
-            LISTEN(tier::release, scripting::events::invoke, script)
+            LISTEN(tier::release, scripting::events::invoke, onecmd)
             {
                 //todo unify
                 static auto vtm_selected = "vtm.selected("sv;
@@ -1922,7 +1922,7 @@ namespace netxs::app::vtm
                 static auto vtm_exit = "vtm.exit("sv;
                 static auto vtm_close = "vtm.close("sv;
                 static auto vtm_shutdown = "vtm.shutdown("sv;
-                auto shadow = utf::trim(view{ script.cmd }, "\r\n\t ");
+                auto shadow = utf::trim(view{ onecmd.cmd }, "\r\n\t ");
                 auto cmd = shadow;
                 auto expression = [](auto prefix, auto& cmd)
                 {
@@ -1948,14 +1948,14 @@ namespace netxs::app::vtm
                 else if (expression(vtm_dtvt, cmd))
                 {
                     auto appspec = desk::spec{ .hidden = true, .type = app::dtvt::id };
-                    appspec.appcfg.env = script.env;
-                    appspec.appcfg.cwd = script.cwd;
+                    appspec.appcfg.env = onecmd.env;
+                    appspec.appcfg.cwd = onecmd.cwd;
                     appspec.appcfg.cmd = cmd;
                     appspec.title = cmd;
                     appspec.label = cmd;
                     appspec.notes = cmd;
                     this->SIGNAL(tier::request, desk::events::exec, appspec);
-                    script.cmd = appspec.appcfg.cmd;
+                    onecmd.cmd = appspec.appcfg.cmd;
                 }
                 else if (expression(vtm_set, cmd))
                 {
@@ -1968,7 +1968,7 @@ namespace netxs::app::vtm
                     auto menuid = itemptr->take(attr::id, ""s);
                     if (menuid.empty())
                     {
-                        script.cmd = "skip: 'id=' not specified.";
+                        onecmd.cmd = "skip: 'id=' not specified.";
                     }
                     else
                     {
@@ -1980,7 +1980,7 @@ namespace netxs::app::vtm
                             stat = true;
                         }
                         dbase.menu[menuid] = appspec;
-                        script.cmd = "ok";
+                        onecmd.cmd = "ok";
                         this->SIGNAL(tier::release, desk::events::apps, dbase.apps_ptr);
                     }
                 }
@@ -1998,7 +1998,7 @@ namespace netxs::app::vtm
                             }
                         }
                         dbase.menu.clear();
-                        script.cmd = "ok";
+                        onecmd.cmd = "ok";
                         this->SIGNAL(tier::release, desk::events::apps, dbase.apps_ptr);
                     }
                     else
@@ -2013,12 +2013,12 @@ namespace netxs::app::vtm
                                 else              stat = faux;
                             }
                             dbase.menu.erase(menuid);
-                            script.cmd = "ok";
+                            onecmd.cmd = "ok";
                             this->SIGNAL(tier::release, desk::events::apps, dbase.apps_ptr);
                         }
                         else
                         {
-                            script.cmd = "skip: 'id=" + menuid + "' not found.";
+                            onecmd.cmd = "skip: 'id=" + menuid + "' not found.";
                         }
                     }
                 }
@@ -2042,8 +2042,8 @@ namespace netxs::app::vtm
                         if (menuid.empty()) menuid = shadow;
                         hall::loadspec(appspec, appspec, *itemptr, menuid);
                     }
-                    appspec.appcfg.env += script.env;
-                    if (appspec.appcfg.cwd.empty()) appspec.appcfg.cwd = script.cwd;
+                    appspec.appcfg.env += onecmd.env;
+                    if (appspec.appcfg.cwd.empty()) appspec.appcfg.cwd = onecmd.cwd;
                     auto title = appspec.title.empty() && appspec.label.empty() ? appspec.menuid
                                : appspec.title.empty() ? appspec.label
                                : appspec.label.empty() ? appspec.title : ""s;
@@ -2051,18 +2051,18 @@ namespace netxs::app::vtm
                     if (appspec.label.empty()) appspec.label = title;
                     if (appspec.notes.empty()) appspec.notes = appspec.menuid;
                     this->SIGNAL(tier::request, desk::events::exec, appspec);
-                    script.cmd = appspec.appcfg.cmd;
+                    onecmd.cmd = appspec.appcfg.cmd;
                 }
                 else if (expression(vtm_selected, cmd))
                 {
                     auto menuid = text{ cmd };
                     if (menuid.empty())
                     {
-                        script.cmd = "skip: id required.";
+                        onecmd.cmd = "skip: id required.";
                     }
                     else
                     {
-                        script.cmd = menuid;
+                        onecmd.cmd = menuid;
                         selected_item = menuid;
                         for (auto user : dbase.usrs)
                         {
@@ -2070,7 +2070,7 @@ namespace netxs::app::vtm
                         }
                     }
                 }
-                else log(prompt::repl, utf::debase<faux, faux>(script.cmd));
+                else log(prompt::repl, utf::debase<faux, faux>(onecmd.cmd));
             };
         }
 


### PR DESCRIPTION
Changes
- Try to unify command line parsing (issues with quotes), #551
- Implement `vtm --script <body>` option, #544
  The `vtm --script <body>` option allows the specified script <body> to be run after the vtm is ready to accept user input.

### Example

bash (run vtm client, wipe taskbar menu, and run two terminals)
```
vtm --script "vtm.del()\nvtm.run()\nvtm.run()"
```

Closes #551