### PR TITLE
Sync keybd modifiers for unfocused window on mouse hover

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.05";
+    static const auto version = "v0.9.99.06";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;


### PR DESCRIPTION
### Changes (Windows only)
- Sync keyboard modifiers for unfocused window on mouse hover.
- Make multi-focus safer.