### PR TITLE
Add support for semantic markers (OSC 133)

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -22,15 +22,21 @@
 - Horizontal scrolling
 - Infinite* scrollback (40k lines by default, * `< max_int32`)
 - Scrollback buffer searching and matching
-- Line-based/rect-block text selection (See #149 for details)
-- Widely used clipboard formats support
+- Line-based/rect-block text selection:
+  - Ctrl: Extend selection.
+  - Alt/Option: Change selection mode (line/block).
+  - Double left click: Select a word.
+  - Triple left click: Select paragraph.
+  - Quadruple left click: Select the entire scrollback buffer or semantic block (when using OSC 133).
+  - Quintuple left click: Select the entire scrollback buffer.
+- Widely used clipboard formats support:
   - Plain text
   - RTF
   - HTML
   - ANSI/VT
   - Protected (Windows only: `ExcludeClipboardContentFromMonitorProcessing`, `CanIncludeInClipboardHistory`, `CanUploadToCloudClipboard`)
 - [VT-100 terminal emulation](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html) compatible (pass vttest 1 and 2 sections)
-- Built-in Windows Console API server
+- Built-in Windows Console API server:
   - Legacy Win32 Console API support
   - No Windows Console Host (conhost.exe) dependency
   - Fullduplex pass-through VT input/output

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -778,7 +778,7 @@ namespace netxs::app::terminal
         auto cB = menu_white;
 
         auto window = ui::cake::ctor();
-        window->plugin<pro::focus>(os::dtvt::active ? pro::focus::mode::hub : pro::focus::mode::focusable)
+        window->plugin<pro::focus>(pro::focus::mode::hub)
             ->plugin<pro::track>()
             ->plugin<pro::acryl>()
             ->plugin<pro::cache>();

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -156,6 +156,7 @@ namespace netxs::ansi
     static const auto osc_reset_color  = "104" ; // Reset color N to default palette. Without params all palette reset.
     static const auto osc_reset_fgclr  = "110" ; // Reset fg color to default.
     static const auto osc_reset_bgclr  = "111" ; // Reset bg color to default.
+    static const auto osc_semantic_fx  = "133" ; // Semantic markers (shell integration).
     static const auto osc_title_report = "l"   ; // Get terminal window title.
     static const auto osc_label_report = "L"   ; // Get terminal window icon label.
 
@@ -1667,7 +1668,7 @@ namespace netxs::ansi
         {
             if (auto len = cooked.size().x)
             {
-                cooked.each([&](cell& c) { c.meta(brush); });
+                cooked.each([&](cell& c){ c.meta(brush); });
                 data(len, cooked.pick());
             }
         }

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.72";
+    static const auto version = "v0.9.73";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1910,6 +1910,11 @@ namespace netxs
               client{ dot_00, { length, 1 } },
               canvas( length, fill )
         { }
+        core(cell const& fill)
+            : region{ dot_00, dot_01 },
+              client{ dot_00, dot_01 },
+              marker{ fill }
+        { }
 
         template<class P>
         auto same(core const& c, P compare) const // core: Compare content.
@@ -2150,6 +2155,31 @@ namespace netxs
                 else                       target = canvas;
             }
             return region.size;
+        }
+        template<feed Direction>
+        auto seek(si32& x, auto proc) // core: Find proc(c) == true.
+        {
+            if (!region) return faux;
+            static constexpr auto rev = Direction == feed::fwd ? faux : true;
+            x += rev ? 1 : 0;
+            auto count = 0;
+            auto found = faux;
+            auto width = (rev ? 0 : region.size.x) - x;
+            auto field = rect{ twod{ x, 0 } + region.coor, { width, 1 }}.normalize();
+            auto allfx = [&](auto& c)
+            {
+                if (proc(c))
+                {
+                    found = true;
+                    return true;
+                }
+                count++;
+                return faux;
+            };
+            netxs::onrect<rev>(*this, field, allfx);
+            if (count) count--;
+            x -= rev ? count + 1 : -count;
+            return found;
         }
         template<feed Direction>
         auto word(twod coord) // core: Detect a word bound.

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2079,7 +2079,7 @@ namespace netxs
             netxs::zoomin(*this, block, fuse);
         }
         template<class P>
