### PR TITLE
Make mouse event synthesis consistent with Windows Console Subsystem public API docs

### DIFF
--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1391,10 +1391,8 @@ namespace netxs::ansi
         ansi::csi_t<T> csier; // vt_parser: CSI table.
         ansi::esc_t<T> intro; // vt_parser:  C0 table.
         ansi::osc_t<T> oscer; // vt_parser: OSC table.
-        si32           decsg; // vt_parser: Enable DEC Special Graphics Mode (if non zero).
 
         vt_parser()
-            : decsg{ 0 }
         {
             intro.resize(ctrl::non_control);
             //intro[ctrl::bs ] = backspace;
@@ -1424,7 +1422,7 @@ namespace netxs::ansi
             };
             auto y = [&](auto const& cluster){ client->post(cluster); };
 
-            utf::decode(s, y, utf8, decsg);
+            utf::decode(s, y, utf8, client->decsg);
             client->flush();
         }
         // vt_parser: Static UTF-8/ANSI parser proc.
@@ -1670,14 +1668,13 @@ namespace netxs::ansi
         }
 
         // vt_parser: Designate G0 Character Set.
-        static void g0__(qiew& ascii, T*& /*p*/)
+        static void g0__(qiew& ascii, T*& client)
         {
             // ESC ( C
             //      [-]
             if (ascii)
             {
-                auto& parser = ansi::get_parser<T>();
-                parser.decsg = ascii.front() == '0' ? 1 : 0; // '0' - DEC Special Graphics mode.
+                client->decsg = ascii.front() == '0' ? 1 : 0; // '0' - DEC Special Graphics mode.
                 ascii.pop_front(); // Take Final character C for designating 94-character sets.
             }
         }
@@ -1688,6 +1685,7 @@ namespace netxs::ansi
         deco style{}; // parser: Parser style.
         deco state{}; // parser: Parser style last state.
         mark brush{}; // parser: Parser brush.
+        si32 decsg{}; // parser: DEC Special Graphics Mode.
 
     private:
         grid proto_cells{}; // parser: Proto lyric.

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.01";
+    static const auto version = "v0.9.99.02";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -934,10 +934,11 @@ struct impl : consrv
             ondata.reset();
             signal.notify_one();
         }
-        void mouse(input::hids& gear, bool moved, twod coord)
+        void mouse(input::hids& gear, twod coord)
         {
             auto state = os::nt::ms_kbstate(gear.ctlstate);
             auto bttns = gear.m_sys.buttons & 0b00011111;
+            auto moved = gear.m_sys.buttons == gear.m_sav.buttons && gear.m_sys.wheelfp == 0.f; // No events means mouse move. MSFT: "MOUSE_EVENT_RECORD::dwEventFlags: If this value is zero, it indicates a mouse button being pressed or released". Far Manager relies on this.
             auto flags = ui32{};
             if (moved) flags |= MOUSE_MOVED;
             for (auto i = 0_sz; i < dclick.size(); i++)
@@ -5119,8 +5120,8 @@ struct impl : consrv
             }
         }
     }
-    void mouse(input::hids& gear, bool moved, twod coord, input::mouse::prot /*encod*/,
-                 input::mouse::mode /*state*/) { events.mouse(gear, moved, coord); }
+    void mouse(input::hids& gear, bool /*moved*/, twod coord, input::mouse::prot /*encod*/,
+                 input::mouse::mode /*state*/) { events.mouse(gear, coord);        }
     void keybd(input::hids& gear, bool decckm) { events.keybd(gear, decckm);       }
     void paste(view block)                     { events.paste(block);              }
     void focus(bool state)                     { events.focus(state);              }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -990,6 +990,7 @@ namespace netxs::ui
 
                 deco style{}; // Parser style state.
                 mark brush{}; // Parser brush state.
+                si32 decsg{}; // Parser DEC Special Graphcs Mode.
                 twod coord{}; // Screen coord state.
                 bool decom{}; // Origin mode  state.
                 sgrs stack{}; // Stach for saved sgr attributes.
@@ -1452,6 +1453,7 @@ namespace netxs::ui
     virtual void clear_all()
             {
                 parser::state = {};
+                parser::decsg = {};
                 decom = faux;
                 rtb();
                 selection_cancel();
@@ -1737,6 +1739,7 @@ namespace netxs::ui
                 parser::flush();
                 saved = { .style = parser::style,
                           .brush = parser::brush,
+                          .decsg = parser::decsg,
                           .coord = coord,
                           .decom = decom };
                 if (decom) saved.coord.y -= y_top;
@@ -1752,6 +1755,7 @@ namespace netxs::ui
                 set_coord(coor);
                 parser::style = saved.style;
                 parser::brush = saved.brush;
+                parser::decsg = saved.decsg;
                 parser::flush(); // Proceed new style.
             }
             // bufferbase: CSI n T/S  Scroll down/up, scrolled up lines are pushed to the scrollback buffer.

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -310,12 +310,12 @@ namespace netxs::ui
             using mode = input::mouse::mode;
             using prot = input::mouse::prot;
 
-            term&       owner; // m_tracking: Terminal object reference.
-            testy<twod> coord; // m_tracking: Last coord of mouse cursor.
-            subs        token; // m_tracking: Subscription token.
-            prot        encod; // m_tracking: Mouse encoding protocol.
-            mode        state; // m_tracking: Mouse reporting mode.
-            si32        smode; // m_tracking: Selection mode state backup.
+            term& owner; // m_tracking: Terminal object reference.
+            twod  coord; // m_tracking: Last coord of mouse cursor.
+            subs  token; // m_tracking: Subscription token.
+            prot  encod; // m_tracking: Mouse encoding protocol.
+            mode  state; // m_tracking: Mouse reporting mode.
+            si32  smode; // m_tracking: Selection mode state backup.
 
             m_tracking(term& owner)
                 : owner{ owner                   },


### PR DESCRIPTION
Changes:
- Make mouse event synthesis consistent with Windows Console Subsystem public API docs:
  ```
  MOUSE_EVENT_RECORD::dwEventFlags
  The type of mouse event. If this value is zero, it indicates a mouse button being pressed or released.
  ```
- Fix `vttest` of screen features. Save DEC Special Graphics Mode state along with cursor position.