### PR TITLE
Don't use Session 0 implicitly to host desktop server on Windows

### DIFF
--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -22,7 +22,8 @@ Option                  | Description
 `-l`, `--listconfig`    | Print configuration.
 `-t`, `--tui`           | Force TUI mode.
 `-g`, `--gui`           | Force GUI mode.
-`-i`, `--install`       | Perform system-wide installation. Desktop Server will always run in Session 0 in user context on Windows.<br>Don't use system-wide installation in case you plan to run GUI apps from the vtm desktop environment. See "Session 0 Isolation" on the Web for details.
+`-i`, `--install`       | Perform system-wide installation. Allow Desktop Server to run in user context in Session 0 on Windows.<br>Placing Desktop Server in Session 0 allows console applications to run independently of the user's GUI login session. Note: This prevents GUI applications from running from the vtm desktop environment. See "Session 0 Isolation" on the Web for details.
+`-0`, `--session0`      | Use Session 0 to run Desktop Server in background.
 `-u`, `--uninstall`     | Perform system-wide deinstallation.
 `-q`, `--quiet`         | Disable logging.
 `-x`, `--script <cmds>` | Specifies script commands to be run by the desktop when ready.

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.02";
+    static const auto version = "v0.9.99.03";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2563,7 +2563,7 @@ namespace netxs::os
                 environ = backup;
             #endif
         }
-        auto fork([[maybe_unused]] text prefix, [[maybe_unused]] view config, [[maybe_unused]] view script = {})
+        auto fork([[maybe_unused]] bool system, [[maybe_unused]] text prefix, [[maybe_unused]] view config, [[maybe_unused]] view script = {})
         {
             auto msg = [](auto& success)
             {
@@ -2575,7 +2575,7 @@ namespace netxs::os
 
                 auto success = std::unique_ptr<std::remove_pointer<fd_t>::type, decltype(&::CloseHandle)>(nullptr, &::CloseHandle);
                 auto svclink = os::invalid_fd;
-                if (nt::session() && nt::connect(os::path::ipcname, FILE_WRITE_DATA, svclink)) // Try vtm service to run server in Session 0.
+                if (system && nt::session() && nt::connect(os::path::ipcname, FILE_WRITE_DATA, svclink)) // Try vtm service to run server in Session 0.
                 {
                     auto envars = os::env::add(); // Take current envvars block.
                     auto size = (ui32)(prefix.size() + config.size() + envars.size() + 2);

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -24,6 +24,7 @@ int main(int argc, char* argv[])
     auto script = text{};
     auto trygui = true;
     auto forced = faux;
+    auto system = faux;
     auto getopt = os::process::args{ argc, argv };
     if (getopt.starts("ssh"))//app::ssh::id))
     {
@@ -36,6 +37,10 @@ int main(int argc, char* argv[])
         {
             auto ok = os::process::dispatch();
             return ok ? 0 : 1;
+        }
+        else if (getopt.match("-0", "--session0"))
+        {
+            system = true;
         }
         else if (getopt.match("-t", "--tui"))
         {
@@ -157,8 +162,8 @@ int main(int argc, char* argv[])
             "\n"
             "\n  Options:"
             "\n"
-            "\n    By default, " + vtm + " runs Desktop Client, running an additional"
-            "\n    instance with Desktop Server in background if it is not found."
+            "\n    By default, " + vtm + " runs Desktop Client and Desktop Server"
+            "\n    in background if it is not running."
             "\n"
             "\n    -h, -?, --help       Print command-line options."
             "\n    -v, --version        Print version."
@@ -167,7 +172,8 @@ int main(int argc, char* argv[])
             "\n    -g, --gui            Force GUI mode."
             "\n    -i, --install        Perform system-wide installation."
             #if defined(WIN32)
-            " Server will run always in Session 0 Isolation."
+            " Allow Desktop Server to run in Session 0."
+            "\n    -0, --session0       Use Session 0 to run Desktop Server in background."
             #endif
             "\n    -u, --uninstall      Perform system-wide deinstallation."
             "\n    -q, --quiet          Disable logging."
@@ -391,7 +397,7 @@ int main(int argc, char* argv[])
         else if (whoami == type::client && !client)
         {
             log("%%New desktop session for [%userid%]", prompt::main, userid.first);
-            auto [success, successor] = os::process::fork(prefix, config.utf8());
+            auto [success, successor] = os::process::fork(system, prefix, config.utf8());
             if (successor)
             {
                 whoami = type::server;
@@ -424,7 +430,7 @@ int main(int argc, char* argv[])
 
         if (whoami == type::daemon)
         {
-            auto [success, successor] = os::process::fork(prefix, config.utf8(), script);
+            auto [success, successor] = os::process::fork(system, prefix, config.utf8(), script);
             if (successor)
             {
                 whoami = type::server;


### PR DESCRIPTION
# Changes (Windows only)
- Don't use Session 0 implicitly to host desktop server on Windows.
- Add `-0`/`--session0` cli options to explicitly use `Session 0` to host the vtm desktop server running in background.

# Notes
System-wide installation (vtm -i) allows Desktop Server to run in user context in Session 0 on Windows. Placing Desktop Server in Session 0  (vtm -0) allows console applications to run independently of the user's GUI login session. But this prevents GUI applications from running from the vtm desktop environment. See "Session 0 Isolation" on the Web for details.

You can test this behavior by running the following command from the vtm desktop environment to launch an Explorer GUI window:

- `command line`:
  ```
  start .
  ```