### PR TITLE
Fix grapheme jumbo-clusters synchronization (like 👨‍👩‍👧‍👦)

### DIFF
--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -206,7 +206,8 @@
   <tr>
     <th>RightDrag</th>
     <td colspan="1"></td>
-    <td colspan="2">Move GUI window</td>
+    <td colspan="1">Move GUI window</td>
+    <td colspan="1"></td>
   </tr>
 </tbody>
 </table>

--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -155,7 +155,7 @@
 </tbody>
 </table>
 
-## GUI mode only
+## GUI mode
 
 <table>
 <thead>
@@ -177,7 +177,11 @@
   </tr>
   <tr>
     <th>CapsLock+Up/DownArrow</th>
-    <td colspan="3">Change cell height</td>
+    <td colspan="3">Change text cell size</td>
+  </tr>
+  <tr>
+    <th>Wheel</th>
+    <td colspan="3">Change text cell size (if unhandled)</td>
   </tr>
   <tr>
     <th>DblLeftClick</th>
@@ -186,10 +190,6 @@
   <tr>
     <th>Home+End</th>
     <td colspan="3">Close GUI window</td>
-  </tr>
-  <tr>
-    <th>Wheel</th>
-    <td colspan="3">Change text cell size (if unhandled)</td>
   </tr>
   <tr>
     <th>AnyDrag<br>Left+RightDrag</th>

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.85";
+    static const auto version = "v0.9.86";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2029,6 +2029,10 @@ namespace netxs
                 template<class C> constexpr inline auto operator () (C brush) const { return func<C>(brush); }
                 template<class D, class S>  inline void operator () (D& dst, S& src) const { dst = src; }
             };
+            struct wipe_t
+            {
+                template<class D>  inline void operator () (D& dst) const { dst = {}; }
+            };
             struct skipnuls_t : public brush_t<skipnuls_t>
             {
                 template<class C> constexpr inline auto operator () (C brush) const { return func<C>(brush); }
@@ -2186,6 +2190,7 @@ namespace netxs
             static constexpr auto     fuse =     fuse_t{};
             static constexpr auto     flat =     flat_t{};
             static constexpr auto     full =     full_t{};
+            static constexpr auto     wipe =     wipe_t{};
             static constexpr auto skipnuls = skipnuls_t{};
             static constexpr auto     text =     text_t{};
             static constexpr auto     meta =     meta_t{};

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -824,7 +824,7 @@ namespace netxs::ui
                         auto visible = (unfocused == blinking) || (blinking && live);
                         auto clip = canvas.core::clip();
                         auto area = clip.trim(body);
-                        if (area)
+                        if (area && form != text_cursor::I_bar)
                         {
                             auto& test = canvas.peek(body.coor);
                             //todo >2x1 matrix support

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -1066,12 +1066,12 @@ namespace netxs::directvt
                             log(prompt::dtvt, "bitmap: ", "Corrupted data, subtype: ", what);
                             break;
                         }
-                        iter = dest;
                         if constexpr (!std::is_same_v<P, noop>)
                         {
-                            update(area.size, head, step, iter);
-                            step = iter;
+                            if (step != iter) update(head, step, iter);
+                            step = dest;
                         }
+                        iter = dest;
                     }
                     else // Unknown subtype.
                     {
@@ -1082,7 +1082,7 @@ namespace netxs::directvt
                 image.mark(mark);
                 if constexpr (!std::is_same_v<P, noop>)
                 {
-                    update(area.size, head, step, iter);
+                    update(head, step, iter);
                 }
                 //log(prompt::dtvt, "frame len: ", frame_len);
                 //log(prompt::dtvt, "nop count: ", nop_count);

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1977,10 +1977,7 @@ namespace netxs::gui
             void handle(s11n::xs::jgc_list         lock)
             {
                 s11n::receive_jgc(lock);
-                //todo repaint jgc cells
-                //todo Trigger to redraw viewport to update jumbo clusters.
-                //todo strike
-                netxs::set_flag<task::all>(owner.reload);
+                netxs::set_flag<task::all>(owner.reload); // Trigger to redraw all to update jumbo clusters.
             }
             void handle(s11n::xs::header_request   lock)
             {

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1973,7 +1973,6 @@ namespace netxs::gui
                     netxs::set_flag<task::inner>(owner.reload);
                     owner.check_blinky();
                 }
-                s11n::request_jgc(intio, lock);
             }
             void handle(s11n::xs::jgc_list         lock)
             {
@@ -3216,6 +3215,7 @@ namespace netxs::gui
                     auto lock = bell::sync();
                     proxy.sync(data);
                     update_gui();
+                    proxy.request_jgc(proxy.intio);
                 };
                 directvt::binary::stream::reading_loop(proxy.intio, sync);
                 proxy.stop(); // Wake up waiting objects, if any.

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2510,10 +2510,15 @@ namespace netxs::gui
             {
                 shadow.render(canvas, r, inner_rect, cell::shaders::alpha);
             });
-            for (auto g_area : { grip_l, grip_r, grip_t, grip_b })
+            if (reload != task::all)
             {
-                //todo push diffs only
-                layer.sync.push_back(g_area);
+                auto coor = layers[client].area.coor;
+                for (auto g_area : { grip_l, grip_r, grip_t, grip_b })
+                {
+                    //todo push diffs only
+                    g_area.coor += coor;
+                    layer.sync.push_back(g_area);
+                }
             }
         }
         template<class T = noop>

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1781,6 +1781,11 @@ namespace netxs::gui
         {
             //...
         }
