### PR TITLE
Enable to send input on startup

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -440,6 +440,7 @@ Notes
         <regions enabled=0/>  <!-- Highlight UI objects boundaries. -->
     </client>
     <term>      <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
+        <sendinput=""/>  <!-- Send input on startup. E.g. sendinput="echo test\n" -->
         <cwdsync=" cd $P\n"/>   <!-- Command to sync the current working directory. When 'Sync' is active, $P (case sensitive) will be replaced with the current path received via OSC9;9 notification. Prefixed with a space to avoid touching command history. -->
         <scrollback>
             <size=40000    />   <!-- Initial scrollback buffer length. -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -386,7 +386,7 @@ Notes
                 <repeat_rate    = 30ms  /> <!-- Repeat rate.                                         -->
             </timings>
             <limits>
-                <window size=3000x2000/> <!-- Max window size -->
+                <window size=3000x2000/> <!-- Max window grid size -->
             </limits>
         </defaults>
         <runapp>    <!-- Override defaults. -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -386,7 +386,7 @@ Notes
                 <repeat_rate    = 30ms  /> <!-- Repeat rate.                                         -->
             </timings>
             <limits>
-                <window size=2000x1000/> <!-- Max window size -->
+                <window size=3000x2000/> <!-- Max window size -->
             </limits>
         </defaults>
         <runapp>    <!-- Override defaults. -->

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -387,7 +387,7 @@ namespace netxs::app::shared
             auto cB = menu_white;
 
             auto window = ui::veer::ctor()
-                ->limits(dot_11, { 400,200 })
+                ->limits(dot_11, { 1000, 500 })
                 ->plugin<pro::focus>(pro::focus::mode::active); // Required for standalone mode.
             auto term = ui::cake::ctor()
                 ->active(cB);

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -387,7 +387,7 @@ namespace netxs::app::shared
             auto cB = menu_white;
 
             auto window = ui::veer::ctor()
-                ->limits(dot_11, { 1000, 500 })
+                ->limits(dot_11)
                 ->plugin<pro::focus>(pro::focus::mode::active); // Required for standalone mode.
             auto term = ui::cake::ctor()
                 ->active(cB);

--- a/src/netxs/apps/calc.xml
+++ b/src/netxs/apps/calc.xml
@@ -41,7 +41,7 @@ R"==(
                 <repeat_rate    = 30ms  /> <!-- Repeat rate.                                         -->
             </timings>
             <limits>
-                <window size=2000x1000 />  <!-- Max window size -->
+                <window size=3000x2000 />  <!-- Max window size -->
             </limits>
         </defaults>
         <runapp>    <!-- Override defaults. -->

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -778,7 +778,7 @@ namespace netxs::app::terminal
         auto def_bcolor = config.take("bgc", argb{ blackdk });
         auto layers = window->attach(ui::cake::ctor())
                             ->colors(cB)
-                            ->limits(dot_11, { 400,200 });
+                            ->limits(dot_11, { 1000, 500 });
         auto scroll = layers->attach(ui::rail::ctor())
                             ->limits({ 10,1 }); // mc crashes when window is too small
         if (appcfg.cmd.empty()) appcfg.cmd = os::env::shell();//todo revise + " -i";
@@ -867,7 +867,7 @@ namespace netxs::app::terminal
                 };
             });
         auto layers = term_stat_area->attach(slot::_1, ui::cake::ctor())
-                                    ->limits(dot_11, { 400,200 });
+                                    ->limits(dot_11, { 1000, 500 });
         auto scroll = layers->attach(ui::rail::ctor()->smooth(faux));
         auto min_size = twod{ 12,1 }; // mc crashes when window is too small
         auto max_size = -dot_11;

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -778,7 +778,7 @@ namespace netxs::app::terminal
         auto def_bcolor = config.take("bgc", argb{ blackdk });
         auto layers = window->attach(ui::cake::ctor())
                             ->colors(cB)
-                            ->limits(dot_11, { 1000, 500 });
+                            ->limits(dot_11);
         auto scroll = layers->attach(ui::rail::ctor())
                             ->limits({ 10,1 }); // mc crashes when window is too small
         if (appcfg.cmd.empty()) appcfg.cmd = os::env::shell();//todo revise + " -i";
