### PR TITLE
Allow Copy/Paste by Ctrl/Shift+Insert in cmd.exe

### DIFF
--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -172,6 +172,10 @@
     <td colspan="3">Toggle fullscreen mode</td>
   </tr>
   <tr>
+    <th>Ctrl+CapsLock</th>
+    <td colspan="3">Toggle text antialiasing mode</td>
+  </tr>
+  <tr>
     <th>DblLeftClick</th>
     <td colspan="3">Toggle fullscreen mode (if unhandled)</td>
   </tr>

--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -176,6 +176,10 @@
     <td colspan="3">Toggle text antialiasing mode</td>
   </tr>
   <tr>
+    <th>CapsLock+Up/DownArrow</th>
+    <td colspan="3">Change cell height</td>
+  </tr>
+  <tr>
     <th>DblLeftClick</th>
     <td colspan="3">Toggle fullscreen mode (if unhandled)</td>
   </tr>

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.84";
+    static const auto version = "v0.9.85";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2898,10 +2898,6 @@ namespace netxs::gui
                 sync_kbstat(toUTF8, pressed || repeat, virtcod, scancod, extflag);
             }
             //print_kbstate("key press:");
-            //if (virtcod == 'A' && param.v.state == 3) // Toggle AA mode.
-            //{
-            //    set_aa_mode(!gcache.aamode);
-            //}
             if (pressed)
             {
                 if (kbstate[VK_MENU] & 0x80 && kbstate[VK_RETURN] & 0x80) // Toggle maximized mode by Alt+Enter.
@@ -2911,11 +2907,21 @@ namespace netxs::gui
                         if (fsmode != state::minimized) set_state(fsmode == state::maximized ? state::normal : state::maximized);
                     });
                 }
-                else if (kbstate[VK_CONTROL] & 0x80 && kbstate[VK_CAPITAL] & 0x80) // Toggle antialiasing mode by Ctrl+CapsLock.
+                else if (kbstate[VK_CAPITAL] & 0x80 && kbstate[VK_CONTROL] & 0x80) // Toggle antialiasing mode by Ctrl+CapsLock.
                 {
                     bell::enqueue(This(), [&](auto& /*boss*/)
                     {
                         set_aa_mode(!gcache.aamode);
+                    });
+                }
+                else if (kbstate[VK_CAPITAL] & 0x80 && (kbstate[VK_UP] & 0x80 || kbstate[VK_DOWN] & 0x80)) // Change cell height by CapsLock+Up/DownArrow.
+                {
+                    auto dir = kbstate[VK_UP] & 0x80 ? 1 : -1;
+                    bell::enqueue(This(), [&, dir](auto& /*boss*/)
+                    {
+                        change_cell_size(dir);
+                        netxs::set_flag<task::all>(reload);
+                        update_gui();
                     });
                 }
                 else if (kbstate[VK_HOME] & 0x80 && kbstate[VK_END] & 0x80) // Shutdown by LeftArrow+RightArrow.

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2911,6 +2911,13 @@ namespace netxs::gui
                         if (fsmode != state::minimized) set_state(fsmode == state::maximized ? state::normal : state::maximized);
                     });
                 }
+                else if (kbstate[VK_CONTROL] & 0x80 && kbstate[VK_CAPITAL] & 0x80) // Toggle antialiasing mode by Ctrl+CapsLock.
+                {
+                    bell::enqueue(This(), [&](auto& /*boss*/)
+                    {
+                        set_aa_mode(!gcache.aamode);
+                    });
+                }
                 else if (kbstate[VK_HOME] & 0x80 && kbstate[VK_END] & 0x80) // Shutdown by LeftArrow+RightArrow.
                 {
                     bell::enqueue(This(), [&](auto& /*boss*/)


### PR DESCRIPTION
Changes (Windows platform only):
- Allow to Copy/Paste by `Ctrl/Shift+Insert` in `cmd.exe`.
- GUI window:
  - Allow to toggle antialiasing mode by `Ctrl+CapsLock`.
  - Allow to change cell height by `CapsLock+Up/DownArrow`.
  - Make any resize actions lazy - ignore resize requests if busy.