-        void plot(core const& block, P fuse) // core: Fill view by the specified block using its coordinates inside canvas area.
+        void plot(core const& block, P fuse) // core: Fill view by the specified block with coordinates inside the canvas area.
         {
             auto local = rect{ client.coor - region.coor, client.size };
             auto joint = local.clip(block.region);

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -467,6 +467,7 @@ namespace netxs::ui
                 vtmode = legacy_mode & ui::console::nt16   ? svga::nt16
                        : legacy_mode & ui::console::vt16   ? svga::vt16
                        : legacy_mode & ui::console::vt256  ? svga::vt256
+                       : legacy_mode & ui::console::gui    ? svga::dtvt
                        : legacy_mode & ui::console::direct ? svga::dtvt
                                                            : svga::vtrgb;
             }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1106,7 +1106,7 @@ struct impl : consrv
             auto mode = testy<bool>{ !!(server.inpmod & nt::console::inmode::insert) };
             auto buff = text{};
             auto nums = utfx{};
-            auto line = para{ cooked.ustr };
+            auto line = para{ 'C', cooked.ustr }; // Set semantic marker OSC 133;C.
             auto done = faux;
             auto crlf = 0;
             auto burn = [&]

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -4451,7 +4451,7 @@ struct impl : consrv
     }
     auto api_window_font_get                 ()
     {
-        log(prompt, "GetCurrentConsoleFont");
+        log(prompt, "GetCurrentConsoleFontEx");
         struct payload : drvpacket<payload>
         {
             struct

--- a/src/netxs/desktopio/generics.hpp
+++ b/src/netxs/desktopio/generics.hpp
@@ -437,11 +437,14 @@ namespace netxs::generics
         {
             Ring& buff;
             si32  addr;
-            iter(Ring& buff, si32 addr)
+
+            constexpr iter(iter const&) = default;
+            constexpr iter(Ring& buff, si32 addr)
               : buff{ buff },
                 addr{ addr }
             { }
-            auto  operator =  (iter const& i)       { assert(&i.buff == &buff); addr = i.addr; return *this;              }
+
+            auto& operator =  (iter const& i)       { assert(&i.buff == &buff); addr = i.addr; return *this;              }
             auto  operator -  (si32 n)        const {      return iter<Ring>{ buff, buff.mod(addr - n) };                 }
             auto  operator +  (si32 n)        const {      return iter<Ring>{ buff, buff.mod(addr + n) };                 }
             auto  operator ++ (int)                 { auto temp = iter<Ring>{ buff, addr }; buff.inc(addr); return temp;  }

--- a/src/netxs/desktopio/generics.hpp
+++ b/src/netxs/desktopio/generics.hpp
@@ -441,6 +441,7 @@ namespace netxs::generics
               : buff{ buff },
                 addr{ addr }
             { }
+            auto  operator =  (iter const& i)       { assert(&i.buff == &buff); addr = i.addr; return *this;              }
             auto  operator -  (si32 n)        const {      return iter<Ring>{ buff, buff.mod(addr - n) };                 }
             auto  operator +  (si32 n)        const {      return iter<Ring>{ buff, buff.mod(addr + n) };                 }
             auto  operator ++ (int)                 { auto temp = iter<Ring>{ buff, addr }; buff.inc(addr); return temp;  }

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -811,13 +811,21 @@ namespace netxs::input
                                         {
                                             fire(dblclick, i);
                                             s.fired = fired;
-                                            s.count = 2;
+                                            s.count++;
                                         }
-                                        else if (s.count == 2)
+                                        else if (s.count >= 2)
                                         {
                                             fire(tplclick, i);
-                                            s.fired = {};
-                                            s.count = {};
+                                            if (s.count == 4) // Limit to quintuple click.
+                                            {
+                                                s.fired = {};
+                                                s.count = {};
+                                            }
+                                            else
+                                            {
+                                                s.fired = fired;
+                                                s.count++;
+                                            }
                                         }
                                     }
                                 }
@@ -845,6 +853,12 @@ namespace netxs::input
                 m_sys.hzwheel = {};
                 m_sys.wheeldt = {};
             }
