### PR TITLE
Fix unintended focus in subsequent desktop sessions

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.95";
+    static const auto version = "v0.9.96";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -275,7 +275,7 @@ R"==(
     <term>       <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
         <cwdsync=" cd $P\n"/>   <!-- Command to sync the current working directory. When 'Sync' is active, $P (case sensitive) will be replaced with the current path received via OSC9;9 notification. Prefixed with a space to avoid touching command history. -->
         <scrollback>
-            <size=40000    />   <!-- Initial scrollback buffer length. -->
+            <size=40000    />   <!-- Initial scrollback buffer size. -->
             <growstep=0    />   <!-- Scrollback buffer grow step. The buffer behaves like a ring in case of zero. -->
             <growlimit=0   />   <!-- Scrollback buffer grow limit. The buffer will behave like a ring when the limit is reached. If set to zero, then the limit is equal to the initial buffer size. -->
             <maxline=65535 />   <!-- Max line length. Line splits if it exceeds the limit. -->


### PR DESCRIPTION
Changes:
- Fix an issue that causes all windows to receive unintended focus in subsequent desktop sessions.
- Built-in terminal:
  - Revise scrollback resize logic.
    It is now possible to specify the scrollback buffer grow step without specifying a grow limit. In this case, the buffer will grow from zero to the specified initial size step by step.
    ```xml
    <config>
      <term>
        <scrollback>
          <size=1000000  />   <!-- Initial scrollback buffer size. -->
          <growstep=10000/>   <!-- Scrollback buffer grow step. The buffer behaves like a ring in case of zero. -->
          <growlimit=0   />   <!-- Scrollback buffer grow limit. The buffer will behave like a ring when the limit is reached. If set to zero, then the limit is equal to the initial buffer size. -->
        </scrollback>
      </term>
    </config>
    ```