### PR TITLE
Fix focus by LeftClick on window menu

### DIFF
--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -838,7 +838,7 @@ namespace netxs::app::terminal
                     {
                         cwd_sync = state;
                         boss.SIGNAL(tier::anycast, terminal::events::release::cwdsync, state);
-                        if (cwd_sync) boss.data_out("\n"); // Trigger command prompt reprint.
+                        if (cwd_sync) boss.data_out("cd .\n"); // Trigger command prompt reprint.
                     }
                 };
                 boss.LISTEN(tier::preview, e2::form::prop::cwd, path, -, (cwd_sync_ptr, cwd_path_ptr))

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -838,7 +838,7 @@ namespace netxs::app::terminal
                     {
                         cwd_sync = state;
                         boss.SIGNAL(tier::anycast, terminal::events::release::cwdsync, state);
-                        if (cwd_sync) boss.data_out("cd .\n"); // Trigger command prompt reprint.
+                        if (cwd_sync) boss.data_out(" cd .\n"); // Trigger command prompt reprint.
                     }
                 };
                 boss.LISTEN(tier::preview, e2::form::prop::cwd, path, -, (cwd_sync_ptr, cwd_path_ptr))
@@ -856,8 +856,8 @@ namespace netxs::app::terminal
                         cwd_path = path;
                         auto cwd = cwd_path.string();
                         auto spc = cwd.find(' ') != text::npos;
-                        auto cmd = spc ? "cd \"" + cwd + "\"\n"
-                                       : "cd "   + cwd + "\n";
+                        auto cmd = spc ? " cd \"" + cwd + "\"\n"
+                                       : " cd "   + cwd + "\n";
                         boss.data_out(cmd);
                     }
                 };

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -176,7 +176,7 @@ namespace netxs::app::terminal
                     {
                         if (item.brand == menu::item::Option) _update_gear(boss, item, gear);
                     }
-                    gear.dismiss(true);
+                    gear.nodbl = true;
                 };
             }
         };

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -390,7 +390,7 @@ namespace netxs::app::tile
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                     {
                         boss.RISEUP(tier::request, e2::form::proceed::createby, gear);
-                        gear.dismiss(true);
+                        gear.nodbl = true;
                     };
                 }},
                 { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "│", .notes = " Split horizontally " }}},
@@ -399,7 +399,7 @@ namespace netxs::app::tile
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                     {
                         boss.RISEUP(tier::release, app::tile::events::ui::split::hz, gear);
-                        gear.dismiss(true);
+                        gear.nodbl = true;
                     };
                 }},
                 { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "──", .notes = " Split vertically " }}},
@@ -408,7 +408,7 @@ namespace netxs::app::tile
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                     {
                         boss.RISEUP(tier::release, app::tile::events::ui::split::vt, gear);
-                        gear.dismiss(true);
+                        gear.nodbl = true;
                     };
                 }},
                 { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "×", .notes = " Delete pane ", .hover = c1 }}},
@@ -418,7 +418,7 @@ namespace netxs::app::tile
                     {
                         auto backup = boss.This();
                         boss.RISEUP(tier::release, e2::form::proceed::quit::one, true);
-                        gear.dismiss(true);
+                        gear.nodbl = true;
                     };
                 }},
             });
@@ -845,16 +845,6 @@ namespace netxs::app::tile
                         // ┌────┐  ┌────┐  ┌─┬──┐  ┌────┐  ┌─┬──┐  ┌─┬──┐  ┌────┐  // ┌─┐  ┌─┬─┐  ┌─┬─┐  ┌─┬─┐  
                         // │Exec│  ├─┐  │  │ H  │  ├ V ─┤  │Swap│  │Fair│  │Shut│  // ├─┤  └─┴─┘  └<┴>┘  └>┴<┘  
                         // └────┘  └─┴──┘  └─┴──┘  └────┘  └─┴──┘  └─┴──┘  └────┘  // └─┘                       
-                        //{ menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " ┐└ ", .notes = " Maximize/restore active pane " }}},
-                        //[](auto& boss, auto& item)
-                        //{
-                        //    boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
-                        //    {
-                        //        gear.countdown = 1;
-                        //        boss.SIGNAL(tier::anycast, app::tile::events::ui::toggle, gear);
-                        //        gear.dismiss(true);
-                        //    };
-                        //}},
                         { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " + ", .notes = " Launch application instances in active empty slots.     \n"
                                                                                                                                    " The app to run can be set by RightClick on the taskbar. " }}},
                         [](auto& boss, auto& /*item*/)
@@ -862,7 +852,7 @@ namespace netxs::app::tile
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                             {
                                 boss.SIGNAL(tier::anycast, app::tile::events::ui::create, gear);
-                                gear.dismiss(true);
+                                gear.nodbl = true;
                             };
                         }},
                         { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = ":::", .notes = " Select all panes " }}},