+        }
+        // mouse: Return the number of clicks for the specified button.
+        auto clicks(si32 button)
+        {
+            button = std::clamp(button, 0, buttons::numofbuttons - 1);
+            return stamp[button].count + 1;
         }
         // mouse: Initiator of visual tree informing about mouse enters/leaves.
         template<bool Entered>

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1044,9 +1044,10 @@ namespace netxs::ui
         { }
         virtual ~para() = default;
 
-        para              (auto utf8) {              ansi::parse(utf8, this);               }
-        auto& operator  = (auto utf8) { wipe(brush); ansi::parse(utf8, this); return *this; }
-        auto& operator += (auto utf8) {              ansi::parse(utf8, this); return *this; }
+        para(id_t id, auto utf8)      { brush.link(id); ansi::parse(utf8, this);               }
+        para(auto utf8)               {                 ansi::parse(utf8, this);               }
+        auto& operator  = (auto utf8) { wipe(brush);    ansi::parse(utf8, this); return *this; }
+        auto& operator += (auto utf8) {                 ansi::parse(utf8, this); return *this; }
 
         operator writ const& () const { return locus; }
 

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3630,7 +3630,7 @@ namespace netxs::os
                 ok(::GetConsoleCursorInfo(os::stdout_fd, &dtvt::backup.caret), "::GetConsoleCursorInfo()", os::unexpected);
                 if (auto cmd_prompt = os::env::get("PROMPT"); cmd_prompt.empty() || cmd_prompt == "$P$G")
                 {
-                    os::env::set("PROMPT", "$e]9;9;$P$e\\$P$G"); // Enable OSC 9;9 notifications for cmd.exe by default.
+                    os::env::set("PROMPT", "$e]133;A$e\\$e]9;9;$P$e\\$e[#{$e[97m$P$G$e[#}$e]133;B$e\\"); // Enable OSC 9;9 notifications for cmd.exe by default.
                 }
 
             #else

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4441,17 +4441,20 @@ namespace netxs::os
                     auto& bitmap = lock.thing;
                     if (os::dtvt::vtmode & ui::console::gui)
                     {
-                        auto update = [](auto size, auto head, auto iter, auto tail)
-                        {
-                            #if defined(_WIN32)
-                                auto offset = (si32)(iter - head);
-                                auto coor = twod{ offset % size.x, offset / size.x };
-                                //todo update client area
-                            #else
-                                //todo update client area
-                            #endif
-                        };
-                        bitmap.get(data, update);
+                        //todo gui-bridge
+                        //auto update = [](auto size, auto head, auto iter, auto tail)
+                        //{
+                        //    #if defined(_WIN32)
+                        //        auto offset = (si32)(iter - head);
+                        //        auto coor = twod{ offset % size.x, offset / size.x };
+                        //        //todo update client area
+                        //    #else
+                        //        auto offset = (si32)(iter - head);
+                        //        auto coor = twod{ offset % size.x, offset / size.x };
+                        //        //todo update client area
+                        //    #endif
+                        //};
+                        //bitmap.get(data, update);
                     }
                     else
                     {

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3493,7 +3493,7 @@ namespace netxs::os
             else
             {
                 dtvt::win_sz = dtvt::consize();
-                //trygui = faux; // Not implemented.
+                trygui = faux; //todo Not implemented.
                 if (trygui)
                 {
                     #if defined(_WIN32)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -841,6 +841,7 @@ namespace netxs::ui
                 vt.oscer[osc_reset_bgclr] = V{ p->owner.ctrack.set(osc_reset_bgclr, q); };
                 vt.oscer[osc_clipboard  ] = V{ p->owner.forward_clipboard(q);           };
                 vt.oscer[osc_term_notify] = V{ p->owner.osc_notify(q);                  };
+                vt.oscer[osc_semantic_fx] = V{ p->owner.osc_marker(q);                  };
                 #undef V
 
                 // Log all unimplemented CSI commands.
@@ -884,23 +885,24 @@ namespace netxs::ui
                     l._kind = {};
                 }
                 line(line const& l)
-                    : rich { l       },
-                      index{ l.index },
-                      style{ l.style }
-                { }
-                line(id_t line_id, deco const& line_style = {})
-                    : index{ line_id },
-                      style{ line_style }
+                    : rich{ l       },
+                     index{ l.index },
+                     style{ l.style }
                 { }
                 line(id_t line_id, deco const& line_style, span dt, twod sz)
-                    : rich { dt, sz },
-                      index{ line_id },
-                      style{ line_style }
+                    : rich{ dt, sz     },
+                     index{ line_id    },
+                     style{ line_style }
+                { }
+                line(id_t line_id, deco const& line_style, cell const& blank)
+                    : rich{ blank      },
+                     index{ line_id    },
+                     style{ line_style }
                 { }
                 line(id_t line_id, deco const& line_style, cell const& blank, si32 length)
-                    : rich { blank, length },
-                      index{ line_id },
-                      style{ line_style }
+                    : rich{ blank, length },
+                     index{ line_id       },
+                     style{ line_style    }
                 { }
                 line(core&& s)
                     : rich{ std::forward<core>(s) }
@@ -1008,6 +1010,8 @@ namespace netxs::ui
             virtual void selection_follow(twod coor, bool lock)           = 0;
             virtual void selection_byword(twod coor)                      = 0;
             virtual void selection_byline(twod coor)                      = 0;
+            virtual void selection_bymark(twod coor)                      = 0;
+            virtual void selection_selall()                               = 0;
             virtual text selection_pickup(si32 selmod)                    = 0;
             virtual void selection_render(face& dest)                     = 0;
             virtual void selection_status(term_state& status) const       = 0;
@@ -2440,7 +2444,7 @@ namespace netxs::ui
                 selection_selbox(faux);
                 selection_update(faux);
             }
-            // alt_screen: Select one line.
+            // alt_screen: Select line.
             void selection_byline(twod coor) override
             {
                 seltop.y = selend.y = coor.y;
@@ -2449,6 +2453,21 @@ namespace netxs::ui
                 selection_locked(faux);
                 selection_selbox(faux);
                 selection_update(faux);
+            }
+            // alt_screen: Select all.
+            void selection_selall() override
+            {
+                seltop.y = 0;
+                seltop.x = 0;
+                selend = panel - dot_11;
+                selection_locked(faux);
+                selection_selbox(true);
+                selection_update(faux);
+            }
+            // alt_screen: Select lines between OSC marks.
+            void selection_bymark(twod /*coor*/) override
+            {
+                selection_selall();
             }
             // alt_screen: Take selected data.
             text selection_pickup(si32 selmod) override
@@ -2777,7 +2796,7 @@ namespace netxs::ui
                     caret = 0;
                     basis = 0;
                     slide = 0;
-                    invite(0, deco{}.wrp(auto_wrap)); // At least one line must exist.
+                    invite(0, deco{}.wrp(auto_wrap), cell{}); // At least one line must exist.
                     ancid = back().index;
                     ancdy = 0;
                     set_width(width);
@@ -2817,7 +2836,7 @@ namespace netxs::ui
                        shore{ boss.config.def_margin }
             {
                 parser::style.wrp(boss.config.def_wrpmod);
-                batch.invite(0, deco{}.wrp(boss.config.def_wrpmod == wrap::on)); // At least one line must exist.
+                batch.invite(0, deco{}.wrp(boss.config.def_wrpmod == wrap::on), cell{}); // At least one line must exist.
                 batch.set_width(1);
                 index_rebuild();
 
@@ -3678,7 +3697,7 @@ namespace netxs::ui
                     do
                     {
                         auto& curln = *head;
-                        block.output(curln);
+                        block.output(curln, cell::shaders::fuse);
                         block.nl(1);
                     }
                     while (++head != tail);
@@ -3703,7 +3722,7 @@ namespace netxs::ui
                         {
                             auto count = arena - index.size;
                             auto curid = batch.back().index;
-                            while (count-- > 0) batch.invite(++curid, parser::style);
+                            while (count-- > 0) batch.invite(++curid, parser::style, parser::brush);
                             start = batch.size;
                         }
                     }
@@ -3751,7 +3770,7 @@ namespace netxs::ui
                     if (old_sctop == 0) upbox.mark(brush.spare);
                     upbox.crop<faux>(upmin);
                     pull(upbox, { 0, old_sctop }, 0, delta_top);
-                    if (batch.size == 0) batch.invite(0, parser::style);
+                    if (batch.size == 0) batch.invite(0, parser::style, parser::brush);
                 }
                 else
                 {
@@ -3772,7 +3791,7 @@ namespace netxs::ui
                 auto line_id = batch.back().index;
                 while (amount-- > 0)
                 {
-                    batch.invite(++line_id, parser::style);
+                    batch.invite(++line_id, parser::style, parser::brush);
                     index.push_back(line_id, 0, 0);
                 }
             }
