### PR TITLE
Enable OSC 9;9 notifications for cmd.exe by default

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.68";
+    static const auto version = "v0.9.69";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3589,8 +3589,7 @@ namespace netxs::os
                 ok(::GetConsoleTitleW(wstr.data(), size), "::GetConsoleTitleW(vtmode)", os::unexpected);
                 dtvt::backup.title = wstr.data();
                 ok(::GetConsoleCursorInfo(os::stdout_fd, &dtvt::backup.caret), "::GetConsoleCursorInfo()", os::unexpected);
-                auto cmd_prompt = os::env::get("PROMPT");
-                if (cmd_prompt.empty() || cmd_prompt == "$P$G")
+                if (auto cmd_prompt = os::env::get("PROMPT"); cmd_prompt.empty() || cmd_prompt == "$P$G")
                 {
                     os::env::set("PROMPT", "$e]9;9;$P$e\\$P$G"); // Enable OSC 9;9 notifications for cmd.exe by default.
                 }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3589,6 +3589,11 @@ namespace netxs::os
                 ok(::GetConsoleTitleW(wstr.data(), size), "::GetConsoleTitleW(vtmode)", os::unexpected);
                 dtvt::backup.title = wstr.data();
                 ok(::GetConsoleCursorInfo(os::stdout_fd, &dtvt::backup.caret), "::GetConsoleCursorInfo()", os::unexpected);
+                auto cmd_prompt = os::env::get("PROMPT");
+                if (cmd_prompt.empty() || cmd_prompt == "$P$G")
+                {
+                    os::env::set("PROMPT", "$e]9;9;$P$e\\$P$G"); // Enable OSC 9;9 notifications for cmd.exe by default.
+                }
 
             #else
 


### PR DESCRIPTION
Changes
- Enable OSC 9;9 notifications for cmd.exe by default:
  If PROMPT is empty or equals "$P$G" set it to:
  ```
  PROMPT="$e]9;9;$P$e\$P$G"
  ```