### PR TITLE
Fix soft line breaks when pasting multi-line text in pwsh

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.93";
+    static const auto version = "v0.9.94";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -836,7 +836,14 @@ struct impl : consrv
                 else if (c == '\n')
                 {
                     if (head != tail && *head == '\r') head++; // Eat LF+CR.
-                    generate('\n', s | LEFT_CTRL_PRESSED, VK_RETURN, 1, 0x1c); // Emulate Shift+Enter.
+                    // pwsh: Ctrl+Enter  adds new line below the cursor, so it changes pasted lines order.
+                    // pwsh: Shift+Enter adds new line, so it's okay for paste.
+                    //  far: Ctrl+Enter  adds new line, so it's okay for paste.
+                    //  far: Shift+Enter paste some macro-string. Far Manager treats Shift+Enter as its own macro not a soft break.
+                    //auto is_far_manager = ...;
+                    //auto soft_break_modifier = is_far_manager ? LEFT_CTRL_PRESSED : SHIFT_PRESSED;
+                    auto soft_break_modifier = LEFT_ALT_PRESSED | SHIFT_PRESSED; // Adding LEFT_ALT_PRESSED changes Far Manager's behavior to what is needed and keeps pwsh intact.
+                    generate('\n', s | soft_break_modifier, VK_RETURN, 1, 0x1c); // Emulate Ctrl+Enter.
                 }
                 else
                 {

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -380,6 +380,7 @@ R"==(
             </item>
             <item label="Clear" notes=" Clear TTY viewport "                  action=TerminalOutput data="\e[2J"/>
             <item label="Reset" notes=" Clear scrollback and SGR-attributes " action=TerminalOutput data="\e[!p"/>
+            <item label="Paste" notes=" Paste from clipboard "    type=Repeat action=TerminalClipboardPaste/>
             <!-- <item label="Hello, World!" notes=" Simulating keypresses "       action=TerminalSendKey data="Hello World!"/> -->
         </menu>
         <selection>

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -380,7 +380,6 @@ R"==(
             </item>
             <item label="Clear" notes=" Clear TTY viewport "                  action=TerminalOutput data="\e[2J"/>
             <item label="Reset" notes=" Clear scrollback and SGR-attributes " action=TerminalOutput data="\e[!p"/>
-            <item label="Paste" notes=" Paste from clipboard "    type=Repeat action=TerminalClipboardPaste/>
             <!-- <item label="Hello, World!" notes=" Simulating keypresses "       action=TerminalSendKey data="Hello World!"/> -->
         </menu>
         <selection>


### PR DESCRIPTION
Changes:
- Fix soft line breaks when pasting multi-line text in pwsh. #605
  - Using `Alt+Shift+Enter` as a soft line break changes Far Manager's behavior to what is needed and keeps pwsh intact.

Closes #605