### PR TITLE
Improve setting GUI popups to foreground

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.10";
+    static const auto version = "v0.9.99.11";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3813,11 +3813,7 @@ namespace netxs::gui
         }
         void window_make_focused()    { ::SetFocus((HWND)master.hWnd); } // Calls WM_KILLFOCOS(prev) + WM_ACTIVATEAPP(next) + WM_SETFOCUS(next).
         void window_make_exposed()    { ::SetWindowPos((HWND)master.hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOSENDCHANGING | SWP_NOACTIVATE); }
-        void window_make_foreground() // Neither ::SetFocus() nor ::SetActiveWindow() can switch focus immediately.
-        {
-            ::SetForegroundWindow((HWND)master.hWnd);
-            ::AllowSetForegroundWindow(ASFW_ANY);
-        }
+        void window_make_foreground() { ::SetForegroundWindow((HWND)master.hWnd); } //::AllowSetForegroundWindow(ASFW_ANY); } // Neither ::SetFocus() nor ::SetActiveWindow() can switch focus immediately.
         void window_shutdown()        { ::SendMessageW((HWND)master.hWnd, WM_CLOSE, NULL, NULL); }
         void window_cleanup()         { ::RemoveClipboardFormatListener((HWND)master.hWnd); ::PostQuitMessage(0); }
         twod mouse_get_pos()          { return twod{ winmsg.pt.x, winmsg.pt.y }; }

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3594,7 +3594,7 @@ namespace netxs::gui
             if (eventid)
             {
                 if (std::find(s.klok.begin(), s.klok.end(), eventid) == s.klok.end()) s.klok.push_back(eventid);
-                ::SetCoalescableTimer((HWND)s.hWnd, eventid, datetime::round<ui32>(elapse), nullptr, TIMERV_DEFAULT_COALESCING);
+                ::SetTimer((HWND)s.hWnd, eventid, datetime::round<ui32>(elapse), nullptr);
             }
         }
         void layer_timer_stop(layer& s, ui32 eventid)

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3645,7 +3645,6 @@ namespace netxs::os
                 os::stdin_fd  = fd_t{ ptr::test(::GetStdHandle(STD_INPUT_HANDLE ), os::invalid_fd) };
                 os::stdout_fd = fd_t{ ptr::test(::GetStdHandle(STD_OUTPUT_HANDLE), os::invalid_fd) };
                 os::stderr_fd = fd_t{ ptr::test(::GetStdHandle(STD_ERROR_HANDLE ), os::invalid_fd) };
-                ::AllowSetForegroundWindow(ASFW_ANY);
             #else
             {
                 auto conmode = -1;


### PR DESCRIPTION
### Changes

- Improve setting GUI popups to foreground. Use timers instead of creating new threads.