### PR TITLE
Implement one-shot toggle to copy text

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -116,7 +116,6 @@ Repeat    | Selects the next label and exec the function specified by the `actio
 Value                        | Description
 -----------------------------|------------
 TerminalCwdSync              | Current working directory sync toggle. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. <br>To enable OSC9;9 shell notifications:<br>- Windows Command Prompt:<br>  `setx PROMPT $e]9;9;$P$e\$P$G`<br>- PowerShell:<br>  `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }`<br>- Bash:<br>  `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '`
-TerminalSelectionMode        | Set terminal text selection mode. The `data=` attribute can have the following values `none`, `text`, `ansi`, `rich`, `html`, `protected`.
 TerminalWrapMode             | Set terminal scrollback lines wrapping mode. Applied to the active selection if it is. The `data=` attribute can have the following values `on`, `off`.
 TerminalAlignMode            | Set terminal scrollback lines aligning mode. Applied to the active selection if it is. The `data=` attribute can have the following values `left`, `right`, `center`.
 TerminalFindNext             | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
@@ -130,9 +129,11 @@ TerminalUndo                 | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discar
 TerminalRedo                 | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
 TerminalClipboardPaste       | Paste from clipboard.
 TerminalClipboardWipe        | Reset clipboard.
+TerminalSelectionMode        | Set terminal text selection mode.<br>The `data=` attribute can have the following values `none`, `text`, `ansi`, `rich`, `html`, `protected`.
 TerminalSelectionCopy        | Сopy selection to clipboard.
 TerminalSelectionRect        | Set linear(false) or rectangular(true) selection form using boolean value.
 TerminalSelectionClear       | Deselect a selection.
+TerminalSelectionOneShot     | One-shot toggle to copy text while mouse tracking is active. Keep selection if `Ctrl` key is pressed.<br>The `data=` attribute can have the following values `none`, `text`, `ansi`, `rich`, `html`, `protected`.
 TerminalViewportCopy         | Сopy viewport to clipboard.
 TerminalViewportPageUp       | Scroll one page up.
 TerminalViewportPageDown     | Scroll one page down.

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.80";
+    static const auto version = "v0.9.81";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -13,6 +13,7 @@ namespace netxs::events::userland
         {
             EVENT_XS( io_log, bool ),
             EVENT_XS( selmod, si32 ),
+            EVENT_XS( onesht, si32 ),
             EVENT_XS( selalt, si32 ),
             GROUP_XS( colors, argb ),
             GROUP_XS( layout, si32 ),
@@ -6387,6 +6388,7 @@ namespace netxs::ui
         flag       resume; // term: Restart scheduled.
         flag       forced; // term: Forced shutdown.
         si32       selmod; // term: Selection mode.
+        si32       onesht; // term: Selection one-shot mode.
         si32       altscr; // term: Alternate scroll mode.
         prot       kbmode; // term: Keyboard input mode.
         escx       w32key; // term: win32-input-mode forward buffer.
@@ -6819,6 +6821,13 @@ namespace netxs::ui
             SIGNAL(tier::release, e2::form::draggable::left, selection_passed());
             SIGNAL(tier::release, ui::term::events::selmod, selmod);
         }
+        // term: Run one-shot selection.
+        void selection_oneshot(si32 newmod)
+        {
+            onesht = newmod;
+            SIGNAL(tier::release, ui::term::events::onesht, onesht);
+            selection_selmod(newmod);
+        }
         // term: Set selection form.
         void selection_selalt(bool boxed)
         {
@@ -6909,7 +6918,9 @@ namespace netxs::ui
             {
                 _copy(gear, data);
             }
-            if (gear.meta(hids::anyCtrl) || selection_cancel()) // Keep selection if Ctrl is pressed.
+            auto ctrl_pressed = gear.meta(hids::anyCtrl);
+            if (onesht != mime::disabled && !ctrl_pressed) selection_oneshot(mime::disabled);
+            if (ctrl_pressed || selection_cancel()) // Keep selection if Ctrl is pressed.
             {
                 base::expire<tier::release>();
                 return true;
@@ -7216,6 +7227,10 @@ namespace netxs::ui
         {
             selection_selmod(mode);
         }
+        void set_oneshot(si32 mode)
+        {
+            selection_oneshot(mode);
+        }
         void set_selalt(bool boxed)
         {
             selection_selalt(boxed);
@@ -7414,6 +7429,7 @@ namespace netxs::ui
               resume{  faux },
               forced{  faux },
               selmod{ config.def_selmod },
+              onesht{ mime::disabled },
               altscr{ config.def_altscr },
               kbmode{ prot::vt }
         {
@@ -7427,6 +7443,7 @@ namespace netxs::ui
             selection_submit();
             publish_property(ui::term::events::io_log,         [&](auto& v){ v = io_log; });
             publish_property(ui::term::events::selmod,         [&](auto& v){ v = selmod; });
+            publish_property(ui::term::events::onesht,         [&](auto& v){ v = onesht; });
             publish_property(ui::term::events::selalt,         [&](auto& v){ v = selalt; });
             publish_property(ui::term::events::colors::bg,     [&](auto& v){ v = target->brush.bgc(); });
             publish_property(ui::term::events::colors::fg,     [&](auto& v){ v = target->brush.fgc(); });


### PR DESCRIPTION
Changes
- Implement one-shot toggle to copy text while mouse tracking is active. #588

New configurable menu button:
Action                     | Description
---------------------------|------------
`TerminalSelectionOneShot` | One-shot toggle to copy text while mouse tracking is active. Keep selection if `Ctrl` key is pressed.<br>The `data=` attribute can have the following values `none`, `text`, `ansi`, `rich`, `html`, `protected`.

Closes #588

### Configuration example (settings.xml)
```xml
<config>
  <term>
    <item label=" HTML " data=none type=Option action=TerminalSelectionOneShot>
      <label="\e[48:2:0:128:128;38:2:0:255:255m HTML \e[m" data=html>
        <notes>
          " One-shot toggle to copy as HTML \n"
          " while mouse tracking is active. "
        </notes>
      </label>
    </item>
    <item label=" Text " data=none type=Option action=TerminalSelectionOneShot>
      <label="\e[48:2:0:128:0;38:2:0:255:0m Text \e[m" data=text>
        <notes>
          " One-shot toggle to copy as Text \n"
          " while mouse tracking is active. "
        </notes>
      </label>
    </item>
    <item label="One-Shot" data=none type=Option action=TerminalSelectionOneShot>
      <label="\e[48:2:0:128:0;38:2:0:255:0m  Text  \e[m" data=text>
        <notes>
          " One-shot toggle to copy as Text \n"
          " while mouse tracking is active. "
        </notes>
      </label>
      <label="\e[48:2:0:128:128;38:2:0:255:255m  HTML  \e[m" data=html>
        <notes>
          " One-shot toggle to copy as HTML \n"
          " while mouse tracking is active. "
        </notes>
      </label>
    </item>
  </term>
</config>