### PR TITLE
Fix vtty applet defaults

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -102,6 +102,7 @@ Repeat    | Selects the next label and exec the function specified by the `actio
 
 Value                        | Description
 -----------------------------|------------
+TerminalCwdSync              | Current working directory sync toggle.
 TerminalSelectionMode        | Set terminal text selection mode. The `data=` attribute can have the following values `none`, `text`, `ansi`, `rich`, `html`, `protected`.
 TerminalWrapMode             | Set terminal scrollback lines wrapping mode. Applied to the active selection if it is. The `data=` attribute can have the following values `on`, `off`.
 TerminalAlignMode            | Set terminal scrollback lines aligning mode. Applied to the active selection if it is. The `data=` attribute can have the following values `left`, `right`, `center`.

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 ---
 
-vtm is a text-based desktop environment that runs console applications in floating windows and allows remote access via tunnel protocols such as SSH.
+vtm is a text-based desktop environment that runs console applications in floating windows and allows remote access over tunnelling protocols such as SSH.
 
 # Supported platforms
 

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -23,6 +23,7 @@ namespace netxs::events::userland
                 EVENT_XS( align    , si32 ),
                 EVENT_XS( wrapln   , si32 ),
                 EVENT_XS( io_log   , bool ),
+                EVENT_XS( cwdsync  , bool ),
                 GROUP_XS( selection, si32 ),
                 GROUP_XS( colors   , rgba ),
 
@@ -42,6 +43,7 @@ namespace netxs::events::userland
                 EVENT_XS( align    , si32 ),
                 EVENT_XS( wrapln   , si32 ),
                 EVENT_XS( io_log   , bool ),
+                EVENT_XS( cwdsync  , bool ),
                 GROUP_XS( selection, si32 ),
                 GROUP_XS( colors   , rgba ),
 
@@ -195,6 +197,7 @@ namespace netxs::app::terminal
             #define proc_list \
                 X(Noop                      ) /* */ \
                 X(TerminalQuit              ) /* */ \
+                X(TerminalCwdSync           ) /* */ \
                 X(TerminalFullscreen        ) /* */ \
                 X(TerminalRestart           ) /* */ \
                 X(TerminalSendKey           ) /* */ \
@@ -503,6 +506,18 @@ namespace netxs::app::terminal
                         _update_to(boss, item, state);
                     };
                 }
+                static void TerminalCwdSync(ui::item& boss, menu::item& item)
+                {
+                    item.reindex([](auto& utf8){ return xml::take<bool>(utf8).value(); });
+                    _submit(boss, item, [](auto& boss, auto& item, auto& /*gear*/)
+                    {
+                        boss.SIGNAL(tier::anycast, preview::cwdsync, item.views[item.taken].value);
+                    });
+                    boss.LISTEN(tier::anycast, release::cwdsync, state)
+                    {
+                        _update_to(boss, item, state);
+                    };
+                }
                 static void TerminalLogStart(ui::item& /*boss*/, menu::item& /*item*/)
                 {
 
@@ -622,32 +637,8 @@ namespace netxs::app::terminal
         }
     }
 
-    auto ui_term_events = [](ui::term& boss, eccc& appcfg, xmls& config)
+    auto ui_term_events = [](ui::term& boss, eccc& appcfg)
     {
-        auto cwd_sync_ptr = ptr::shared<os::fs::path>();
-        auto& cwd_sync = *cwd_sync_ptr;
-        auto cwdmacro = config.take("/config/term/cwdsync", ""s);
-        boss.LISTEN(tier::preview, e2::form::prop::cwd, path, -, (cwd_sync_ptr))
-        {
-            if (cwd_sync != path)
-            {
-                boss.template expire<tier::preview>(true);
-                cwd_sync = path;
-            }
-        };
-        if (cwdmacro.size())
-        {
-            boss.LISTEN(tier::anycast, e2::form::prop::cwd, path, -, (cwdmacro))
-            {
-                if (cwd_sync != path)
-                {
-                    cwd_sync = path;
-                    auto cmd = cwdmacro;
-                    utf::replace_all(cmd, "$P", path);
-                    boss.data_out(cmd);
-                }
-            };
-        }
         boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, fast)
         {
             boss.SIGNAL(tier::preview, e2::form::proceed::quit::one, fast);
@@ -771,7 +762,7 @@ namespace netxs::app::terminal
             ->colors(def_fcolor, def_bcolor)
             ->invoke([&](auto& boss)
             {
-                ui_term_events(boss, appcfg, config);
+                ui_term_events(boss, appcfg);
             });
         layers->attach(app::shared::scroll_bars(scroll));
         return window;
@@ -834,7 +825,39 @@ namespace netxs::app::terminal
 
         if (appcfg.cmd.empty()) appcfg.cmd = os::env::shell();//todo revise + " -i";
         auto inst = scroll->attach(ui::term::ctor(config))
-                          ->plugin<pro::focus>(pro::focus::mode::focused);
+            ->plugin<pro::focus>(pro::focus::mode::focused)
+            ->invoke([&](auto& boss)
+            {
+                auto cwd_sync_ptr = ptr::shared<bool>();
+                auto cwd_path_ptr = ptr::shared<os::fs::path>();
+                auto& cwd_sync = *cwd_sync_ptr;
+                auto& cwd_path = *cwd_path_ptr;
+                boss.LISTEN(tier::anycast, terminal::events::preview::cwdsync, state)
+                {
+                    cwd_sync = state;
+                    boss.SIGNAL(tier::anycast, terminal::events::release::cwdsync, state);
+                };
+                boss.LISTEN(tier::preview, e2::form::prop::cwd, path, -, (cwd_sync_ptr, cwd_path_ptr))
+                {
+                    if (cwd_sync)
+                    {
+                        boss.template expire<tier::preview>(true);
+                        cwd_path = path;
+                    }
+                };
+                boss.LISTEN(tier::anycast, e2::form::prop::cwd, path)
+                {
+                    if (cwd_sync && path.size() && cwd_path != path)
+                    {
+                        cwd_path = path;
+                        auto cwd = cwd_path.string();
+                        auto spc = cwd.find(' ') != text::npos;
+                        auto cmd = spc ? "cd \"" + cwd + "\"\n"
+                                       : "cd "   + cwd + "\n";
+                        boss.data_out(cmd);
+                    }
+                };
+            });
         auto sb = layers->attach(ui::fork::ctor());
         auto vt = sb->attach(slot::_2, ui::grip<axis::Y>::ctor(scroll));
         static constexpr auto drawfx = [](auto& boss, auto& canvas, auto handle, auto /*object_len*/, auto handle_len, auto region_len, auto wide)
@@ -930,7 +953,7 @@ namespace netxs::app::terminal
             ->attach_property(ui::term::events::search::status,  terminal::events::search::status)
             ->invoke([&](auto& boss)
             {
-                ui_term_events(boss, appcfg, config);
+                ui_term_events(boss, appcfg);
             });
         return window;
     };

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -834,8 +834,12 @@ namespace netxs::app::terminal
                 auto& cwd_path = *cwd_path_ptr;
                 boss.LISTEN(tier::anycast, terminal::events::preview::cwdsync, state)
                 {
-                    cwd_sync = state;
-                    boss.SIGNAL(tier::anycast, terminal::events::release::cwdsync, state);
+                    if (cwd_sync != state)
+                    {
+                        cwd_sync = state;
+                        boss.SIGNAL(tier::anycast, terminal::events::release::cwdsync, state);
+                        if (cwd_sync) boss.data_out("\n"); // Trigger command prompt reprint.
+                    }
                 };
                 boss.LISTEN(tier::preview, e2::form::prop::cwd, path, -, (cwd_sync_ptr, cwd_path_ptr))
                 {

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -849,11 +849,14 @@ namespace netxs::app::terminal
                 {
                     if (cwd_sync && path.size() && cwd_path != path)
                     {
+                        auto old = cwd_path.root_name().string();
                         cwd_path = path;
+                        auto drv = cwd_path.root_name().string();
+                        auto cmd = old != drv ? drv + "\n" : text{};
                         auto cwd = cwd_path.string();
                         auto spc = cwd.find(' ') != text::npos;
-                        auto cmd = spc ? "cd \"" + cwd + "\"\n"
-                                       : "cd "   + cwd + "\n";
+                        cmd += spc ? "cd \"" + cwd + "\"\n"
+                                   : "cd "   + cwd + "\n";
                         boss.data_out(cmd);
                     }
                 };

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -297,6 +297,13 @@ namespace netxs::app::tile
                         {
                             pro::focus::set(boss.This(), gear.id, pro::focus::solo::on, pro::focus::flip::off);
                         };
+                        boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent)
+                        {
+                            parent->LISTEN(tier::anycast, e2::form::prop::cwd, path, boss.relyon)
+                            {
+                                boss.SIGNAL(tier::anycast, e2::form::prop::cwd, path);
+                            };
+                        };
                     })
                     ->branch(slot::_1, ui::postfx<cell::shaders::contrast>::ctor()
                         ->upload(what.header)
@@ -821,6 +828,10 @@ namespace netxs::app::tile
                             gate.SIGNAL(tier::release, e2::data::changed, menuid); // Set current  default;
                         }
                         oneoff.reset();
+                    };
+                    boss.LISTEN(tier::preview, e2::form::prop::cwd, path)
+                    {
+                        boss.SIGNAL(tier::anycast, e2::form::prop::cwd, path);
                     };
                 });
 

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -146,10 +146,11 @@ namespace netxs::ansi
     static const auto osc_label        = "1"   ; // Set icon label.
     static const auto osc_title        = "2"   ; // Set title.
     static const auto osc_xprop        = "3"   ; // Set xprop.
+    static const auto osc_set_palette  = "4"   ; // Set 256 colors palette.
     static const auto osc_linux_color  = "P"   ; // Set 16 colors palette. (Linux console)
     static const auto osc_linux_reset  = "R"   ; // Reset 16/256 colors palette. (Linux console)
-    static const auto osc_set_palette  = "4"   ; // Set 256 colors palette.
     static const auto osc_clipboard    = "52"  ; // Set clipboard.
+    static const auto osc_term_notify  = "9"   ; // Terminal notifications.
     static const auto osc_set_fgcolor  = "10"  ; // Set fg color.
     static const auto osc_set_bgcolor  = "11"  ; // Set bg color.
     static const auto osc_reset_color  = "104" ; // Reset color N to default palette. Without params all palette reset.

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.64";
+    static const auto version = "v0.9.65";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -413,6 +413,7 @@ namespace netxs::events::userland
                     EVENT_XS( fullscreen, ui::sptr   ), // set fullscreen app.
                     EVENT_XS( viewport  , rect       ), // request: return form actual viewport.
                     EVENT_XS( lucidity  , si32       ), // set or request window transparency, si32: 0-255, -1 to request.
+                    EVENT_XS( cwd       , text       ), // riseup:preview->anycast: current working directory.
                     GROUP_XS( window    , twod       ), // set or request window properties.
                     GROUP_XS( ui        , text       ), // set or request textual properties.
                     GROUP_XS( colors    , rgba       ), // set or request bg/fg colors.

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -236,6 +236,11 @@ namespace netxs::ui
                 auto& item = lock.thing;
                 notify<tier::anycast>(e2::form::prop::colors::fg, item.color);
             }
+            void handle(s11n::xs::cwd         lock)
+            {
+                auto& path = lock.thing.path;
+                notify<tier::anycast>(e2::form::prop::cwd, path);
+            }
             void handle(s11n::xs::slimmenu    lock)
             {
                 auto& item = lock.thing;
@@ -1380,6 +1385,10 @@ namespace netxs::ui
                 LISTEN(tier::preview, e2::config::fps, fps, tokens)
                 {
                     conio.fps.send(canal, fps);
+                };
+                LISTEN(tier::preview, e2::form::prop::cwd, path, tokens)
+                {
+                    conio.cwd.send(canal, path);
                 };
                 LISTEN(tier::preview, hids::events::mouse::button::click::any, gear, tokens)
                 {

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -847,6 +847,7 @@ namespace netxs::directvt
         STRUCT_macro(fgc,               (rgba, color))
         STRUCT_macro(slimmenu,          (bool, menusize))
         STRUCT_macro(init,              (text, user) (si32, mode) (text, env) (text, cwd) (text, cmd) (text, cfg) (twod, win))
+        STRUCT_macro(cwd,               (text, path))
 
         #undef STRUCT_macro
         #undef STRUCT_macro_lite
@@ -1357,7 +1358,8 @@ namespace netxs::directvt
             X(bgc              ) /* Set background color.                         */\
             X(fgc              ) /* Set foreground color.                         */\
             X(slimmenu         ) /* Set window menu size.                         */\
-            X(init             ) /* Startup data.                                 */
+            X(init             ) /* Startup data.                                 */\
+            X(cwd              ) /* CWD Notification.                             */
             //X(quit             ) /* Close and disconnect dtvt app.                */
             //X(focus            ) /* Request to set focus.                         */
 

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -342,8 +342,8 @@ int main(int argc, char* argv[])
         else
         {
             params = " "s + params;
-            aptype = app::vtty::id;
-            apname = app::vtty::name;
+            aptype = app::teletype::id;
+            apname = app::teletype::name;
         }
         log("%appname% %version%", apname, app::shared::version);
         params = utf::remain(params, ' ');

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1506,6 +1506,16 @@ namespace netxs::app::vtm
                             boss.SIGNAL(tier::release, e2::form::state::maximized, owner_id);
                         }
                     };
+
+                    boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent_ptr)
+                    {
+                        auto& parent = *parent_ptr;
+                        parent.LISTEN(tier::preview, e2::form::prop::cwd, path, boss.relyon)
+                        {
+                            boss.SIGNAL(tier::anycast, e2::form::prop::cwd, path);
+                            parent.template expire<tier::preview>(true);
+                        };
+                    };
                 });
         }
         auto create(link& what)

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1513,7 +1513,6 @@ namespace netxs::app::vtm
                         parent.LISTEN(tier::preview, e2::form::prop::cwd, path, boss.relyon)
                         {
                             boss.SIGNAL(tier::anycast, e2::form::prop::cwd, path);
-                            parent.template expire<tier::preview>(true);
                         };
                     };
                 });

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -253,7 +253,7 @@ R"==(
             <layout = QWERTY/>  <!-- Not implemented. QWERTY, AZERTY, Dvorak, etc. -->
         </keyboard>
     </client>
-    <term cwdsync="">       <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
+    <term>       <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
         <scrollback>
             <size=40000    />   <!-- Initial scrollback buffer length. -->
             <growstep=0    />   <!-- Scrollback buffer grow step. The buffer behaves like a ring in case of zero. -->
@@ -349,6 +349,9 @@ R"==(
                 </label>
                 <label="\e[38:2:0:255:255mHTML-code\e[m" data="html"/>
                 <label="\e[38:2:0:255:255mProtected\e[m" data="protected"/>
+            </item>
+            <item label="Sync" notes=" CWD sync is off " type=Option action=TerminalCwdSync data="off">
+                <label="\e[38:2:0:255:0mSync\e[m" notes=" CWD sync is on " data="on"/>
             </item>
             <item label="Log" notes=" Console logging is off " type=Option action=TerminalStdioLog data="off">
                 <label="\e[38:2:0:255:0mLog\e[m" notes=" Console logging is on   \n Run Logs to see output  " data="on"/>

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -253,7 +253,7 @@ R"==(
             <layout = QWERTY/>  <!-- Not implemented. QWERTY, AZERTY, Dvorak, etc. -->
         </keyboard>
     </client>
-    <term>      <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
+    <term cwdsync="">       <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
         <scrollback>
             <size=40000    />   <!-- Initial scrollback buffer length. -->
             <growstep=0    />   <!-- Scrollback buffer grow step. The buffer behaves like a ring in case of zero. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -351,7 +351,7 @@ R"==(
                 <label="\e[38:2:0:255:255mProtected\e[m" data="protected"/>
             </item>
             <item label="Sync" notes=" CWD sync is off " type=Option action=TerminalCwdSync data="off">
-                <label="\e[38:2:0:255:0mSync\e[m" notes=" CWD sync is on " data="on"/>
+                <label="\e[38:2:0:255:0mSync\e[m" notes=" CWD sync is on                          \n Make sure your shell has OSC9;9 enabled " data="on"/>
             </item>
             <item label="Log" notes=" Console logging is off " type=Option action=TerminalStdioLog data="off">
                 <label="\e[38:2:0:255:0mLog\e[m" notes=" Console logging is on   \n Run Logs to see output  " data="on"/>


### PR DESCRIPTION
Changes
- Fix vtty applet defaults, #562
- Add experimental synchronization of the current working directory for all terminal windows with the "Sync" switch enabled.
  Shell `CWD Sync` activation (OSC9;9):
  - Windows Command Prompt:
  ```
  PROMPT $e]9;9;$P$e\$P$G
  ```
  - PowerShell:
  ```
  function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }
  ```
  - Bash:
  ```
  export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
  ```

Closes #562