### PR TITLE
Make CWD sync configurable via settings

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -102,7 +102,7 @@ Repeat    | Selects the next label and exec the function specified by the `actio
 
 Value                        | Description
 -----------------------------|------------
-TerminalCwdSync              | Current working directory sync toggle.
+TerminalCwdSync              | Current working directory sync toggle. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. <br>To enable OSC9;9 shell notifications:<br>- Windows Command Prompt:<br>  `setx PROMPT $e]9;9;$P$e\$P$G`<br>- PowerShell:<br>  `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }`<br>- Bash:<br>  `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '`
 TerminalSelectionMode        | Set terminal text selection mode. The `data=` attribute can have the following values `none`, `text`, `ansi`, `rich`, `html`, `protected`.
 TerminalWrapMode             | Set terminal scrollback lines wrapping mode. Applied to the active selection if it is. The `data=` attribute can have the following values `on`, `off`.
 TerminalAlignMode            | Set terminal scrollback lines aligning mode. Applied to the active selection if it is. The `data=` attribute can have the following values `left`, `right`, `center`.

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -415,6 +415,7 @@ Note: Hardcoded settings are built from the [/src/vtm.xml](../src/vtm.xml) sourc
         <regions enabled=0 />             <!-- Highlight UI objects boundaries. -->
     </client>
     <term>      <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
+        <cwdsync=" cd $P\n"/>   <!-- Command to sync the current working directory. When 'Sync' is active, $P (case sensitive) will be replaced with the current path received via OSC9;9 notification. Prefixed with a space to avoid touching command history. -->
         <scrollback>
             <size=40000    />   <!-- Scrollback buffer length. -->
             <growstep=0    />   <!-- Scrollback buffer grow step. The buffer behaves like a ring in case of zero. -->

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.67";
+    static const auto version = "v0.9.68";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -254,6 +254,7 @@ R"==(
         </keyboard>
     </client>
     <term>       <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
+        <cwdsync=" cd $P\n"/>   <!-- Command to sync the current working directory. When 'Sync' is active, $P (case sensitive) will be replaced with the current path received via OSC9;9 notification. Prefixed with a space to avoid touching command history. -->
         <scrollback>
             <size=40000    />   <!-- Initial scrollback buffer length. -->
             <growstep=0    />   <!-- Scrollback buffer grow step. The buffer behaves like a ring in case of zero. -->


### PR DESCRIPTION
Changes
- Make the CWD sync command template configurable via settings:
  ```xml
  <config>
    <term>
      <cwdsync=" cd $P\n"/>
    </term>
  </config>
  ```
  Now it is possible to configure the cwdsync command template, for example, make it without prefixed whitespace to be compatible with Far Manager (https://github.com/FarGroup/FarManager/issues/798):
  pwsh:
  ```
  "vtm.run(id=Term cfg='<config><term cwdsync=`"cd `$P\n`"/></config>')" | vtm
  ```