### PR TITLE
Fix default GUI-window position and size

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -210,7 +210,7 @@ All value literals containing spaces must be enclosed in double or single quotes
 Value type | Format
 -----------|-----------------
 `RGBA`     | `#rrggbbaa` \| `0xaarrggbb` \| `rrr,ggg,bbb,aaa` \| 256-color index
-`boolean`  | `true` \| `false` \| `yes` \| `no` \| `1` \| `0` \| `on` \| `off`
+`boolean`  | `true` \| `false` \| `yes` \| `no` \| `1` \| `0` \| `on` \| `off` \| `undef`
 `string`   | _UTF-8 text string_
 `x;y`      | _integer_ <any_delimeter> _integer_
 
@@ -257,8 +257,8 @@ Note: Hardcoded settings are built from the [/src/vtm.xml](../src/vtm.xml) sourc
     <gui> <!-- GUI related settings. (win32 platform only for now) -->
         <antialiasing=off/>   <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
         <cellheight=20/>      <!-- Text cell height in physical pixels. Note: The width of the text cell depends on the primary font (the first one in the font list). -->
-        <gridsize=0,0/>       <!-- Window initial grid size in text cells. -->
-        <wincoor=0,0/>        <!-- Window initial coordinates (top-left corner on the desktop in physical pixels). -->
+        <gridsize=""/>        <!-- Window initial grid size "width,height" in text cells. If gridsize="" or gridsize=0,0, then the size of the GUI window is left to the OS window manager. -->
+        <wincoor=""/>         <!-- Window initial coordinates "x,y" (top-left corner on the desktop in physical pixels). If wincoor="", then the position of the GUI window is left to the OS window manager. -->
         <winstate=normal/>    <!-- Window initial state: normal | maximized | minimized -->
         <blinkrate=400ms/>    <!-- SGR5/6 attribute blink rate. Blinking will be disabled when set to zero. -->
         <fonts> <!-- Font fallback ordered list. The rest of the fonts available in the system will be loaded dynamically. -->

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -533,19 +533,6 @@ namespace netxs::app::shared
         }
     };
 
-    void update_winsz(xmls& config)
-    {
-        if (os::dtvt::vtmode & ui::console::gui)
-        {
-            auto wincoord = config.take("/config/gui/wincoor", twod{ 100, 100 });
-            auto gridsize = config.take("/config/gui/gridsize", twod{ 80, 25 });
-            auto cellsize = std::clamp(config.take("/config/gui/cellheight", si32{ 16 }), 1, 256);
-            os::dtvt::cellsz = cellsize ? std::abs(cellsize) : 20;
-            os::dtvt::window.size = std::max(dot_11, gridsize ? gridsize
-                                                              : os::dtvt::wingui.size / twod{ std::max(1, os::dtvt::cellsz / 2), os::dtvt::cellsz });
-            if (wincoord != dot_00) os::dtvt::window.coor = wincoord;
-        }
-    }
     void splice(xipc client, xmls& config)
     {
         if (os::dtvt::active || !(os::dtvt::vtmode & ui::console::gui)) os::tty::splice(client);
@@ -555,7 +542,12 @@ namespace netxs::app::shared
             auto winstate = config.take("/config/gui/winstate", win::state::normal, app::shared::win::options);
             auto aliasing = config.take("/config/gui/antialiasing", faux);
             auto blinking = config.take("/config/gui/blinkrate", span{ 400ms });
+            auto wincoord = config.take("/config/gui/wincoor", dot_mx);
+            auto gridsize = config.take("/config/gui/gridsize", dot_mx);
+            auto cellsize = std::clamp(config.take("/config/gui/cellheight", si32{ 20 }), 0, 256);
             auto fontlist = utf::split<true, std::list<text>>(config.take<true>("/config/gui/fontlist", ""s), '\n');
+            if (cellsize == 0) cellsize = 20;
+            if (gridsize == dot_00) gridsize = dot_mx;
             if (fontlist.size()) log(prompt::xml, ansi::err("Tag '/config/gui/fontlist' is deprecated. Use '/config/gui/fonts/*' instead."));
             else
             {
@@ -567,7 +559,7 @@ namespace netxs::app::shared
                 }
             }
             auto event_domain = netxs::events::auth{};
