### PR TITLE
Force cmd.exe's `cd` to always change drive

### DIFF
--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -857,6 +857,7 @@ namespace netxs::app::terminal
                         cwd_path = path;
                         auto drv = cwd_path.root_name().string();
                         auto cmd = old != drv ? drv + "\n" : text{};
+                        //auto cmd = (drv.size() && old != drv) ? drv + " && " : text{};
                         auto cwd = cwd_path.string();
                         auto spc = cwd.find(' ') != text::npos;
                         cmd += spc ? "cd \"" + cwd + "\"\n"

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -853,15 +853,11 @@ namespace netxs::app::terminal
                 {
                     if (cwd_sync && path.size() && cwd_path != path)
                     {
-                        auto old = cwd_path.root_name().string();
                         cwd_path = path;
-                        auto drv = cwd_path.root_name().string();
-                        auto cmd = old != drv ? drv + "\n" : text{};
-                        //auto cmd = (drv.size() && old != drv) ? drv + " && " : text{};
                         auto cwd = cwd_path.string();
                         auto spc = cwd.find(' ') != text::npos;
-                        cmd += spc ? "cd \"" + cwd + "\"\n"
-                                   : "cd "   + cwd + "\n";
+                        auto cmd = spc ? "cd \"" + cwd + "\"\n"
+                                       : "cd "   + cwd + "\n";
                         boss.data_out(cmd);
                     }
                 };

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.65";
+    static const auto version = "v0.9.66";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1342,7 +1342,7 @@ namespace netxs::utf
         {
             auto c = *head;
                  if (delims.find(c) != view::npos) break;
-            else if (c == '\\' && head != tail) ++head;
+            else if (c == '\\' && ++head == tail) break;
             ++head;
         }
         return head;
@@ -1354,7 +1354,7 @@ namespace netxs::utf
         {
             auto c = *head;
                  if (delim == c) break;
-            else if (c == '\\' && head != tail) ++head;
+            else if (c == '\\' && ++head == tail) break;
             ++head;
         }
         return head;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -280,7 +280,7 @@ R"==(
             <color13 = magentalt  />
             <color14 = cyanlt     />
             <color15 = whitelt    />
-            <default bgc=pureblack fgc=whitelt />  <!-- Initial colors. -->
+            <default bgc=pureblack fgc=whitedk />  <!-- Initial colors. -->
             <match fx=color bgc="0xFF007F00" fgc=whitelt/>  <!-- Color of the selected text occurrences. Set fx to use cell::shaders: xlight | color | invert | reverse -->
             <selection>
                 <text fx=color bgc=bluelt fgc=whitelt/>  <!-- Highlighting of the selected text in plaintext mode. -->


### PR DESCRIPTION
Changes
- Force the cmd.exe's `cd` to always change the drive:
  ```
  C:\Temp> cd d:\temp
  d:\temp> _
  ```