@@ -871,7 +861,7 @@ namespace netxs::app::tile
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                             {
                                 boss.SIGNAL(tier::anycast, app::tile::events::ui::select, gear);
-                                gear.dismiss(true);
+                                gear.nodbl = true;
                             };
                         }},
                         { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " │ ", .notes = " Split active panes horizontally " }}},
@@ -880,7 +870,7 @@ namespace netxs::app::tile
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                             {
                                 boss.SIGNAL(tier::anycast, app::tile::events::ui::split::hz, gear);
-                                gear.dismiss(true);
+                                gear.nodbl = true;
                             };
                         }},
                         { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "──", .notes = " Split active panes vertically " }}},
@@ -889,7 +879,7 @@ namespace netxs::app::tile
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                             {
                                 boss.SIGNAL(tier::anycast, app::tile::events::ui::split::vt, gear);
-                                gear.dismiss(true);
+                                gear.nodbl = true;
                             };
                         }},
                         { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "┌┘", .notes = " Change split orientation " }}},
@@ -898,7 +888,7 @@ namespace netxs::app::tile
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                             {
                                 boss.SIGNAL(tier::anycast, app::tile::events::ui::rotate, gear);
-                                gear.dismiss(true);
+                                gear.nodbl = true;
                             };
                         }},
                         { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "<->", .notes = " Swap two or more panes " }}},
@@ -907,7 +897,7 @@ namespace netxs::app::tile
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                             {
                                 boss.SIGNAL(tier::anycast, app::tile::events::ui::swap, gear);
-                                gear.dismiss(true);
+                                gear.nodbl = true;
                             };
                         }},
                         { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = ">|<", .notes = " Equalize split ratio " }}},
@@ -916,7 +906,7 @@ namespace netxs::app::tile
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                             {
                                 boss.SIGNAL(tier::anycast, app::tile::events::ui::equalize, gear);
-                                gear.dismiss(true);
+                                gear.nodbl = true;
                             };
                         }},
                         { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "\"…\"", .notes = " Set tiling manager window title using clipboard data " }}},
@@ -925,6 +915,7 @@ namespace netxs::app::tile
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                             {
                                 app::shared::set_title(boss, gear);
+                                gear.nodbl = true;
                             };
                         }},
                         { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "×", .notes = " Close active app ", .hover = c1 }}},
@@ -933,7 +924,7 @@ namespace netxs::app::tile
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                             {
                                 boss.SIGNAL(tier::anycast, app::tile::events::ui::close, gear);
-                                gear.dismiss(true);
+                                gear.nodbl = true;
                             };
                         }},
                     });

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -107,7 +107,6 @@ namespace netxs::app::shared
                 gear.set_clipboard(dot_00, old_title, mime::ansitext);
             }
         }
-        gear.dismiss(true);
     };
 
     using builder_t = std::function<ui::sptr(eccc, xmls&)>;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.66";
+    static const auto version = "v0.9.67";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -641,14 +641,16 @@ struct impl : consrv
         {
             static constexpr auto cd_prefix = "cd "sv;
             static constexpr auto cd_forced = "cd/d ";
+            auto shadow = qiew{ line };
+            utf::trim_front(shadow);
             if (exe.starts_with("cmd")
-             && line.size() > cd_prefix.size()
-             && line.back() != '\t')
+             && shadow.size() > cd_prefix.size()
+             && shadow.back() != '\t')
             {
-                auto prefix = line.substr(0, 3);
+                auto prefix = shadow.substr(0, 3).str();
                 utf::to_low(prefix);
                 if (prefix != cd_prefix) return;
-                auto crop = qiew{ line }.substr(cd_prefix.size());
+                auto crop = shadow.substr(cd_prefix.size());
                 auto path = crop;
                 utf::trim_front(path, " \t\r\n");
                 if (path && path.front() != '/')

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -227,9 +227,9 @@ struct impl : consrv
         auto done(para& line)
         {
             auto& new_data = line.content();
-            auto trimmed = utf::trim(new_data.utf8(), whitespaces);
-
-            if (trimmed.size() && (data.empty() || data.back() != new_data))
+            if (new_data.size().x  // Don't save space prefixed commands in history.
+            && !new_data.peek(dot_00).isspc()
+            && (data.empty() || data.back() != new_data))
             {
                 data.push_back(new_data);
                 seek = data.size() - 1;

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -6230,6 +6230,7 @@ namespace netxs::ui
             {
                 static constexpr auto cwdsync = "9"sv;
                 auto type = data.substr(0, delimpos++);
+                if (io_log) log("\tOSC %%;%type% notify: ", ansi::osc_term_notify, type, ansi::hi(utf::debase<faux, faux>(data.substr(delimpos))));
                 if (type == cwdsync)
                 {
                     auto path = text{ data.substr(delimpos) };


### PR DESCRIPTION
Changes
- Fix focus by LeftClick on window menu.
- Use the `cd` command with a space prefix to avoid command history when synching cwd.
- Don't save space prefixed commands in cmd.exe history.
- Log OSC9;9 notifications.