### PR TITLE
Fix line splitting in scripts

### DIFF
--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -613,12 +613,7 @@ namespace netxs::app::desk
                     {
                         usrcfg.win = {};
                         usrcfg.hid = gear.id;
-                        auto script = std::move(usrcfg.cmd);
-                        utf::split<true>(utf::dequote(script), '\n', [&](auto onecmd)
-                        {
-                            usrcfg.cmd = onecmd;
-                            boss.RISEUP(tier::release, scripting::events::invoke, usrcfg);
-                        });
+                        boss.RISEUP(tier::release, scripting::events::invoke, usrcfg);
                         oneshot->reset();
                     };
                 };

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.60";
+    static const auto version = "v0.9.61";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1561,7 +1561,7 @@ namespace netxs::utf
         }
         return utf8;
     }
-    auto dequote(view utf8)
+    auto dequote(qiew utf8)
     {
         if (utf8.size() > 1) 
         {

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -216,7 +216,7 @@ int main(int argc, char* argv[])
         {
             if (reply.size() && os::dtvt::vtmode & ui::console::redirio)
             {
-                os::io::send(utf::concat(reply, "\n"));
+                os::io::send(reply);
             }
             --result;
         }};
@@ -224,7 +224,7 @@ int main(int argc, char* argv[])
         auto active = flag{ faux };
         auto locker = std::mutex{};
         auto syncio = std::unique_lock{ locker };
-        auto buffer = utf::split<true, std::list<text>>(utf::dequote(script), '\n');
+        auto buffer = std::list{ script };
         auto stream = sptr<os::ipc::socket>{};
         auto readln = os::tty::readline([&](auto line)
         {
@@ -456,7 +456,7 @@ int main(int argc, char* argv[])
         auto settings = config.utf8();
         auto execline = [&](qiew line){ domain->SIGNAL(tier::release, scripting::events::invoke, onecmd, ({ .cmd = line })); };
         auto shutdown = [&]{ domain->SIGNAL(tier::general, e2::shutdown, msg, (utf::concat(prompt::main, "Shutdown on signal"))); };
-        utf::split<true>(utf::dequote(script), '\n', execline);
+        execline(script);
         auto readline = os::tty::readline(execline, shutdown);
         while (auto user = server->meet())
         {


### PR DESCRIPTION
Changes
- Fix line splitting, #555

You can now run multiple commands on one line, as well as set multi-line window titles:

```
vtm --script "vtm.run(title='Line1 \nLine2' cmd=cmd); vtm.run(title='Second Window' cmd=cmd)"
```

Closes #555