### PR TITLE
Make GUI mode the default mode on Windows

### DIFF
--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -13,7 +13,7 @@ vtm -i | -u | -v | -?
 <script relay via piped redirection> | vtm [ -p <id> ]
 ```
 
-> By default, vtm runs Desktop Client, running an additional instance with Desktop Server in background if it is not found.
+> By default, vtm runs Desktop Client, running an additional instance with Desktop Server in background if it is not running.
 
 Option                  | Description
 ------------------------|-------------------------------------------------------
@@ -23,17 +23,17 @@ Option                  | Description
 `-t`, `--tui`           | Force TUI mode.
 `-g`, `--gui`           | Force GUI mode.
 `-i`, `--install`       | Perform system-wide installation. Allow Desktop Server to run in user context in Session 0 on Windows.<br>Placing Desktop Server in Session 0 allows console applications to run independently of the user's GUI login session. Note: This prevents GUI applications from running from the vtm desktop environment. See "Session 0 Isolation" on the Web for details.
-`-0`, `--session0`      | Use Session 0 to run Desktop Server in background.
 `-u`, `--uninstall`     | Perform system-wide deinstallation.
+`-0`, `--session0`      | Use Session 0 to run Desktop Server in background.
 `-q`, `--quiet`         | Disable logging.
 `-x`, `--script <cmds>` | Specifies script commands to be run by the desktop when ready.
-`-c`, `--config <file>` | Specifies the settings file to load.
-`-p`, `--pin <id>`      | Specifies the desktop id it is pinned to.
+`-c`, `--config <file>` | Specifies a settings file to load or plain xml-data to merge.
+`-p`, `--pin <id>`      | Specifies the desktop id it will be pinned to.
 `-s`, `--server`        | Run Desktop Server.
 `-d`, `--daemon`        | Run Desktop Server in background.
 `-m`, `--monitor`       | Run Desktop Monitor.
 `-r`, `--`, `--run`     | Run desktop applet standalone.
-`<type>`                | Desktop applet type to run.
+`<type>`                | Desktop applet to run.
 `<args...>`             | Desktop applet arguments.
 
 ### Desktop Applets
@@ -49,7 +49,7 @@ The following commands have a short form:
   - `vtm -r vtty <cui_app...>` can be shortened to `vtm <cui_app...>`.
   - `vtm -r dtty ssh <user@host dtvt_app...>` can be shortened to `vtm ssh <user@host dtvt_app...>`.
 
-Instead of the path to the configuration file, the configuration body itself can be specified:
+It is possible to specify plain xml-data to modify current settings (this case is detected by the `<config` literal at the beginning):
 
   - `vtm -c \"<config><term><scrollback size=1000000/></term></config>\" -r term`.
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -20,12 +20,16 @@ graph LR
 - Hardcoded settings
   - See [/src/vtm.xml](../src/vtm.xml) for reference.
 - `--config <file>` CLI option
-  - The current configuration can be patched by specifying a configuration fragment in plain text in place of the configuration file path (this case is detected by the `<config` keyword at the beginning).  
+  - `<file>`: Path to the configuration file.  
+    `command line`:
+    ```bash
+    vtm -c "/path/to/settings.xml" -r term
+    ```
+  - The current configuration can be patched by specifying plain xml-data in place of the `<file>` (this case is detected by the `<config` keyword at the beginning).  
     `command line`:
     ```bash
     vtm -c "<config><term><scrollback size=1000000 growstep=100000/></term></config>" -r term
     ```
-
 - Global settings
   - on POSIX: `/etc/vtm/settings.xml`
   - on Windows: `%programdata%/vtm/settings.xml`

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -20,7 +20,7 @@ graph LR
 - Hardcoded settings
   - See [/src/vtm.xml](../src/vtm.xml) for reference.
 - `--config <file>` CLI option
