### PR TITLE
Enable CJK wrapping for IME composition preview

### DIFF
--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -22,7 +22,7 @@ Option                  | Description
 `-l`, `--listconfig`    | Print configuration.
 `-t`, `--tui`           | Force TUI mode.
 `-g`, `--gui`           | Force GUI mode.
-`-i`, `--install`       | Perform system-wide installation.
+`-i`, `--install`       | Perform system-wide installation. Desktop Server will always run in Session 0 in user context on Windows.<br>Don't use system-wide intallation in case you want to run GUI apps from vtm desktop environment, see "Session 0 Isolation" on the Web for details.
 `-u`, `--uninstall`     | Perform system-wide deinstallation.
 `-q`, `--quiet`         | Disable logging.
 `-x`, `--script <cmds>` | Specifies script commands to be run by the desktop when ready.

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -22,7 +22,7 @@ Option                  | Description
 `-l`, `--listconfig`    | Print configuration.
 `-t`, `--tui`           | Force TUI mode.
 `-g`, `--gui`           | Force GUI mode.
-`-i`, `--install`       | Perform system-wide installation. Desktop Server will always run in Session 0 in user context on Windows.<br>Don't use system-wide intallation in case you want to run GUI apps from vtm desktop environment, see "Session 0 Isolation" on the Web for details.
+`-i`, `--install`       | Perform system-wide installation. Desktop Server will always run in Session 0 in user context on Windows.<br>Don't use system-wide installation in case you want to run GUI apps from the vtm desktop environment, see "Session 0 Isolation" on the Web for details.
 `-u`, `--uninstall`     | Perform system-wide deinstallation.
 `-q`, `--quiet`         | Disable logging.
 `-x`, `--script <cmds>` | Specifies script commands to be run by the desktop when ready.

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -22,7 +22,7 @@ Option                  | Description
 `-l`, `--listconfig`    | Print configuration.
 `-t`, `--tui`           | Force TUI mode.
 `-g`, `--gui`           | Force GUI mode.
-`-i`, `--install`       | Perform system-wide installation. Desktop Server will always run in Session 0 in user context on Windows.<br>Don't use system-wide installation in case you want to run GUI apps from the vtm desktop environment, see "Session 0 Isolation" on the Web for details.
+`-i`, `--install`       | Perform system-wide installation. Desktop Server will always run in Session 0 in user context on Windows.<br>Don't use system-wide installation in case you plan to run GUI apps from the vtm desktop environment. See "Session 0 Isolation" on the Web for details.
 `-u`, `--uninstall`     | Perform system-wide deinstallation.
 `-q`, `--quiet`         | Disable logging.
 `-x`, `--script <cmds>` | Specifies script commands to be run by the desktop when ready.

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1110,14 +1110,14 @@ namespace netxs::ansi
 
     struct runtime
     {
-        bool iswrapln;
-        bool isr_to_l;
-        bool isrlfeed;
-        bool straight; // runtime: Text substring retrieving direction.
-        bool centered;
-        bool arighted;
-        si32 tabwidth;
-        dent textpads;
+        bool iswrapln = true;
+        bool isr_to_l = faux;
+        bool isrlfeed = faux;
+        bool straight = true; // runtime: Text substring retrieving direction.
+        bool centered = faux;
+        bool arighted = faux;
+        si32 tabwidth = 8;
+        dent textpads = {};
 
         void combine(deco const& global, deco const& custom)
         {

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99";
+    static const auto version = "v0.9.99.01";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -3896,12 +3896,17 @@ namespace netxs::ui
                 canvas.fill(handle, [&](cell& c){ c.link(boss.bell::id).xlight(); });
             }
         };
-        static constexpr auto underline = [](auto& /*boss*/, auto& canvas, auto handle, auto object_len, auto handle_len, auto region_len, auto /*wide*/)
+        static constexpr auto underline = [](auto& boss, auto& canvas, auto handle, auto object_len, auto handle_len, auto region_len, auto /*wide*/)
         {
             if (object_len && handle_len != region_len) // Show only if it is oversized.
             {
-                //canvas.fill(handle, [](cell& c){ c.und(!c.und()); });
-                canvas.fill(handle, [](cell& c){ c.und(true); });
+                auto fgc = boss.color().fgc();
+                auto src = boss.base::This();
+                while (!fgc && (src = src->parent())) // Detect scrollbar/underline color.
+                {
+                    fgc = src->color().fgc();
+                }
+                canvas.fill(handle, [&](cell& c){ c.unc(fgc).und(true); });
             }
         };
     }

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -2553,12 +2553,12 @@ namespace netxs::ui
         svga cmode = svga::vtrgb; // face: Color mode.
 
         // face: Print proxy something else at the specified coor.
-        template<class T, class P>
+        template<bool Split = true, class T, class P>
         void output_proxy(T const& block, twod coord, P proxy)
         {
             flow::sync(block);
             flow::ac(coord);
-            flow::compose<true>(block, proxy);
+            flow::compose<Split>(block, proxy);
         }
         // face: Print something else at the specified coor.
         template<bool Split = true, class T, class P = noop>

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2353,8 +2353,8 @@ namespace netxs::ui
                 auto find = selection_active()
                          && match.length()
                          && owner.selmod == mime::textonly;
-                canvas.move(full.coor);
-                dest.fill(canvas, cell::shaders::fuse);
+                canvas.move(full.coor - dest.coor());
+                dest.plot(canvas, cell::shaders::fuse);
                 if (find)
                 {
                     if (auto area = canvas.area())

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -166,6 +166,9 @@ int main(int argc, char* argv[])
             "\n    -t, --tui            Force TUI mode."
             "\n    -g, --gui            Force GUI mode."
             "\n    -i, --install        Perform system-wide installation."
+            #if defined(WIN32)
+            " Server will run always in Session 0 Isolation."
+            #endif
             "\n    -u, --uninstall      Perform system-wide deinstallation."
             "\n    -q, --quiet          Disable logging."
             "\n    -x, --script <cmds>  Specifies script commands."


### PR DESCRIPTION
Changes:
- GUI mode:
  - Enable CJK wrapping for IME composition preview.
  - Fix GUI window position after reconnecting via RDP or change the active display layout.
- Add Session 0 Isolation notes: Don't use system-wide installation on Windows in case you want to run GUI apps from the vtm desktop environment. See "Session 0 Isolation" on the Web for details.
- Make window menu scrollbar color (white underline) consistent.