-            if (auto window = event_domain.create<gui::window>(event_domain, os::dtvt::window, fontlist, os::dtvt::cellsz, aliasing, blinking))
+            if (auto window = event_domain.create<gui::window>(event_domain, wincoord, gridsize, fontlist, cellsize, aliasing, blinking))
             {
                 window->connect(winstate);
             }
@@ -576,7 +568,6 @@ namespace netxs::app::shared
     void start(text cmd, text aclass, xmls& config)
     {
         auto [client, server] = os::ipc::xlink();
-        update_winsz(config);
         auto thread = std::thread{ [&, &client = client] //todo clang 15.0.0 still disallows capturing structured bindings (wait for clang 16.0.0)
         {
             app::shared::splice(client, config);
@@ -588,7 +579,7 @@ namespace netxs::app::shared
         auto appcfg = eccc{ .cmd = cmd,
                             .cfg = os::dtvt::active ? ""s : "<config simple=1/>"s };
         auto applet = app::shared::builder(aclass)(appcfg, config);
-        domain->invite(server, applet, os::dtvt::vtmode, os::dtvt::window.size);
+        domain->invite(server, applet, os::dtvt::vtmode, os::dtvt::gridsz);
         domain->stop();
         server->shut();
         thread.join();

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.92";
+    static const auto version = "v0.9.93";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -167,12 +167,10 @@ namespace netxs::ui
             //todo use s11n::xs::screenmode:  normal/fullscreen/maximized/mnimized
             void handle(s11n::xs::fullscrn    lock)
             {
-                auto& item = lock.thing;
                 owner.fullscreen = true;
             }
             void handle(s11n::xs::restored    lock)
             {
-                auto& item = lock.thing;
                 owner.fullscreen = faux;
             }
             void handle(s11n::xs::sysboard    lock)

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -162,8 +162,18 @@ namespace netxs::ui
             void handle(s11n::xs::syswinsz    lock)
             {
                 auto& item = lock.thing;
-                owner.fullscreen = item.fullscreen;
                 notify(e2::conio::winsz, item.winsize);
+            }
+            //todo use s11n::xs::screenmode:  normal/fullscreen/maximized/mnimized
+            void handle(s11n::xs::fullscrn    lock)
+            {
+                auto& item = lock.thing;
+                owner.fullscreen = true;
+            }
+            void handle(s11n::xs::restored    lock)
+            {
+                auto& item = lock.thing;
+                owner.fullscreen = faux;
             }
             void handle(s11n::xs::sysboard    lock)
             {
@@ -1447,7 +1457,7 @@ namespace netxs::ui
                 LISTEN(tier::preview, e2::form::size::enlarge::fullscreen, gear, tokens)
                 {
                     auto [ext_gear_id, gear_ptr] = input.get_foreign_gear_id(gear.id);
-                    if (gear_ptr) conio.fullscreen.send(canal, ext_gear_id);
+                    if (gear_ptr) conio.fullscrn.send(canal, ext_gear_id);
                 };
                 LISTEN(tier::preview, e2::form::size::enlarge::maximize, gear, tokens)
                 {

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -165,11 +165,11 @@ namespace netxs::ui
                 notify(e2::conio::winsz, item.winsize);
             }
             //todo use s11n::xs::screenmode:  normal/fullscreen/maximized/mnimized
-            void handle(s11n::xs::fullscrn    lock)
+            void handle(s11n::xs::fullscrn  /*lock*/)
             {
                 owner.fullscreen = true;
             }
-            void handle(s11n::xs::restored    lock)
+            void handle(s11n::xs::restored  /*lock*/)
             {
                 owner.fullscreen = faux;
             }

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -818,7 +818,7 @@ namespace netxs::directvt
         STRUCT_macro(sysclose,          (bool, fast))
         STRUCT_macro(syspaste,          (id_t, gear_id) (text, txtdata))
         STRUCT_macro(sysfocus,          (id_t, gear_id) (bool, state) (bool, focus_combine) (bool, focus_force_group))
-        STRUCT_macro(syswinsz,          (id_t, gear_id) (twod, winsize))
+        STRUCT_macro(syswinsz,          (id_t, gear_id) (twod, winsize) (bool, fullscreen))
         STRUCT_macro(syskeybd,          (id_t, gear_id)  // syskeybd: Devide id.
                                         (si32, ctlstat)  // syskeybd: Keybd modifiers.
                                         (bool, extflag) //todo deprecated

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -797,7 +797,7 @@ namespace netxs::directvt
         //STRUCT_macro(focus,             (id_t, gear_id) (bool, state) (bool, focus_combine) (bool, focus_force_group))
         STRUCT_macro(focus_cut,         (id_t, gear_id))
         STRUCT_macro(focus_set,         (id_t, gear_id) (si32, solo))
-        STRUCT_macro(fullscreen,        (id_t, gear_id))
+        STRUCT_macro(fullscrn,          (id_t, gear_id))
         STRUCT_macro(maximize,          (id_t, gear_id))
         STRUCT_macro(header,            (id_t, window_id) (text, utf8))
         STRUCT_macro(footer,            (id_t, window_id) (text, utf8))
@@ -818,7 +818,7 @@ namespace netxs::directvt
         STRUCT_macro(sysclose,          (bool, fast))
         STRUCT_macro(syspaste,          (id_t, gear_id) (text, txtdata))
         STRUCT_macro(sysfocus,          (id_t, gear_id) (bool, state) (bool, focus_combine) (bool, focus_force_group))
-        STRUCT_macro(syswinsz,          (id_t, gear_id) (twod, winsize) (bool, fullscreen))
+        STRUCT_macro(syswinsz,          (id_t, gear_id) (twod, winsize))
         STRUCT_macro(syskeybd,          (id_t, gear_id)  // syskeybd: Devide id.
                                         (si32, ctlstat)  // syskeybd: Keybd modifiers.
                                         (bool, extflag) //todo deprecated
@@ -843,6 +843,7 @@ namespace netxs::directvt
         STRUCT_macro(fps,               (si32, frame_rate))
         STRUCT_macro(init,              (text, user) (si32, mode) (text, env) (text, cwd) (text, cmd) (text, cfg) (twod, win))
         STRUCT_macro(cwd,               (text, path))
+        STRUCT_macro(restored,          (id_t, gear_id))
 
         #undef STRUCT_macro
         #undef STRUCT_macro_lite
@@ -1343,7 +1344,7 @@ namespace netxs::directvt
             X(jgc_list         ) /* List of jumbo GC.                             */\
             X(focus_cut        ) /* Request to focus cut.                         */\
             X(focus_set        ) /* Request to focus set.                         */\
-            X(fullscreen       ) /* Request to fullscreen.                        */\
+            X(fullscrn         ) /* Notify/Request to fullscreen.                 */\
             X(maximize         ) /* Request to maximize window.                   */\
             X(header           ) /* Set window title.                             */\
             X(footer           ) /* Set window footer.                            */\
@@ -1374,7 +1375,8 @@ namespace netxs::directvt
             X(unknown_gc       ) /* Unknown gc token.                             */\
             X(fps              ) /* Set frame rate.                               */\
             X(init             ) /* Startup data.                                 */\
-            X(cwd              ) /* CWD Notification.                             */
+            X(cwd              ) /* CWD Notification.                             */\
+            X(restored         ) /* Notify normal window state.                   */
             //X(quit             ) /* Close and disconnect dtvt app.                */
             //X(focus            ) /* Request to set focus.                         */
 

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2413,7 +2413,6 @@ namespace netxs::gui
                 if (blink_count) layers[blinky].show();
                 size_window();
             }
-            netxs::set_flag<input::hids::Fullscrn>(kbmod, fsmode == state::maximized);
         }
         void check_fsmode(arch hWnd)
         {
@@ -2483,17 +2482,24 @@ namespace netxs::gui
             gridsz = layers[blinky].area.size / cellsz;
             blink_count = 0;
             blink_mask.assign(gridsz.x * gridsz.y, 0);
-            if (fsmode != state::maximized)
+            auto fullscreen = fsmode == state::maximized;
+            auto sizechanged = proxy.w.winsize != gridsz;
+            if (!fullscreen)
             {
                 size_title(head_grid, titles.head_page);
                 size_title(foot_grid, titles.foot_page);
                 sync_titles_pixel_layout();
             }
-            if (proxy.w.winsize != gridsz)
+            if (sizechanged || proxy.w.fullscreen != fullscreen)
             {
-                netxs::set_flag<task::all>(reload);
-                waitsz = gridsz;
-                proxy.w.winsize = gridsz;
+                if (sizechanged)
+                {
+                    netxs::set_flag<task::all>(reload);
+                    waitsz = gridsz;
+                    proxy.w.winsize = gridsz;
+                }
+                else netxs::set_flag<task::sized>(reload);
+                proxy.w.fullscreen = fullscreen;
                 proxy.winsz(proxy.w); // And wait for reply to resize and redraw.
             }
             else netxs::set_flag<task::sized>(reload);

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3054,7 +3054,6 @@ namespace netxs::gui
             if (auto rc = ::TranslateMessage(&msg)) // Update kb buffer + update IME. Alt_Numpads are sent via WM_IME_CHAR for IME-aware kb layouts. ! All WM_IME_CHARs are sent before any WM_KEYUP.
             {                                       // ::ToUnicodeEx() doesn't update IME.
                 auto m = MSG{};
-                if (::PeekMessageW(&m, {}, WM_QUIT, WM_QUIT, PM_NOREMOVE)) return;
                 auto msgtype = altkey ? WM_SYSCHAR : WM_CHAR;
                 while (::PeekMessageW(&m, {}, msgtype, msgtype, PM_REMOVE)) to_WIDE.push_back((wchr)m.wParam);
                 if (to_WIDE.size()) keytype = 1;

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3051,7 +3051,7 @@ namespace netxs::gui
             //os::logstd("Vkey=", utf::to_hex(virtcod), " scancod=", utf::to_hex(scancod), " pressed=", pressed ? "1":"0");
             //if (auto rc = os::nt::TranslateMessageEx(&msg, 1/*Do not process Alt+Numpad*/)) // ::TranslateMessageEx() do not update IME.
             //todo process Alt+Numpads on our side.
-            if (auto rc = ::TranslateMessage(&msg)) // Update kb buffer + update IME. Alt_Numpads are sent via WM_IME_CHAR for IME-aware kb layouts.
+            if (auto rc = ::TranslateMessage(&msg)) // Update kb buffer + update IME. Alt_Numpads are sent via WM_IME_CHAR for IME-aware kb layouts. ! All WM_IME_CHARs are sent before any WM_KEYUP.
             {                                       // ::ToUnicodeEx() doesn't update IME.
                 auto m = MSG{};
                 if (::PeekMessageW(&m, {}, WM_QUIT, WM_QUIT, PM_NOREMOVE)) return;

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1155,7 +1155,6 @@ namespace netxs::input
             NumLock  = 1 << 12, // ⇭ Num Lock
             CapsLock = 1 << 13, // ⇪ Caps Lock
             ScrlLock = 1 << 14, // ⇳ Scroll Lock (⤓)
-            Fullscrn = 1 << 15, // Fullscreen mode
             AltGr    = LAlt   | LCtrl,
             anyCtrl  = LCtrl  | RCtrl,
             anyAlt   = LAlt   | RAlt,

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -62,7 +62,7 @@ namespace netxs::scripting
                 token.clear();
             }
 
-            void handle(s11n::xs::fullscreen        /*lock*/)
+            void handle(s11n::xs::fullscrn          /*lock*/)
             {
                 //...
             }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -915,7 +915,6 @@ namespace netxs::os
                 {
                     modstate |= input::hids::LShift;
                 }
-                auto fsmode = modstate & input::hids::Fullscrn;
                 auto lshift = modstate & input::hids::LShift;
                 auto rshift = modstate & input::hids::RShift;
                 auto lwin   = modstate & input::hids::LWin;
@@ -928,7 +927,6 @@ namespace netxs::os
                 bool caps   = ms_ctrls & CAPSLOCK_ON;
                 bool scrl   = ms_ctrls & SCROLLLOCK_ON;
                 auto state  = si32{};
-                if (fsmode) state |= input::hids::Fullscrn;
                 if (lshift) state |= input::hids::LShift;
                 if (rshift) state |= input::hids::RShift;
                 if (lalt  ) state |= input::hids::LAlt;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3467,12 +3467,8 @@ namespace netxs::os
         static auto config = text{}; // dtvt: DirectVT configuration XML data.
         static auto leadin = text{}; // dtvt: The first block read from stdin.
         static auto backup = tios{}; // dtvt: Saved console state to restore at exit.
-        static auto window = rect{}; // dtvt: Initial window area.
-        static auto wingui = rect{}; // dtvt: Initial GUI window area.
+        static auto gridsz = twod{}; // dtvt: Initial window grid size.
         static auto client = xipc{}; // dtvt: Internal IO link.
-        //static auto iconic = si32{}; // dtvt: Initial window state: normal = 0, minimized = 1, fullscreen = 2.
-        //static auto uifont = std::list<text>{}; // dtvt: Font list for gui console.
-        static auto cellsz = si32{}; // dtvt: Font size for gui console.
 
         auto consize()
         {
@@ -3532,7 +3528,7 @@ namespace netxs::os
                     if (::PeekNamedPipe(os::stdin_fd, buffer.data(), (DWORD)buffer.size(), &length, NULL, NULL)
                      && length)
                     {
-                        dtvt::active = buffer.size() == length && buffer.get(cfsize, dtvt::window.size);
+                        dtvt::active = buffer.size() == length && buffer.get(cfsize, dtvt::gridsz);
                         if (dtvt::active)
                         {
                             io::recv(os::stdin_fd, buffer);
@@ -3543,7 +3539,7 @@ namespace netxs::os
                 {
                     auto header = io::recv(os::stdin_fd, buffer);
                     length = (DWORD)header.size();
-                    dtvt::active = buffer.size() == length && buffer.get(cfsize, dtvt::window.size);
+                    dtvt::active = buffer.size() == length && buffer.get(cfsize, dtvt::gridsz);
                     if (!dtvt::active)
                     {
                         dtvt::leadin = header;
@@ -3561,7 +3557,7 @@ namespace netxs::os
                         auto length = header.length();
                         if (length)
                         {
-                            dtvt::active = buffer.size() == length && buffer.get(cfsize, dtvt::window.size);
+                            dtvt::active = buffer.size() == length && buffer.get(cfsize, dtvt::gridsz);
                             if (!dtvt::active)
                             {
                                 dtvt::leadin = header;
@@ -3614,7 +3610,7 @@ namespace netxs::os
             }
             else
             {
-                dtvt::window.size = dtvt::consize();
+                dtvt::gridsz = dtvt::consize();
                 if (trygui)
                 {
                     #if defined(_WIN32)
@@ -3623,32 +3619,31 @@ namespace netxs::os
                         auto proc_count = ::GetConsoleProcessList(&processpid, 1);
                         if (forced || 1 == proc_count) // Run gui console.
                         {
-                            auto r = RECT{};
-                            auto h = ::GetConsoleWindow();
-                            ok(::GetWindowRect(h, &r));
-                            auto modeflags = DWORD{};
-                            ok(::GetConsoleDisplayMode(&modeflags));
-                            auto maximized = modeflags == CONSOLE_FULLSCREEN;
-                            //dtvt::iconic = maximized ? gui::window::state::fullscreen
-                            //                         : ::IsIconic(h) ? gui::window::state::minimized
-                            //                                         : gui::window::state::normal;
-                            auto font_info = CONSOLE_FONT_INFOEX{ sizeof(CONSOLE_FONT_INFOEX) };
-                            auto cell_height = 20;
-                            if (ok(::GetCurrentConsoleFontEx(os::stdout_fd, maximized, &font_info)) && font_info.dwFontSize.Y)
-                            {
-                                //dtvt::uifont.emplace_back(utf::to_utf(font_info.FaceName));
-                                cell_height = font_info.dwFontSize.Y;
-                            }
-                            //if (cell_height == 0) cell_height = 20;
-                            //if (dtvt::uifont.empty()) dtvt::uifont.emplace_back("Courier New");
-                            //dtvt::window.coor = { r.left + (r.right - r.left - cell_height / 2 * dtvt::window.size.x) / 2, // Centrify window.
-                            //                      r.top  + (r.bottom - r.top - cell_height * dtvt::window.size.y) / 2 };
-                            dtvt::window.coor = { r.left, r.top };
-                            //dtvt::wingui = {{ r.left, r.top }, { r.right - r.left, r.bottom - r.top }}; // It doesn't work with WT.
-                            dtvt::wingui = dtvt::window;
-                            dtvt::wingui.size *= twod{ std::max(1, cell_height / 2), cell_height};
+                            //auto r = RECT{};
+                            //auto h = ::GetConsoleWindow();
+                            //ok(::GetWindowRect(h, &r));
+                            //auto modeflags = DWORD{};
+                            //ok(::GetConsoleDisplayMode(&modeflags));
+                            //auto maximized = modeflags == CONSOLE_FULLSCREEN;
+                            ////dtvt::iconic = maximized ? gui::window::state::fullscreen
+                            ////                         : ::IsIconic(h) ? gui::window::state::minimized
+                            ////                                         : gui::window::state::normal;
+                            //auto font_info = CONSOLE_FONT_INFOEX{ sizeof(CONSOLE_FONT_INFOEX) };
+                            //auto cell_height = 20;
+                            //if (ok(::GetCurrentConsoleFontEx(os::stdout_fd, maximized, &font_info)) && font_info.dwFontSize.Y)
+                            //{
+                            //    //dtvt::uifont.emplace_back(utf::to_utf(font_info.FaceName));
+                            //    cell_height = font_info.dwFontSize.Y;
+                            //}
+                            ////if (cell_height == 0) cell_height = 20;
+                            ////if (dtvt::uifont.empty()) dtvt::uifont.emplace_back("Courier New");
+                            ////dtvt::window.coor = { r.left + (r.right - r.left - cell_height / 2 * dtvt::gridsz.x) / 2, // Centrify window.
+                            ////                      r.top  + (r.bottom - r.top - cell_height * dtvt::gridsz.y) / 2 };
+                            //dtvt::window.coor = { r.left, r.top };
+                            ////dtvt::wingui = {{ r.left, r.top }, { r.right - r.left, r.bottom - r.top }}; // It doesn't work with WT.
+                            //dtvt::wingui = dtvt::window;
+                            //dtvt::wingui.size *= twod{ std::max(1, cell_height / 2), cell_height};
                             dtvt::vtmode |= ui::console::gui;
-
                             os::stdin_fd  = os::invalid_fd;
                             os::stdout_fd = os::invalid_fd;
                             os::stderr_fd = os::invalid_fd;
@@ -4628,7 +4623,7 @@ namespace netxs::os
                     if (item.form == mime::disabled) input::board::normalize(item);
                     else                             item.set();
                     os::clipboard::set(item);
-                    auto crop = utf::trunc(item.utf8, dtvt::window.size.y / 2); // Trim preview before sending.
+                    auto crop = utf::trunc(item.utf8, dtvt::gridsz.y / 2); // Trim preview before sending.
                     s11n::sysboard.send(dtvt::client, id_t{}, item.size, crop.str(), item.form);
                 }
                 void handle(s11n::xs::clipdata_request lock)
@@ -4737,7 +4732,7 @@ namespace netxs::os
             m.coordxy = { si16min, si16min };
             c.fast = true;
             f.state = true;
-            w.winsize = os::dtvt::window.size;
+            w.winsize = os::dtvt::gridsz;
             focus(f);
 
             #if defined(_WIN32)
@@ -5594,7 +5589,7 @@ namespace netxs::os
                                 ok(::AddClipboardFormatListener(hWnd), "::AddClipboardFormatListener()", os::unexpected);
                                 // Continue processing the switch to initialize the clipboard state after startup.
                             case WM_CLIPBOARDUPDATE:
-                                os::clipboard::sync((arch)hWnd, binary::proxy(), dtvt::client, dtvt::window.size);
+                                os::clipboard::sync((arch)hWnd, binary::proxy(), dtvt::client, dtvt::gridsz);
                                 break;
                             case WM_DESTROY:
                                 ok(::RemoveClipboardFormatListener(hWnd), "::RemoveClipboardFormatListener()", os::unexpected);
@@ -5680,7 +5675,7 @@ namespace netxs::os
                 if (dtvt::vtmode & ui::console::nt16)
                 {
                     auto c16 = palette;
-                    c16.srWindow = { .Right = (si16)dtvt::window.size.x, .Bottom = (si16)dtvt::window.size.y }; // Suppress unexpected scrollbars.
+                    c16.srWindow = { .Right = (si16)dtvt::gridsz.x, .Bottom = (si16)dtvt::gridsz.y }; // Suppress unexpected scrollbars.
                     argb::set_vtm16_palette([&](auto index, auto color){ c16.ColorTable[index] = argb::swap_rb(color); }); // conhost crashes if alpha non zero.
                     ok(::SetConsoleScreenBufferInfoEx(os::stdout_fd, &c16), "::SetConsoleScreenBufferInfoEx()", os::unexpected);
                 }
@@ -5733,7 +5728,7 @@ namespace netxs::os
                 if (dtvt::vtmode & ui::console::nt16) // Restore pelette.
                 {
                     auto count = DWORD{};
-                    ok(::FillConsoleOutputAttribute(os::stdout_fd, 0, dtvt::window.size.x * dtvt::window.size.y, {}, &count), "::FillConsoleOutputAttribute()", os::unexpected); // To avoid palette flickering.
+                    ok(::FillConsoleOutputAttribute(os::stdout_fd, 0, dtvt::gridsz.x * dtvt::gridsz.y, {}, &count), "::FillConsoleOutputAttribute()", os::unexpected); // To avoid palette flickering.
                     ok(::SetConsoleScreenBufferInfoEx(os::stdout_fd, &palette), "::SetConsoleScreenBufferInfoEx()", os::unexpected);
                 }
                 if (saved_fd != os::invalid_fd)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -8063,7 +8063,7 @@ namespace netxs::ui
                 auto winsize = stream.syswinsz.freeze().thing.winsize;
                 if (ipccon && winsize != new_area.size)
                 {
-                    stream.syswinsz.send(*this, 0, new_area.size);
+                    stream.syswinsz.send(*this, 0, new_area.size, faux);
                 }
             };
             SIGNAL(tier::general, e2::config::fps, fps, (-1));

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7613,7 +7613,7 @@ namespace netxs::ui
                     }
                 });
             }
-            void handle(s11n::xs::fullscreen          lock)
+            void handle(s11n::xs::fullscrn            lock)
             {
                 auto& m = lock.thing;
                 master.trysync(master.active, [&]

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -402,13 +402,12 @@ int main(int argc, char* argv[])
             signal.reset();
             if (client || (client = os::ipc::socket::open<os::role::client>(prefix, denied)))
             {
-                app::shared::update_winsz(config);
                 auto userinit = directvt::binary::init{};
                 auto env = os::env::add();
                 auto cwd = os::env::cwd();
                 auto cmd = script;
                 auto cfg = config.utf8();
-                auto win = os::dtvt::window.size;
+                auto win = os::dtvt::gridsz;
                 userinit.send(client, userid.first, os::dtvt::vtmode, env, cwd, cmd, cfg, win);
                 app::shared::splice(client, config);
                 return 0;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -12,8 +12,8 @@ R"==(<config>
     <gui> <!-- GUI related settings. (win32 platform only for now) -->
         <antialiasing=off/>   <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
         <cellheight=20/>      <!-- Text cell height in physical pixels. Note: The width of the text cell depends on the primary font (the first one in the font list). -->
-        <gridsize=0,0/>       <!-- Window initial grid size in text cells. -->
-        <wincoor=0,0/>        <!-- Window initial coordinates (top-left corner on the desktop in physical pixels). -->
+        <gridsize=""/>        <!-- Window initial grid size "width,height" in text cells. If gridsize="" or gridsize=0,0, then the size of the GUI window is left to the OS window manager. -->
+        <wincoor=""/>         <!-- Window initial coordinates "x,y" (top-left corner on the desktop in physical pixels). If wincoor="", then the position of the GUI window is left to the OS window manager. -->
         <winstate=normal/>    <!-- Window initial state: normal | maximized | minimized -->
         <blinkrate=400ms/>    <!-- SGR5/6 attribute blink rate. Blinking will be disabled when set to zero. -->
         <fonts> <!-- Font fallback ordered list. The rest of the fonts available in the system will be loaded dynamically. -->


### PR DESCRIPTION
Changes:
- Allow panoramic scrolling by left drag in fullscreen mode.
- Restore cell pixel size when switching to/from fullscreen mode if the size has been changed.
  - Changing the cell size in normal mode resets the fullscreen cell size.
- Fix default GUI-window position and size (don't rely on parent console window).
  ```xml
  <config>
    <gui> <!-- GUI related settings. (win32 platform only for now) -->
      <gridsize=""/> <!-- Window initial grid size "width,height" in text cells. If gridsize="" or gridsize=0,0, then the size of the GUI window is left to the OS window manager. -->
      <wincoor=""/>  <!-- Window initial coordinates "x,y" (top-left corner on the desktop in physical pixels). If wincoor="", then the position of the GUI window is left to the OS window manager. -->
    </gui>
  <config>
  ```