### PR TITLE
Allow compact XML syntax

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -30,6 +30,10 @@ graph LR
     ```bash
     vtm -c "<config><term><scrollback size=1000000 growstep=100000/></term></config>" -r term
     ```
+    `command line (compact xml syntax)`:
+    ```bash
+    vtm -c "<config/term/scrollback size=1000000 growstep=100000/>" -r term
+    ```
 - Global settings
   - on POSIX: `/etc/vtm/settings.xml`
   - on Windows: `%programdata%/vtm/settings.xml`
@@ -180,6 +184,24 @@ The following declarations have the same meaning:
     <listitem id=first />
     <listitem id=second/>
 </list>
+```
+
+### Compact XML syntax
+
+The following declarations have the same meaning:
+
+```xml
+<config>
+    <document>
+        <thing="thinf_value">
+            <name="name_value"/>
+        </thing>
+    </document>
+</config>
+```
+
+```xml
+<config/document/thing="thing_value" name="name_value"/>
 ```
 
 ### Configuration structure

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.11";
+    static const auto version = "v0.9.99.12";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;


### PR DESCRIPTION
### Changes

- Allow compact XML syntax. Sort of https://github.com/directvt/vtm/issues/330#issuecomment-1369641803.
  `command line`:
  ```cmd
  vtm -c "<config/term/colors/default fgc=0xFF00ffff bgc=0xff00007f/>" -r term
  ```
  `~/.config/vtm/settings.xml`:
  ```xml
  <config/term/colors/default fgc=0xFF00ffff bgc=0xff00007f/>
  ```