+        template<class T = noop>
+        void draw_cell(auto& /*canvas*/, rect /*placeholder*/, cell const& /*c*/, T&& /*blinks*/ = {})
+        {
+            //...
+        }
     };
     struct surface : surface_base
     {
@@ -2566,7 +2571,7 @@ namespace netxs::gui
                 placeholder.size.x = width;
                 //todo draw glyph inside the cursor (respect blinking glyphs)
                 //c.fgc(fgcolor).bgc(bgcolor);
-                //draw_cell(canvas, placeholder, c, blinks);
+                //gcache.draw_cell(canvas, placeholder, c, blinks);
                 netxs::onrect(canvas, placeholder, cell::shaders::full(bgcolor));
             }
             else if (style == text_cursor::underline)
@@ -2576,7 +2581,7 @@ namespace netxs::gui
                 placeholder.size.y = width;
                 c.fgc(fgcolor).bgc(bgcolor);
                 //todo draw glyph inside the cursor (respect blinking glyphs)
-                //draw_cell(canvas, placeholder, c, blinks);
+                //gcache.draw_cell(canvas, placeholder, c, blinks);
                 netxs::onrect(canvas, placeholder, cell::shaders::full(bgcolor));
             }
         }

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -848,23 +848,20 @@ namespace netxs
             inbody<faux>(canvas, bitmap, joint, basis, handle, online);
         }
     }
-    // intmath: Intersect two sprite's clips and invoke handle(sprite1_element, sprite2_element) for each elem in the intersection.
+    // intmath: Intersect two sprites and invoke handle(sprite1_element, sprite2_element) for each element in the intersection.
     template<class NewlineFx = noop>
     void onclip(auto&& canvas, auto&& bitmap, auto handle, NewlineFx online = {})
     {
         auto canvas_clip = canvas.clip();
         auto bitmap_area = bitmap.area();
-        //canvas_clip.coor -= bitmap_area.coor;
         if (canvas_clip.trimby(bitmap_area))
         {
             auto basis = canvas_clip.coor - bitmap_area.coor;
+            canvas_clip.coor -= canvas.coor();
             netxs::inbody<faux>(canvas, bitmap, canvas_clip, basis, handle, online);
         }
     }
-
-    // intmath: Draw the rectangle region inside the canvas by
-    //          invoking handle(canvas_element)
-    //          (without boundary checking).
+    // intmath: Draw a rectangular area inside the canvas by calling handle(canvas_element) without checking the bounds.
     template<bool RtoL = faux, class T, class Rect, class P, class NewlineFx = noop, bool Plain = std::is_same_v<void, std::invoke_result_t<P, decltype(*(std::declval<T&>().begin()))>>>
     void onrect(T&& canvas, Rect const& region, P handle, NewlineFx online = {})
     {

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4562,7 +4562,8 @@ namespace netxs::os
                 {
                     auto& bitmap = lock.thing;
                     #if defined(_WIN32)
-                        auto update = [](auto size, auto head, auto iter, auto tail)
+                        auto& size = bitmap.image.size();
+                        auto update = [&](auto head, auto iter, auto tail)
                         {
                             auto offset = (si32)(iter - head);
                             auto mx = std::max(1, size.x);

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -77,7 +77,7 @@
 #define EEET(...) { auto et_start = datetime::now(); \
                     __VA_ARGS__; \
                     auto et_stop = datetime::round<si32, std::chrono::microseconds>(datetime::now() - et_start); \
-                    log("et: ", (et_stop) / 1000.f, " ms\t expr: ", #__VA_ARGS__); }
+                    os::logstd("et: ", (et_stop) / 1000.f, " ms\t expr: ", #__VA_ARGS__); }
 namespace netxs
 {
     struct eccc

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7586,8 +7586,6 @@ namespace netxs::ui
 
             void handle(s11n::xs::bitmap_dtvt         lock)
             {
-                s11n::request_jgc(master, lock);
-                lock.unlock();
                 master.bell::enqueue(master.This(), [&](auto& /*boss*/) mutable
                 {
                     master.base::deface();
@@ -7911,8 +7909,15 @@ namespace netxs::ui
             nodata = {};
             stream.syswinsz.freeze().thing.winsize = {};
             active.exchange(true);
-            ipccon.runapp(config, base::size(), connect, [&](view utf8){ if (active) stream.sync(utf8); },
-                                                         [&]{ onexit(); });
+            auto receiver = [&](view utf8)
+            {
+                if (active)
+                {
+                    stream.sync(utf8);
+                    stream.request_jgc(*this);
+                }
+            };
+            ipccon.runapp(config, base::size(), connect, receiver, [&]{ onexit(); });
         }
         // dtvt: Close dtvt-object.
         void stop(bool fast, bool notify = true)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7509,6 +7509,10 @@ namespace netxs::ui
                     follow[axis::X] = true;
                     follow[axis::Y] = true;
                 }
+                if (gear.keycode == input::key::Esc && !gear.meta(hids::anyCtrl | hids::anyAlt | hids::anyShift))
+                {
+                    selection_cancel();
+                }
                 if (io_log) log(prompt::key, ansi::hi(input::key::map::data(gear.keycode).name));
 
                 ipccon.keybd(gear, decckm, kbmode);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7584,7 +7584,7 @@ namespace netxs::ui
         {
             dtvt& master; // evnt: Terminal object reference.
 
-            void handle(s11n::xs::bitmap_dtvt         lock)
+            void handle(s11n::xs::bitmap_dtvt       /*lock*/)
             {
                 master.bell::enqueue(master.This(), [&](auto& /*boss*/) mutable
                 {


### PR DESCRIPTION
Changes:
- Fix grapheme jumbo-clusters synchronization.
- Optimize rendering performance (only redraw changes).
- Allow to cancel selection by Esc in built-in terminal.
- Fix doubling I-bar cursor over wide characters.