-  - Instead of the path to the configuration file, the configuration body itself can be specified (this case is detected by the keyword `<config` at the beginning).  
+  - The current configuration can be patched by specifying a configuration fragment in plain text in place of the configuration file path (this case is detected by the `<config` keyword at the beginning).  
     `command line`:
     ```bash
     vtm -c "<config><term><scrollback size=1000000 growstep=100000/></term></config>" -r term

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.08";
+    static const auto version = "v0.9.99.09";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -930,7 +930,7 @@ namespace netxs::ui
             }
         }
         // base: Update nested object.
-        virtual void update(sptr old_item_ptr, sptr new_item_ptr)
+        virtual void replace(sptr old_item_ptr, sptr new_item_ptr)
         {
             auto head = subset.begin();
             auto tail = subset.end();

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -166,6 +166,23 @@ namespace netxs::ui
                     s11n::ack_input_fields.send(canal, ext_gear_id, field_list);
                 });
             }
+            void handle(s11n::xs::command     lock)
+            {
+                //todo implement
+                //auto cmd = eccc{ .cmd = lock.thing.utf8 };
+                //notify(scripting::events::invoke, cmd);
+                auto cmd = qiew{ lock.thing.utf8 };
+                if (cmd.starts_with("exit") || cmd.starts_with("quit"))
+                {
+                    lock.unlock();
+                    disconnect();
+                }
+                else
+                {
+                    auto msg = utf::concat(prompt::repl, ansi::err("Not implemented: "), ansi::clr(yellowlt, utf::trim(cmd, "\r\n")));
+                    s11n::logs.send(canal, ui32{}, datetime::now(), msg);
+                }
+            }
             void handle(s11n::xs::sysfocus    lock)
             {
                 auto& focus = lock.thing;
@@ -1303,6 +1320,7 @@ namespace netxs::ui
             //LISTEN(tier::general, e2::conio::logs, utf8, tokens)
             //{
             //    //todo application internal log output
+            //    //conio.logs.send(canal, os::process::id.first, os::process::id.second, text{ utf8 });
             //};
             LISTEN(tier::anycast, e2::form::upon::started, item_ptr, tokens)
             {

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2365,7 +2365,7 @@ namespace netxs::ui
                     auto new_item = item_template(data_src, arg_new_value)
                                          ->depend(data_src);
                     item_shadow = ptr::shadow(new_item); // Update current item shadow.
-                    boss_ptr->update(old_item, new_item);
+                    boss_ptr->replace(old_item, new_item);
                 }
             };
             branch(new_item);
@@ -3482,7 +3482,7 @@ namespace netxs::ui
             else base::subset.clear();
         }
         // rail: Update nested object.
-        void update(sptr old_object, sptr new_object) override
+        void replace(sptr old_object, sptr new_object) override
         {
             auto object_coor = dot_00;
             if (!empty())
@@ -3990,7 +3990,7 @@ namespace netxs::ui
             else base::subset.clear();
         }
         // pads: Update nested object.
-        void update(sptr old_object, sptr new_object) override
+        void replace(sptr old_object, sptr new_object) override
         {
             remove(old_object);
             attach(new_object);

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -713,7 +713,7 @@ namespace netxs::gui
                     netxs::set_flag<fontcat::loaded>(fontstat[i].s);
                     auto is_primary = fallback.empty();
                     auto& f = fallback.emplace_back(*this, barefont, i, cellsize, is_primary);
-                    log("%%Using font '%fontname%' (%iscolor%). Order %index%.", prompt::gui, f.font_name, f.color ? "color" : "monochromatic", fallback.size() - 1);
+                    log("%%Using font '%fontname%' (%iscolor%). Index %index%.", prompt::gui, f.font_name, f.color ? "color" : "monochromatic", fallback.size() - 1);
                 }
                 return hit;
             };

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -8,7 +8,7 @@
 
 using namespace netxs;
 
-enum class type { client, server, daemon, logmon, runapp, hlpmsg, config };
+enum class type { client, server, daemon, logmon, runapp, config };
 enum class code { noaccess, noserver, nodaemon, nosrvlog, interfer, errormsg };
 
 int main(int argc, char* argv[])
@@ -22,11 +22,10 @@ int main(int argc, char* argv[])
     auto errmsg = text{};
     auto vtpipe = text{};
     auto script = text{};
-    auto trygui = true;
-    auto forced = faux;
+    auto rungui = true;
     auto system = faux;
     auto getopt = os::process::args{ argc, argv };
-    if (getopt.starts("ssh"))//app::ssh::id))
+    if (getopt.starts("ssh"))
     {
         whoami = type::runapp;
         params = getopt.rest();
@@ -44,12 +43,11 @@ int main(int argc, char* argv[])
         }
         else if (getopt.match("-t", "--tui"))
         {
-            trygui = faux;
+            rungui = faux;
         }
         else if (getopt.match("-g", "--gui"))
         {
-            trygui = true;
-            forced = true;
+            rungui = true;
         }
         else if (getopt.match("-r", "--", "--run", /*UD*/"--runapp"))
         {
@@ -114,8 +112,98 @@ int main(int argc, char* argv[])
         }
         else if (getopt.match("-?", "-h", "--help"))
         {
-            whoami = type::hlpmsg;
-            break;
+            os::dtvt::initialize();
+            netxs::logger::wipe();
+            auto syslog = os::tty::logger();
+            log("\nText-based Desktop Environment " + text{ app::shared::version } +
+                "\n(virtual terminal multiplexer)"
+                "\n"
+                "\n  Syntax:"
+                "\n"
+                "\n    vtm [ -c <file> ][ -q ][ -p <id> ][ -s | -d | -m ][ -x <cmds> ]"
+                "\n    vtm [ -c <file> ][ -q ][ -t | -g ][ -r [ <type> ]][ <args...> ]"
+                "\n    vtm [ -c <file> ]  -l"
+                "\n    vtm -i | -u | -v | -?"
+                "\n"
+                "\n    <script relay via piped redirection> | vtm [ -p <id> ]"
+                "\n"
+                "\n  Options:"
+                "\n"
+                "\n    By default, vtm runs Desktop Client and Desktop Server."
+                "\n"
+                "\n    -h, -?, --help       Print command-line options."
+                "\n    -v, --version        Print version."
+                "\n    -l, --listconfig     Print configuration."
+                "\n    -t, --tui            Force TUI mode."
+                "\n    -g, --gui            Force GUI mode."
+                "\n    -i, --install        Perform system-wide installation."
+                #if defined(WIN32)
+                " Allow Desktop Server to run in Session 0."
+                #endif
+                "\n    -u, --uninstall      Perform system-wide deinstallation."
+                #if defined(WIN32)
+                "\n    -0, --session0       Use Session 0 to run Desktop Server in background."
+                #endif
+                "\n    -q, --quiet          Disable logging."
+                "\n    -x, --script <cmds>  Specifies script commands."
+                "\n    -c, --config <file>  Specifies a settings file to load or plain xml-data to merge."
+                "\n    -p, --pin <id>       Specifies the desktop id it will be pinned to."
+                "\n    -s, --server         Run Desktop Server."
+                "\n    -d, --daemon         Run Desktop Server in background."
+                "\n    -m, --monitor        Run Desktop Monitor."
+                "\n    -r, --, --run        Run desktop applet standalone."
+                "\n    <type>               Desktop applet to run."
+                "\n    <args...>            Desktop applet arguments."
+                "\n"
+                "\n    Desktop applet             │ Type │ Arguments"
+                "\n    ───────────────────────────┼──────┼─────────────────────────────────────────────────"
+                "\n    Teletype Console (default) │ vtty │ CUI application with arguments to run."
+                "\n    Terminal Console           │ term │ CUI application with arguments to run."
+                "\n    DirectVT Gateway           │ dtvt │ DirectVT-aware application to run."
+                "\n    DirectVT Gateway with TTY  │ dtty │ CUI application to run, forwarding DirectVT I/O."
+                "\n"
+                "\n    The following commands have a short form:"
+                "\n"
+                "\n      'vtm -r vtty <cui_app...>' can be shortened to 'vtm <cui_app...>'."
+                "\n      'vtm -r dtty ssh <user@host dtvt_app...>' can be shortened to 'vtm ssh <user@host dtvt_app...>'."
+                "\n"
+                "\n  Settings loading order:"
+                "\n"
+                "\n    - Initialize hard-coded settings."
+                "\n    - In case of using the '--config <file>' option and the <file> can be loaded:"
+                "\n        - Overlay the settings from the <file>."
+                "\n      otherwise:"
+                "\n        - Overlay system-wide settings from " + os::path::expand(app::shared::sys_config).second + "."
+                "\n        - Overlay user-wise settings from "   + os::path::expand(app::shared::usr_config).second + "."
+                "\n    - Overlay the settings received from the DirectVT Gateway."
+                "\n"
+                "\n    It is possible to specify plain xml-data to modify current settings:"
+                "\n    (detected by the `<config` literal)"
+                "\n"
+                "\n      vtm -c \"<config><term><scrollback size=1000000/></term></config>\" -r term"
+                "\n"
+                "\n  Script commands:"
+                "\n"
+                "\n    Syntax: \"<command>([<args...>])[; <command>([<args...>]); ... <command>([<args...>])]\""
+                "\n"
+                "\n    Command                       │ Description"
+                "\n    ──────────────────────────────┼───────────────────────────────────────────────────────"
+                "\n    vtm.run([<attrs...>])         │ Create and run a menu item constructed using"
+                "\n                                  │ a space-separated list of <attr>=<val>."
+                "\n                                  │ Run a temporary menu item constructed using"
+                "\n                                  │ default attributes if no arguments specified."
+                "\n    vtm.set(id=<id> [<attrs...>]) │ Create or override a menu item using a space-separated"
+                "\n                                  │ list of <attr>=<val>."
+                "\n    vtm.del([<id>])               │ Delete the taskbar menu item by <id>."
+                "\n                                  │ Delete all menu items if no <id> specified."
+                "\n    vtm.dtvt(<dtvt_app...>)       │ Create a temporary menu item and run DirectVT Gateway"
+                "\n                                  │ to host specified <dtvt_app...>."
+                "\n    vtm.selected(<id>)            │ Set selected menu item using specified <id>."
+                "\n    vtm.shutdown()                │ Terminate the running desktop session."
+                "\n"
+                "\n    The following characters in script commands will be de-escaped: \\e \\t \\r \\n \\a \\\" \\' \\\\"
+                "\n");
+            return 0;
         }
         else if (getopt.match("-v", "--version"))
         {
@@ -137,107 +225,10 @@ int main(int argc, char* argv[])
         }
     }
 
-    trygui = trygui && (whoami == type::runapp
-                     || whoami == type::client
-                     || whoami == type::hlpmsg);
-    os::dtvt::initialize(trygui, forced);
+    rungui = rungui && (whoami == type::runapp
+                     || whoami == type::client);
+    os::dtvt::initialize(rungui);
     os::dtvt::checkpoint();
-
-    if (whoami == type::hlpmsg)
-    {
-        netxs::logger::wipe();
-        auto syslog = os::tty::logger();
-        auto vtm = os::process::binary<true>();
-        auto pad = text(os::process::binary<true>().size(), ' ');
-        log("\nText-based Desktop Environment " + text{ app::shared::version } +
-            "\n"
-            "\n  Syntax:"
-            "\n"
-            "\n    " + vtm + " [ -c <file> ][ -q ][ -p <id> ][ -s | -d | -m ][ -x <cmds> ]"
-            "\n    " + vtm + " [ -c <file> ][ -q ][ -t | -g ][ -r [ <type> ]][ <args...> ]"
-            "\n    " + vtm + " [ -c <file> ]  -l"
-            "\n    " + vtm + " -i | -u | -v | -?"
-            "\n"
-            "\n    <script relay via piped redirection> | " + vtm + " [ -p <id> ]"
-            "\n"
-            "\n  Options:"
-            "\n"
-            "\n    By default, " + vtm + " runs Desktop Client and Desktop Server"
-            "\n    in background if it is not running."
-            "\n"
-            "\n    -h, -?, --help       Print command-line options."
-            "\n    -v, --version        Print version."
-            "\n    -l, --listconfig     Print configuration."
-            "\n    -t, --tui            Force TUI mode."
-            "\n    -g, --gui            Force GUI mode."
-            "\n    -i, --install        Perform system-wide installation."
-            #if defined(WIN32)
-            " Allow Desktop Server to run in Session 0."
-            "\n    -0, --session0       Use Session 0 to run Desktop Server in background."
-            #endif
-            "\n    -u, --uninstall      Perform system-wide deinstallation."
-            "\n    -q, --quiet          Disable logging."
-            "\n    -x, --script <cmds>  Specifies script commands."
-            "\n    -c, --config <file>  Specifies the settings file to load."
-            "\n    -p, --pin <id>       Specifies the desktop id it is pinned to."
-            "\n    -s, --server         Run Desktop Server."
-            "\n    -d, --daemon         Run Desktop Server in background."
-            "\n    -m, --monitor        Run Desktop Monitor."
-            "\n    -r, --, --run        Run desktop applet standalone."
-            "\n    <type>               Desktop applet type to run."
-            "\n    <args...>            Desktop applet arguments."
-            "\n"
-            "\n    Desktop applet             │ Type │ Arguments"
-            "\n    ───────────────────────────┼──────┼─────────────────────────────────────────────────"
-            "\n    Teletype Console (default) │ vtty │ CUI application with arguments to run."
-            "\n    Terminal Console           │ term │ CUI application with arguments to run."
-            "\n    DirectVT Gateway           │ dtvt │ DirectVT-aware application to run."
-            "\n    DirectVT Gateway with TTY  │ dtty │ CUI application to run, forwarding DirectVT I/O."
-            "\n"
-            "\n    The following commands have a short form:"
-            "\n"
-            "\n      'vtm -r vtty <cui_app...>' can be shortened to 'vtm <cui_app...>'."
-            "\n      'vtm -r dtty ssh <user@host dtvt_app...>' can be shortened to 'vtm ssh <user@host dtvt_app...>'."
-            "\n"
-            "\n    Instead of the path to the configuration file, the configuration body itself can be specified:"
-            "\n"
-            "\n      'vtm -c \"<config><term><scrollback size=1000000/></term></config>\" -r term'."
-            "\n"
-            "\n  Settings loading order:"
-            "\n"
-            "\n    - Initialize hard-coded settings."
-            "\n    - In case of using the '--config <file>' option and the <file> can be loaded:"
-            "\n        - Overlay the settings from the <file>."
-            "\n      otherwise:"
-            "\n        - Overlay system-wide settings from " + os::path::expand(app::shared::sys_config).second + "."
-            "\n        - Overlay user-wise settings from "   + os::path::expand(app::shared::usr_config).second + "."
-            "\n    - Overlay the settings received from the DirectVT Gateway."
-            "\n"
-            "\n  Script commands:"
-            "\n"
-            "\n    Syntax: \"<command>([<args...>])[; <command>([<args...>]); ... <command>([<args...>])]\""
-            "\n"
-            "\n    Command                       │ Description"
-            "\n    ──────────────────────────────┼───────────────────────────────────────────────────────"
-            "\n    vtm.run([<attrs...>])         │ Create and run a menu item constructed using"
-            "\n                                  │ a space-separated list of <attr>=<val>."
-            "\n                                  │ Run a temporary menu item constructed using"
-            "\n                                  │ default attributes if no arguments specified."
-            "\n    vtm.set(id=<id> [<attrs...>]) │ Create or override a menu item using a space-separated"
-            "\n                                  │ list of <attr>=<val>."
-            "\n    vtm.del([<id>])               │ Delete the taskbar menu item by <id>."
-            "\n                                  │ Delete all menu items if no <id> specified."
-            "\n    vtm.dtvt(<dtvt_app...>)       │ Create a temporary menu item and run DirectVT Gateway"
-            "\n                                  │ to host specified <dtvt_app...>."
-            "\n    vtm.selected(<id>)            │ Set selected menu item using specified <id>."
-            "\n    vtm.shutdown()                │ Terminate the running desktop session."
-            "\n"
-            "\n    The following characters in script commands will be de-escaped: \\e \\t \\r \\n \\a \\\" \\' \\\\"
-            "\n"
-            );
-        os::release(faux);
-        return 0;
-    }
 
     if (os::dtvt::vtmode & ui::console::redirio && (whoami == type::runapp || whoami == type::client))
     {


### PR DESCRIPTION
### Changes
- Make GUI mode the default mode on Windows.
- Overlay the specified XML fragment instead of replacing the configuration when using the `vtm -c <xmlfragment/>` cli option.