### PR TITLE
Fix cli mode abrackadabras

### DIFF
--- a/src/netxs/apps/calc.cpp
+++ b/src/netxs/apps/calc.cpp
@@ -54,7 +54,6 @@ int main(int argc, char* argv[])
     }
     auto params = getopt.rest();
 
-    os::dtvt::checkpoint();
     banner();
     if (errmsg.size())
     {

--- a/src/netxs/apps/term.cpp
+++ b/src/netxs/apps/term.cpp
@@ -54,7 +54,6 @@ int main(int argc, char* argv[])
     }
     auto params = getopt.rest();
 
-    os::dtvt::checkpoint();
     banner();
     if (errmsg.size())
     {

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.12";
+    static const auto version = "v0.9.99.13";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -228,7 +228,6 @@ int main(int argc, char* argv[])
     rungui = rungui && (whoami == type::runapp
                      || whoami == type::client);
     os::dtvt::initialize(rungui);
-    os::dtvt::checkpoint();
 
     if (os::dtvt::vtmode & ui::console::redirio && (whoami == type::runapp || whoami == type::client))
     {


### PR DESCRIPTION
### Changes

- Fix cli mode abrackadabras.
  ```
    Syntax: "<command>([<args...>])[; <command>([<args...>]); ... <command>([<args...>])]"

    Command                       Γöé Description
    ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓö╝ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
    vtm.run([<attrs...>])         Γöé Create and run a menu item constructed using
                                  Γöé a space-separated list of <attr>=<val>.
                                  Γöé Run a temporary menu item constructed using
                                  Γöé default attributes if no arguments specified.
    vtm.set(id=<id> [<attrs...>]) Γöé Create or override a menu item using a space-separated
                                  Γöé list of <attr>=<val>.
    vtm.del([<id>])               Γöé Delete the taskbar menu item by <id>.
                                  Γöé Delete all menu items if no <id> specified.
    vtm.dtvt(<dtvt_app...>)       Γöé Create a temporary menu item and run DirectVT Gateway
                                  Γöé to host specified <dtvt_app...>.
    vtm.selected(<id>)            Γöé Set selected menu item using specified <id>.
    vtm.shutdown()                Γöé Terminate the running desktop session.
  ```