### PR TITLE
Fix extended keys reporting

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -254,6 +254,21 @@ Note: Hardcoded settings are built from the [/src/vtm.xml](../src/vtm.xml) sourc
 
 ```xml
 <config>
+    <gui> <!-- GUI related settings. (win32 platform only for now) -->
+        <antialiasing=off/>   <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
+        <cellheight=20/>      <!-- Text cell height in physical pixels. Note: The width of the text cell depends on the primary font (the first one in the font list). -->
+        <gridsize=0,0/>       <!-- Window initial grid size in text cells. -->
+        <wincoor=0,0/>        <!-- Window initial coordinates (top-left corner on the desktop in physical pixels). -->
+        <winstate=normal/>    <!-- Window initial state: normal | maximized | minimized -->
+        <blinkrate=400ms/>    <!-- SGR5/6 attribute blink rate. Blinking will be disabled when set to zero. -->
+        <fonts> <!-- Font fallback ordered list. The rest of the fonts available in the system will be loaded dynamically. -->
+            <font*/> <!-- Clear previously defined fonts. Start a new list. -->
+            <font="Courier New"/> <!-- The first font in the list: Primary font. Its metrics define the cell geometry. -->
+            <font="Cascadia Mono"/>
+            <font="NSimSun"/>
+            <font="Noto Sans Devanagari"/>
+        </fonts>
+    </gui>
     <menu wide=off selected=Term>  <!-- Set selected using menu item id. -->
         <item*/>  <!-- Use asterisk at the end of the element name to set defaults.
                        Using an asterisk with the parameter name of the first element in the list without any other nested attributes

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -557,7 +557,17 @@ namespace netxs::app::shared
             auto winstate = config.take("winstate", win::state::normal, app::shared::win::options);
             auto aliasing = config.take("antialiasing", faux);
             auto blinking = config.take("blinkrate", span{ 400ms });
-            auto fontlist = utf::split<true, std::list<text>>(config.take("fontlist", ""s), '\n');
+            auto fontlist = utf::split<true, std::list<text>>(config.take<true>("fontlist", ""s), '\n');
+            if (fontlist.size()) log(prompt::xml, ansi::err("Tag '/config/gui/fontlist' is deprecated. Use '/config/gui/fonts/*' instead."));
+            else
+            {
+                auto recs = config.list("fonts/font");
+                for (auto& f : recs)
+                {
+                    //todo implement 'fonts/font/file' - font file path/url
+                    fontlist.push_back(f->value());
+                }
+            }
             auto event_domain = netxs::events::auth{};
             if (auto window = event_domain.create<gui::window>(event_domain, os::dtvt::window, fontlist, os::dtvt::cellsz, aliasing, blinking))
             {

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.86";
+    static const auto version = "v0.9.87";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -3043,7 +3043,8 @@ namespace netxs
         auto tile(core& image, auto fx) // core: Tile with a specified bitmap.
         {
             auto step = image.size();
-            auto init = region.coor - region.coor % step - region.coor.less(dot_00, step, dot_00);
+            auto grid = netxs::grid_mod(region.coor, step);
+            auto init = region.coor - grid - region.coor.less(dot_00, step, dot_00);
             auto coor = init;
             auto stop = region.coor + region.size;
             while (coor.y < stop.y)

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -83,7 +83,7 @@ namespace netxs
         constexpr auto  operator -  (xy2d p) const { return xy2d{ x - p.x, y - p.y };  }
         constexpr auto  operator *  (xy2d p) const { return xy2d{ x * p.x, y * p.y };  }
         constexpr auto  operator /  (xy2d p) const { return xy2d{ x / p.x, y / p.y };  }
-        constexpr auto  operator %  (xy2d p) const { return xy2d{ x % p.x, y % p.y };  }
+        constexpr auto  operator %  (xy2d p) const { return xy2d{ x % p.x, y % p.y };  } // Consider to use grid_mod().
         constexpr auto  operator -  ()       const { return xy2d{      -x,-y       };  }
         constexpr auto  operator &  (T i)    const { return xy2d{   x & i, y & i   };  }
         constexpr auto  operator ~  ()       const { return xy2d{       y, x       };  }
@@ -199,6 +199,7 @@ namespace netxs
     twod divround(twod p, si32 n) { return { divround(p.x, n  ), divround(p.y, n  ) }; }
     twod divround(si32 n, twod p) { return { divround(n  , p.x), divround(n  , p.y) }; }
     twod divround(twod n, twod p) { return { divround(n.x, p.x), divround(n.y, p.y) }; }
+    twod grid_mod(twod n, twod p) { return { grid_mod(n.x, p.x), grid_mod(n.y, p.y) }; }
 }
 
 namespace std

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2956,7 +2956,8 @@ namespace netxs::gui
                 struct
                 {
                     ui32 repeat   : 16;// 0-15
-                    si32 scancode : 9; // 16-24 (24 - extended)
+                    si32 scancode : 8; // 16-23
+                    si32 extended : 1; // 24
                     ui32 reserved : 4; // 25-28 (reserved)
                     ui32 context  : 1; // 29 (29 - context)
                     ui32 state    : 2; // 30-31: 0 - pressed, 1 - repeated, 2 - unknown, 3 - released
@@ -2965,8 +2966,8 @@ namespace netxs::gui
             auto param = key_state_t{ .token = (ui32)lParam };
             if (param.v.state == 2/*unknown*/) return;
             auto pressed = param.v.state == 0;
-            auto repeat = param.v.state == 1;
-            auto extflag = !!(param.v.scancode >> 9);
+            auto repeat  = param.v.state == 1;
+            auto extflag = param.v.extended;
             auto scancod = param.v.scancode;
             auto to_WIDE = std::array<wchr, 32>{};
             auto sc = !(pressed || repeat) ? scancod | 0x8000 : scancod; // 15-bit indicate pressed state for ToUnicodeEx.

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1215,7 +1215,7 @@ namespace netxs::gui
                     auto limit = block.coor.x + block.size.x;
                     block.size.x = std::max(2, block.size.y);
                     auto stepx = 3 * block.size.x;
-                    block.coor.x -= placeholder.coor.x % stepx;
+                    block.coor.x -= netxs::grid_mod(placeholder.coor.x, stepx);
                     while (block.coor.x < limit)
                     {
                         netxs::onrect(target, block.trim(placeholder), cell::shaders::full(color));
@@ -1243,7 +1243,7 @@ namespace netxs::gui
                     auto& wavy_raster = cgi_glyphs[synthetic::wavyunderline];
                     auto offset = placeholder.coor;
                     auto fract4 = wavy_raster.area.size.x - cellsz.x; // synthetic::wavyunderline has a bump at the beginning to synchronize the texture offset.
-                    offset.x -= offset.x % fract4;
+                    offset.x -= netxs::grid_mod(offset.x, fract4);
                     draw_glyf(target, wavy_raster, offset, color);
                 }
                 else

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -348,6 +348,13 @@ namespace netxs
         return n < 0 ? 1 + (n - 1) / d
                      : n / d;
     }
+    template<class T1, class T2, class T3 = T2, class = std::enable_if_t<std::is_integral_v<T1> && std::is_integral_v<T2> && std::is_integral_v<T3>>>
+    constexpr T3 grid_mod(T1 n, T2 d)
+    {
+        auto mod = n % d;
+        if (mod < 0) mod += d;
+        return mod;
+    }
 
     template<bool B, class T>
     struct _disintegrate { using type = T; };

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -356,7 +356,7 @@ namespace netxs::ui
         {
             if (n)
             {
-                dx(tabwidth - caretpos.x % tabwidth);
+                dx(tabwidth - netxs::grid_mod(caretpos.x, tabwidth));
                 if (n > 0 ? --n : ++n) dx(tabwidth * n);
             }
         }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -785,7 +785,7 @@ namespace netxs::os
                         parser::flush();
                         if (cmd.cmd == ansi::fn::tb)
                         {
-                            coord.x += parser::style.tablen * cmd.arg - coord.x % parser::style.tablen;
+                            coord.x += parser::style.tablen * cmd.arg - netxs::grid_mod(coord.x, parser::style.tablen);
                         }
                         else if (cmd.cmd == ansi::fn::nl)
                         {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1590,7 +1590,7 @@ namespace netxs::ui
                     else
                     {
                         coord.x += notab ? owner.config.def_tablen
-                                         : owner.config.def_tablen - coord.x % owner.config.def_tablen;
+                                         : owner.config.def_tablen - netxs::grid_mod(coord.x, owner.config.def_tablen);
                     }
                 }
                 else

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -16,26 +16,24 @@ R"==(<config>
         <wincoor = 0,0 />        <!-- Window initial coordinates (top-left corner on the desktop in physical pixels). -->
         <winstate = normal />    <!-- Window initial state: normal | maximized | minimized -->
         <blinkrate = 400ms />    <!-- SGR5/6 attribute blink rate. Blinking will be disabled when set to zero. -->
-        <fontlist> <!-- Font fallback list (LF-delimited (\n), ordered). The rest of the fonts available in the system will be loaded dynamically. -->
-            "Courier New\n" <!-- Primary font. Its metrics define the cell geometry. -->
-            "Cascadia Mono\n"
-            "Fira Code\n"
-            "NSimSun\n"
-            "Noto Sans Devanagari\n"
-        </fontlist>
+        <fonts> <!-- Font fallback ordered list. The rest of the fonts available in the system will be loaded dynamically. -->
+            <font*/> <!-- Clear previously defined fonts. Start a new list. -->
+            <font="Courier New"/> <!-- The first font in the list: Primary font. Its metrics define the cell geometry. -->
+            <font="Cascadia Mono"/>
+            <font="NSimSun"/>
+            <font="Noto Sans Devanagari"/>
+        </fonts>
     </gui>
     <simple=0/>  <!-- For internal use only. -->
     <menu wide=off selected=Term>  <!-- wide: Set wide or compact menu layout; selected: Set selected menu item id. -->
-        <item*/>  <!-- Use asterisk at the end of the element name to set defaults.
-                       Using an asterisk with the parameter name of the first element in the list without any other nested elements
-                       indicates the beginning of the list, i.e. the list will replace the existing one when the configuration is merged. -->
+        <item*/>  <!-- Clear all previously defined items. Start a new list of items. -->
         <item splitter label="apps">
             <notes>
                 " Default applications group                         \n"
                 " It can be configured in ~/.config/vtm/settings.xml "
             </notes>
         </item>
-        <item* hidden=no winsize=0,0 wincoor=0,0 winform=normal /> <!-- winform: normal | maximized | minimized -->
+        <item* hidden=no winsize=0,0 wincoor=0,0 winform=normal /> <!-- winform: normal | maximized | minimized (asterisk in the xml node name to set default node values) -->
         <item id=Term label="Term" type=dtvt title="Terminal Console" cmd="$0 -r term">
             <notes>
                 " Terminal Console               \n"

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -10,12 +10,12 @@ R"==(<config>
         </javascript>
     </scripting>
     <gui> <!-- GUI related settings. (win32 platform only for now) -->
-        <antialiasing = off />   <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
-        <cellheight = 20 />      <!-- Text cell height in physical pixels. Note: The width of the text cell depends on the primary font (the first one in the font list). -->
-        <gridsize = 0,0 />       <!-- Window initial grid size in text cells. -->
-        <wincoor = 0,0 />        <!-- Window initial coordinates (top-left corner on the desktop in physical pixels). -->
-        <winstate = normal />    <!-- Window initial state: normal | maximized | minimized -->
-        <blinkrate = 400ms />    <!-- SGR5/6 attribute blink rate. Blinking will be disabled when set to zero. -->
+        <antialiasing=off/>   <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
+        <cellheight=20/>      <!-- Text cell height in physical pixels. Note: The width of the text cell depends on the primary font (the first one in the font list). -->
+        <gridsize=0,0/>       <!-- Window initial grid size in text cells. -->
+        <wincoor=0,0/>        <!-- Window initial coordinates (top-left corner on the desktop in physical pixels). -->
+        <winstate=normal/>    <!-- Window initial state: normal | maximized | minimized -->
+        <blinkrate=400ms/>    <!-- SGR5/6 attribute blink rate. Blinking will be disabled when set to zero. -->
         <fonts> <!-- Font fallback ordered list. The rest of the fonts available in the system will be loaded dynamically. -->
             <font*/> <!-- Clear previously defined fonts. Start a new list. -->
             <font="Courier New"/> <!-- The first font in the list: Primary font. Its metrics define the cell geometry. -->


### PR DESCRIPTION
Changes:
- Fix extended keys reporting (right Enter didn't work in wsl).
- Fix stylized underline glitch in dual monitor setups.
- Fix case of loading fonts if no fonts are found.
- Change `settings.xml` structure:
  - Change `</config/gui/fontlist/>` to `</config/gui/fonts/font*>`:
    ```xml
    <config>
    <gui>
        <fonts> <!-- Font fallback ordered list. The rest of the fonts available in the system will be loaded dynamically. -->
            <font*/> <!-- Clear previously defined fonts. Start a new list. -->
            <font="Courier New"/> <!-- The first font in the list: Primary font. Its metrics define the cell geometry. -->
            <font="Cascadia Mono"/>
            <font="NSimSun"/>
            <font="Noto Sans Devanagari"/>
        </fonts>
    </gui>
    </config>
    ```