@@ -4499,7 +4518,7 @@ namespace netxs::ui
                     auto height = curln.height(panel.x);
                     auto length = curln.length();
                     auto adjust = curln.style.jet();
-                    dest.output(curln, coor);
+                    dest.output(curln, coor, cell::shaders::fuse);
                     //dest.output_proxy(curln, coor, [&](auto const& coord, auto const& subblock, auto isr_to_l)
                     //{
                     //    dest.text(coord, subblock, isr_to_l, cell::shaders::fusefull);
@@ -4601,7 +4620,7 @@ namespace netxs::ui
             {
                 assert(test_futures());
 
-                auto blank = brush.dry();
+                auto blank = brush.dry().link(parser::brush.link());
                 auto clear = [&](twod coor)
                 {
                     auto& from = index[coor.y];
@@ -4739,7 +4758,7 @@ namespace netxs::ui
                 {
                     auto after = batch.index_by_id(curid);
                     auto tmpln = std::move(batch[after]);
-                    auto curit = batch.ring::insert(after + 1, tmpln.index, tmpln.style);
+                    auto curit = batch.ring::insert(after + 1, tmpln.index, tmpln.style, parser::brush);
                     auto endit = batch.end();
 
                     auto& newln = *curit;
@@ -4844,7 +4863,7 @@ namespace netxs::ui
                         batch.remove(start, range);
 
                         // Insert block.
-                        while (count-- > 0) batch.insert(floor, id_t{}, parser::style);
+                        while (count-- > 0) batch.insert(floor, id_t{}, parser::style, parser::brush);
 
                         batch.reindex(start); //todo revise ? The index may be outdated due to the ring.
                         index_rebuild();
@@ -4881,7 +4900,7 @@ namespace netxs::ui
                         batch.remove(floor, range);
 
                         // Insert block.
-                        while (count-- > 0) batch.insert(start, id_t{}, parser::style);
+                        while (count-- > 0) batch.insert(start, id_t{}, parser::style, parser::brush);
 
                         batch.reindex(start); //todo revise ? The index may be outdated due to the ring.
                     }
@@ -5386,7 +5405,7 @@ namespace netxs::ui
                 selection_selbox(faux);
                 selection_update(faux);
             }
-            // scroll_buf: Select one line.
+            // scroll_buf: Select line.
             void selection_byline(twod coor) override
             {
                 auto scrolling_margin = batch.slide + y_top;
@@ -5409,7 +5428,6 @@ namespace netxs::ui
                     upend.role = dnend.role = grip::idle;
                     upmid = selection_coor_to_grip(coor, grip::base);
                     dnmid = upmid;
-                    upmid.coor = dot_00;
                     auto& curln = batch.item_by_id(upmid.link);
                     auto limit = std::max(0, curln.length() - 1);
                     upmid.coor = offset_to_screen(curln, 0);
@@ -5426,6 +5444,119 @@ namespace netxs::ui
                     dnend = upend;
                     upend.coor.x = 0;
                     dnend.coor.x = panel.x - 1;
+                }
+                selection_locked(faux);
+                selection_selbox(faux);
+                selection_update(faux);
+            }
+            // scroll_buf: Select all (ignore non-scrolling regions).
+            void selection_selall() override
+            {
+                place = part::mid;
+                uptop.role = dntop.role = grip::idle;
+                upend.role = dnend.role = grip::idle;
+                auto& topln = batch.front();
+                auto& endln = batch.back();
+                auto x = std::max(0, endln.length() - 1);
+                upmid = { .link = topln.index, .coor = offset_to_screen(topln, 0), .role = grip::base};
+                dnmid = { .link = endln.index, .coor = offset_to_screen(endln, x), .role = grip::base};
+                selection_locked(faux);
+                selection_selbox(faux);
+                selection_update(faux);
+            }
+            // scroll_buf: Select lines between OSC marks.
+            void selection_bymark(twod coor) override
+            {
+                auto scrolling_margin = batch.slide + y_top;
+                if (coor.y < scrolling_margin) // Inside the top margin.
+                {
+                    place = part::top;
+                    upmid.role = dnmid.role = grip::idle;
+                    upend.role = dnend.role = grip::idle;
+                    uptop.role = grip::base;
+                    uptop.coor = {-owner.origin.x, 0 };
+                    dntop = uptop;
+                    uptop.coor.x = 0;
+                    dntop.coor.x = panel.x - 1;
+                    dntop.coor.y += y_top;
+                }
+                else if (coor.y < scrolling_margin + arena) // Inside the scrolling region.
+                {
+                    upmid = selection_coor_to_grip(coor, grip::base);
+                    dnmid = upmid;
+                    auto curit = batch.iter_by_id(upmid.link);
+                    auto& line = *curit;
+                    auto start = screen_to_offset(line, upmid.coor);
+                    auto group = line.empty() ? line.link() : line.at(start).link();
+                    auto check = [&](auto& c){ return c.link() != group; };
+                    if (!group) // Semantic markers are not used.
+                    {
+                        selection_selall();
+                    }
+                    else
+                    {
+                        place = part::mid;
+                        auto offup = start;
+                        auto offdn = start;
+                        auto up_rc = line.seek<feed::rev>(offup, check);
+                        auto dn_rc = line.seek<feed::fwd>(offdn, check);
+                        if (up_rc) // We are inside the command line.
+                        {
+                            upmid.coor = offset_to_screen(line, offup);
+                            dnmid.coor = offset_to_screen(line, offdn);
+                        }
+                        else // We are inside the output or prompt.
+                        {
+                            auto head = batch.begin();
+                            auto tail = batch.end();
+                            auto iter = curit;
+                            upmid.link = batch.front().index;
+                            while (head != iter)
+                            {
+                                auto& curln = *--iter;
+                                auto found = curln.empty() ? curln.link() != group : !curln.each(check);
+                                if (found)
+                                {
+                                    upmid.link = curln.index + 1;
+                                    break;
+                                }
+                            }
+                            if (!dn_rc)
+                            {
+                                auto& backln = batch.back();
+                                dnmid.link = backln.index;
+                                iter = curit;
+                                while (tail != ++iter)
+                                {
+                                    auto& curln = *iter;
+                                    auto found = curln.empty() ? curln.link() != group : !curln.each(check);
+                                    if (found)
+                                    {
+                                        dnmid.link = curln.index - 1;
+                                        break;
+                                    }
+                                }
+                            }
+                            auto& upline = batch.item_by_id(upmid.link);
+                            auto& dnline = batch.item_by_id(dnmid.link);
+                            upmid.coor = offset_to_screen(upline, 0);
+                            dnmid.coor = offset_to_screen(dnline, dn_rc ? offdn : (dnline.empty() ? 0 : dnline.length() - 1));
+                        }
+                        uptop.role = dntop.role = grip::idle;
+                        upend.role = dnend.role = grip::idle;
+                    }
+                }
+                else // Inside the bottom margin.
+                {
+                    place = part::end;
+                    upmid.role = dnmid.role = grip::idle;
+                    uptop.role = dntop.role = grip::idle;
+                    upend.role = grip::base;
+                    upend.coor = {-owner.origin.x, 0 };
+                    dnend = upend;
+                    upend.coor.x = 0;
+                    dnend.coor.x = panel.x - 1;
+                    dnend.coor.y += scend;
                 }
                 selection_locked(faux);
                 selection_selbox(faux);
@@ -6222,6 +6353,13 @@ namespace netxs::ui
         hook       onerun; // term: One-shot token for restart session.
         vtty       ipccon; // term: IPC connector. Should be destroyed first.
 
+        // term: Set semantic marker (OSC 133).
+        void osc_marker(view data)
+        {
+            auto type = data.size() ? data.front() : 0;
+            if (io_log) log("\tOSC %% semantic marker: %type%", ansi::osc_semantic_fx, type ? type : '-');
+            target->brush.link(type);
+        }
         // term: Terminal notification (OSC 9).
         void osc_notify(view data)
         {
@@ -6828,7 +6966,10 @@ namespace netxs::ui
         }
         void selection_tplclk(hids& gear)
         {
-            target->selection_byline(gear.coord);
+            auto clicks = gear.clicks(hids::buttons::left);
+                 if (clicks == 3) target->selection_byline(gear.coord);
+            else if (clicks == 4) target->selection_bymark(gear.coord);
+            else if (clicks == 5) target->selection_selall();
             gear.dismiss();
             base::expire<tier::release>();
             base::deface();
@@ -6981,28 +7122,34 @@ namespace netxs::ui
         void set_color(cell brush)
         {
             //todo remove base::color dependency (background is colorized twice! use transparent target->brush)
+            auto& console = *target;
             brush.link(base::id);
             base::color(brush);
-            target->brush.reset(brush);
+            brush.link(console.brush.link());
+            console.brush.reset(brush);
         }
         void set_bg_color(rgba bg)
         {
             //todo remove base::color dependency (background is colorized twice! use transparent target->brush)
+            auto& console = *target;
             auto brush = base::color();
             brush.bgc(bg);
             brush.link(base::id);
             base::color(brush);
-            target->brush.reset(brush);
+            brush.link(console.brush.link());
+            console.brush.reset(brush);
             SIGNAL(tier::release, ui::term::events::colors::bg, bg);
         }
         void set_fg_color(rgba fg)
         {
             //todo remove base::color dependency (background is colorized twice! use transparent target->brush)
+            auto& console = *target;
             auto brush = base::color();
             brush.fgc(fg);
             brush.link(base::id);
             base::color(brush);
-            target->brush.reset(brush);
+            brush.link(console.brush.link());
+            console.brush.reset(brush);
             SIGNAL(tier::release, ui::term::events::colors::fg, fg);
         }
         void set_wrapln(si32 wrapln)


### PR DESCRIPTION
Changes
- Fix standalone terminal focus, #575
- Render colored whitespaces instead of shaded block glyphs "▓▒░".
- Add support for selecting semantically (OSC 133) homogeneous blocks with the mouse (4x left-click).
- Add semantic markers for cmd.exe by default (OSC 133).
- Built-in terminal/teletype: Change the multiple left click behavior:
  - Double left click: Select a word.
  - Triple left click: Select paragraph.
  - Quadruple left click: Select the entire scrollback buffer or semantic block (when using OSC 133).
  - Quintuple left click: Select the entire scrollback buffer.
  
Closes #574
Closes #575