@@ -867,7 +867,7 @@ namespace netxs::app::terminal
                 };
             });
         auto layers = term_stat_area->attach(slot::_1, ui::cake::ctor())
-                                    ->limits(dot_11, { 1000, 500 });
+                                    ->limits(dot_11);
         auto scroll = layers->attach(ui::rail::ctor()->smooth(faux));
         auto min_size = twod{ 12,1 }; // mc crashes when window is too small
         auto max_size = -dot_11;

--- a/src/netxs/apps/term.xml
+++ b/src/netxs/apps/term.xml
@@ -41,7 +41,7 @@ R"==(
                 <repeat_rate    = 30ms  /> <!-- Repeat rate.                                         -->
             </timings>
             <limits>
-                <window size=2000x1000 />  <!-- Max window size -->
+                <window size=3000x2000 />  <!-- Max window size -->
             </limits>
         </defaults>
         <runapp>    <!-- Override defaults. -->

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.96";
+    static const auto version = "v0.9.97";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -515,7 +515,7 @@ namespace netxs::ui
         twod shadow_offset = dot_21;
 
         twod min_value = dot_00;
-        twod max_value = twod{ 2000, 1000 }; //todo unify
+        twod max_value = twod{ 3000, 2000 }; //todo unify
 
         static auto& globals()
         {

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1543,7 +1543,7 @@ namespace netxs::ui
             g.repeat_rate    = config.take("timings/repeat_rate"   , span{ 30ms  });
             g.fader_time     = config.take("timings/fader/duration", span{ 150ms });
             g.fader_fast     = config.take("timings/fader/fast"    , span{ 0ms   });
-            g.max_value      = config.take("limits/window/size"    , twod{ 2000, 1000  });
+            g.max_value      = config.take("limits/window/size"    , twod{ 3000, 2000  });
             g.menuwide       = config.take("/config/menu/wide"     , faux);
 
             g.shadow_enabled = config.take("shadow/enabled", true);

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -827,7 +827,7 @@ struct impl : consrv
                 auto c = *head++;
                 if (c == '\r' || c == '\n')
                 {
-                    auto mouse_reporting = server.inpmod & nt::console::inmode::mouse;
+                    //auto mouse_reporting = server.inpmod & nt::console::inmode::mouse;
                     if (c == '\r')
                     {
                         if (head != tail && *head == '\n') head++; // Eat CR+LF.
@@ -840,11 +840,13 @@ struct impl : consrv
                     // pwsh: Shift+Enter   adds new line, so it's okay for paste.
                     //  far: (Ctrl)+Enter  adds new line, so it's okay for paste.
                     //  far: Shift+Enter   paste some macro-string. Far Manager treats Shift+Enter as its own macro not a soft break.
-                    //generate('\r', s, VK_RETURN, 1, 0x1c); // Emulate Enter.
-                    //if (noni) generate('\n', s);
-                    //else      generate('\r', s | SHIFT_PRESSED, VK_RETURN, 1, 0x1c /*os::nt::takevkey<VK_RETURN>().key*/); // Emulate hitting Enter. Pressed Shift to soft line break when pasting from clipboard.
-                    auto soft_break_modifier = mouse_reporting ? 0 : SHIFT_PRESSED; // Emulate Shift+Enter if no mouse reporting enabled.
-                    generate('\n', s | soft_break_modifier, VK_RETURN, 1, 0x1c);    // Send a lone Enter keystroke otherwise.
+                    ////generate('\r', s, VK_RETURN, 1, 0x1c); // Emulate Enter.
+                    ////if (noni) generate('\n', s);
+                    ////else      generate('\r', s | SHIFT_PRESSED, VK_RETURN, 1, 0x1c /*os::nt::takevkey<VK_RETURN>().key*/); // Emulate hitting Enter. Pressed Shift to soft line break when pasting from clipboard.
+                    //auto soft_break_modifier = mouse_reporting ? 0 : SHIFT_PRESSED; // Emulate Shift+Enter if no mouse reporting enabled.
+                    //generate('\n', s | soft_break_modifier, VK_RETURN, 1, 0x1c);    // Send a lone Enter keystroke otherwise.
+                    // Send Enter keystroke without any modifiers because it could be a sort of sendinput data.
+                    generate('\n', s, VK_RETURN, 1, 0x1c);
                 }
                 else
                 {

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -66,7 +66,7 @@ namespace netxs::gui
         { }
         void hide() { live = faux; }
         void show() { live = true; }
-        void wipe() { std::memset(data.data(), 0, (sz_t)area.size.x * area.size.y * sizeof(argb)); }
+        void wipe() { std::memset(data.data(), 0, (sz_t)area.size.x * area.size.y * sizeof(argb{})); }
         auto resized() { return area.size != prev.size; }
         template<bool Forced = faux>
         void strike(rect r)

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -66,7 +66,7 @@ namespace netxs::gui
         { }
         void hide() { live = faux; }
         void show() { live = true; }
-        void wipe() { std::memset(data.data(), 0, (sz_t)area.size.x * area.size.y * sizeof(argb{})); }
+        void wipe() { std::memset((void*)data.data(), 0, (sz_t)area.size.x * area.size.y * sizeof(argb)); }
         auto resized() { return area.size != prev.size; }
         template<bool Forced = faux>
         void strike(rect r)

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -66,6 +66,8 @@ namespace netxs::gui
         { }
         void hide() { live = faux; }
         void show() { live = true; }
+        void wipe() { std::memset(data.data(), 0, (sz_t)area.size.x * area.size.y * sizeof(argb)); }
+        auto resized() { return area.size != prev.size; }
         template<bool Forced = faux>
         void strike(rect r)
         {
@@ -1312,11 +1314,11 @@ namespace netxs::gui
             if (hdc) ::DeleteDC(hdc);
             for (auto eventid : klok) ::KillTimer(hWnd, eventid);
         }
-        auto canvas(bool wipe = faux)
+        auto canvas(bool zeroize = faux)
         {
             if (hdc && area)
             {
-                if (area.size != prev.size)
+                if (resized())
                 {
                     auto ptr = (void*)nullptr;
                     auto bmi = BITMAPINFO{ .bmiHeader = { .biSize        = sizeof(BITMAPINFOHEADER),
@@ -1328,7 +1330,7 @@ namespace netxs::gui
                     if (auto hbm = ::CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, &ptr, 0, 0)) // 0.050 ms
                     {
                         //auto new_data = bits{ std::span<argb>{ (argb*)ptr, (sz_t)area.size.x * area.size.y }, area };
-                        //if (!wipe) // Crop.
+                        //if (!zeroize) // Crop.
                         //{
                         //    auto d = new_data.data();
                         //    auto s = data.data();
@@ -1343,13 +1345,13 @@ namespace netxs::gui
                         //}
                         //data = new_data;
                         ::DeleteObject(::SelectObject(hdc, hbm));
-                        wipe = faux;
+                        zeroize = faux;
                         prev.size = area.size;
                         data = bits{ std::span<argb>{ (argb*)ptr, (sz_t)area.size.x * area.size.y }, area };
                     }
                     else log("%%Compatible bitmap creation error: %ec%", prompt::gui, ::GetLastError());
                 }
-                if (wipe) std::memset(data.data(), 0, (sz_t)area.size.x * area.size.y * sizeof(argb));
+                if (zeroize) wipe();
             }
             data.move(area.coor);
             return data;
@@ -2533,8 +2535,6 @@ namespace netxs::gui
             layers[client].area.size += size_delta;
             layers[blinky].area = layers[client].area - border;
             gridsz = layers[blinky].area.size / cellsz;
-            blink_count = 0;
-            blink_mask.assign(gridsz.x * gridsz.y, 0);
             auto sizechanged = proxy.w.winsize != gridsz;
             if (fsmode != state::maximized)
             {
@@ -2695,7 +2695,7 @@ namespace netxs::gui
             auto blink_canvas = blink_layer.canvas();
             auto origin = blink_canvas.coor();
             auto blinks = blink_mask.begin() + offset;
-            auto p = rect{origin + start, cellsz };
+            auto p = rect{ origin + start, cellsz };
             auto m = origin + blink_canvas.size();
             while (head != tail)
             {
@@ -2732,7 +2732,7 @@ namespace netxs::gui
         }
         void draw_header() { draw_title(header, head_grid); }
         void draw_footer() { draw_title(footer, foot_grid); }
-        bool check_blinky()
+        void check_blinky()
         {
             auto changed = std::exchange(blinking, !!blink_count) != blinking;
             if (changed)
@@ -2748,7 +2748,6 @@ namespace netxs::gui
                     layers[client].stop_timer(timers::blink);
                 }
             }
-            return changed;
         }
         void update_gui()
         {
@@ -2760,6 +2759,20 @@ namespace netxs::gui
             {
                 if (what == task::all)
                 {
+                    if (blink_count)
+                    {
+                        blink_count = 0;
+                        blink_mask.assign(gridsz.x * gridsz.y, 0);
+                        if(!layers[blinky].resized()) // Manually zeroize blinking canvas if its size has not changed.
+                        {
+                            layers[blinky].wipe();
+                        }
+                        layers[blinky].strike<true>(layers[blinky].area);
+                    }
+                    else // Keep blink mask size in sync.
+                    {
+                        blink_mask.resize(gridsz.x * gridsz.y);
+                    }
                     auto bitmap_lock = proxy.bitmap_dtvt.freeze();
                     auto& grid = bitmap_lock.thing.image;
                     fill_stripe(grid.begin(), grid.end());

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1036,7 +1036,7 @@ namespace netxs::input
                         meta.remove_prefix(1);
                         if (auto v = utf::to_int(meta))
                         {
-                            static constexpr auto max_value = twod{ 3000, 2000 }; //todo unify
+                            static constexpr auto max_value = twod{ 1000, 500 }; //todo unify
                             size.x = v.value();
                             if (meta)
                             {

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1161,6 +1161,7 @@ namespace netxs::input
             anyShift = LShift | RShift,
             anyAltGr = anyAlt | anyCtrl,
             anyWin   = LWin   | RWin,
+            anyMod   = anyAlt | anyCtrl | anyShift | anyWin,
         };
 
         static auto build_alone_key()
@@ -1431,11 +1432,7 @@ namespace netxs::input
         auto chord(si32 k, Args&&... mods)
         {
             if constexpr (sizeof...(mods)) return k == keybd::keycode && (meta(mods) && ...);
-            else                           return k == keybd::keycode;
-        }
-        auto kbmod()
-        {
-            return meta(hids::anyCtrl | hids::anyAlt | hids::anyShift | hids::anyWin);
+            else                           return k == keybd::keycode && !meta(hids::anyMod);
         }
 
         // hids: Stop handeling this event.

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1036,7 +1036,7 @@ namespace netxs::input
                         meta.remove_prefix(1);
                         if (auto v = utf::to_int(meta))
                         {
-                            static constexpr auto max_value = twod{ 2000, 1000 }; //todo unify
+                            static constexpr auto max_value = twod{ 3000, 2000 }; //todo unify
                             size.x = v.value();
                             if (meta)
                             {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -173,6 +173,8 @@ namespace netxs::ui
             si32 def_altscr;
             bool def_alt_on;
 
+            text send_input;
+
             static void recalc_buffer_metrics(si32& def_length, si32& def_growdt, si32& def_growmx)
             {
                 if (def_growdt == 0)
@@ -200,6 +202,7 @@ namespace netxs::ui
                      { "reverse", commands::fx::reverse }};
 
                 config.cd("/config/term/");
+                send_input =             config.take("sendinput", text{});
                 def_mxline = std::max(1, config.take("scrollback/maxline",   si32{ 65535 }));
                 def_length = std::max(1, config.take("scrollback/size",      si32{ 40000 }));
                 def_growdt = std::max(0, config.take("scrollback/growstep",  si32{ 0 }    ));
@@ -7360,6 +7363,7 @@ namespace netxs::ui
                 {
                     auto& title = wtrack.get(ansi::osc_title);
                     if (title.empty()) wtrack.set(ansi::osc_title); // Set default title if it is empty.
+                    if (config.send_input.size()) ipccon.write<faux>(config.send_input);
                 });
                 appcfg.win = target->panel;
                 ipccon.runapp(*this, appcfg, fdlink);

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1266,7 +1266,7 @@ namespace netxs::app::vtm
                 ->plugin<pro::frame>()
                 ->plugin<pro::light>()
                 ->plugin<pro::focus>()
-                ->limits(dot_11, { 400,200 }) //todo unify, set via config
+                ->limits(dot_11, { 1000, 500 }) //todo unify, set via config
                 ->invoke([&](auto& boss)
                 {
                     boss.base::kind(base::reflow_root);

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1266,7 +1266,7 @@ namespace netxs::app::vtm
                 ->plugin<pro::frame>()
                 ->plugin<pro::light>()
                 ->plugin<pro::focus>()
-                ->limits(dot_11, { 1000, 500 }) //todo unify, set via config
+                ->limits(dot_11)
                 ->invoke([&](auto& boss)
                 {
                     boss.base::kind(base::reflow_root);

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -669,7 +669,7 @@ namespace netxs::app::vtm
             {
                 boss.LISTEN(tier::release, hids::events::mouse::button::drag::start::any, gear, memo)
                 {
-                    if (boss.size().inside(gear.coord) && !gear.kbmod())
+                    if (boss.size().inside(gear.coord) && !gear.meta(hids::anyMod))
                     if (drags || !gear.capture(boss.id)) return;
                     {
                         drags = true;
@@ -680,21 +680,21 @@ namespace netxs::app::vtm
                 boss.LISTEN(tier::release, hids::events::mouse::button::drag::pull::any, gear, memo)
                 {
                     if (!drags) return;
-                    if (gear.kbmod()) proceed(faux);
-                    else              coord = gear.coord - gear.delta.get();
+                    if (gear.meta(hids::anyMod)) proceed(faux);
+                    else                         coord = gear.coord - gear.delta.get();
                 };
                 boss.LISTEN(tier::release, hids::events::mouse::button::drag::stop::any, gear, memo)
                 {
                     if (!drags) return;
-                    if (gear.kbmod()) proceed(faux);
-                    else              proceed(true);
+                    if (gear.meta(hids::anyMod)) proceed(faux);
+                    else                         proceed(true);
                     gear.setfree();
                 };
                 boss.LISTEN(tier::release, hids::events::mouse::button::drag::cancel::any, gear, memo)
                 {
                     if (!drags) return;
-                    if (gear.kbmod()) proceed(faux);
-                    else              proceed(true);
+                    if (gear.meta(hids::anyMod)) proceed(faux);
+                    else                         proceed(true);
                     gear.setfree();
                 };
                 boss.LISTEN(tier::release, e2::render::background::prerender, parent_canvas, memo)

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -214,7 +214,7 @@ R"==(
                 <repeat_rate    = 30ms  /> <!-- Repeat rate.                                         -->
             </timings>
             <limits>
-                <window size=3000x2000/>  <!-- Max window size -->
+                <window size=3000x2000/>  <!-- Max window grid size -->
             </limits>
         </defaults>
         <runapp>    <!-- Override defaults. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -214,7 +214,7 @@ R"==(
                 <repeat_rate    = 30ms  /> <!-- Repeat rate.                                         -->
             </timings>
             <limits>
-                <window size=2000x1000/>  <!-- Max window size -->
+                <window size=3000x2000/>  <!-- Max window size -->
             </limits>
         </defaults>
         <runapp>    <!-- Override defaults. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -273,7 +273,8 @@ R"==(
 )==" // C2026 String too big, trailing characters truncated.
 R"==(
     <term>       <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
-        <cwdsync=" cd $P\n"/>   <!-- Command to sync the current working directory. When 'Sync' is active, $P (case sensitive) will be replaced with the current path received via OSC9;9 notification. Prefixed with a space to avoid touching command history. -->
+        <sendinput=""/>  <!-- Send input on startup. E.g. sendinput="echo test\n" -->
+        <cwdsync=" cd $P\n"/>  <!-- Command to sync the current working directory. When 'Sync' is active, $P (case sensitive) will be replaced with the current path received via OSC9;9 notification. Prefixed with a space to avoid touching command history. -->
         <scrollback>
             <size=40000    />   <!-- Initial scrollback buffer size. -->
             <growstep=0    />   <!-- Scrollback buffer grow step. The buffer behaves like a ring in case of zero. -->


### PR DESCRIPTION
Changes:
- Change the default window grid size limits to 3000x2000 cells. It is configurable via `settings.xml`.
- Fix issue with redrawing of blinking text (SGR 5/6).
- Built-in terminal:
  - Enable to send input on startup.
    `command line`:
    ```bash
    vtm -c "<config><term sendinput='echo 123\n'/></config>" -r vtty
    ```