### PR TITLE
Fix recursive escaping

### DIFF
--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -49,10 +49,6 @@ The following commands have a short form:
   - `vtm -r vtty <cui_app...>` can be shortened to `vtm <cui_app...>`.
   - `vtm -r dtty ssh <user@host dtvt_app...>` can be shortened to `vtm ssh <user@host dtvt_app...>`.
 
-It is possible to specify plain xml-data to modify current settings (this case is detected by the `<config` literal at the beginning):
-
-  - `vtm -c "<config><term><scrollback size=1000000/></term></config>" -r term`
-
 ### Settings loading order
 
 ```mermaid
@@ -69,6 +65,8 @@ graph LR
         D ---> H["Overlay the settings received
         from the DirectVT Gateway"]
         G --> H
+        H --> O[Overlay
+        plain xml-data]
     end
 ```
 
@@ -79,6 +77,15 @@ graph LR
     - Merge with system-wide settings from `/etc/vtm/settings.xml` (`%PROGRAMDATA%/vtm/settings.xml` on Windows).
     - Merge with user-wise settings from `~/.config/vtm/settings.xml`.
 - Merge with DirectVT packet received from the hosting DirectVT Gateway.
+- Merge the settings from the plain xml-data.  
+  The plain xml-data could be specified in place of `<file>` in `--config <file>` option:
+  ```cmd
+  vtm -c "<config><term><scrollback size=1000000/></term></config>" -r term
+  ```
+  or (using compact syntax)
+  ```cmd
+  vtm -c "<config/term/scrollback size=1000000/>" -r term
+  ```
 
 ### Script commands
 
@@ -93,7 +100,14 @@ Script Command                           | Description
 `vtm.selected(<item_id>)`                | Set selected menu item using specified `<id>` (affected to the desktop RightDrag gesture and Tile's `+` button).
 `vtm.shutdown()`                         | Terminate the running desktop session.
 
-The following characters in script commands will be de-escaped: `\e` `\t` `\r` `\n` `\a` `\"` `\'` `\\`
+### Character escaping
+
+The following characters in commands will be de-escaped:
+
+Chars                              | Description
+-----------------------------------|-------------------------------------------
+`\e`, `\t`, `\r`, `\n`, `\a`, `\\` | For every occurrence.
+`\"` or `\'`                       | Iif a literal is enclosed in corresponding quotes.
 
 ### Usage Examples
 

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -104,10 +104,15 @@ Script Command                           | Description
 
 The following characters in commands will be de-escaped:
 
-Characters                         | Description
------------------------------------|-------------------------------------------
-`\e`, `\t`, `\r`, `\n`, `\a`, `\\` | For every occurrence.
-`\"` or `\'`                       | IIF a literal is enclosed in corresponding quotes.
+Characters | Expanded to
+-----------|-------------------------
+`\a`       | ASCII 0x07 BEL
+`\t`       | ASCII 0x09 TAB
+`\n`       | ASCII 0x0A LF
+`\r`       | ASCII 0x0D CR
+`\e`       | ASCII 0x1B ESC
+`\\`       | ASCII 0x5C Backslash
+`$0`       | Current module full path
 
 ### Usage Examples
 

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -104,10 +104,10 @@ Script Command                           | Description
 
 The following characters in commands will be de-escaped:
 
-Chars                              | Description
+Characters                         | Description
 -----------------------------------|-------------------------------------------
 `\e`, `\t`, `\r`, `\n`, `\a`, `\\` | For every occurrence.
-`\"` or `\'`                       | Iif a literal is enclosed in corresponding quotes.
+`\"` or `\'`                       | IIF a literal is enclosed in corresponding quotes.
 
 ### Usage Examples
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -14,6 +14,8 @@ graph LR
         D ---> H["Overlay the settings received
         from the DirectVT Gateway"]
         G --> H
+        H --> O[Overlay
+        plain xml-data]
     end
 ```
 
@@ -24,15 +26,6 @@ graph LR
     `command line`:
     ```bash
     vtm -c "/path/to/settings.xml" -r term
-    ```
-  - The current configuration can be patched by specifying plain xml-data in place of the `<file>` (this case is detected by the `<config` keyword at the beginning).  
-    `command line`:
-    ```bash
-    vtm -c "<config><term><scrollback size=1000000 growstep=100000/></term></config>" -r term
-    ```
-    `command line (compact xml syntax)`:
-    ```bash
-    vtm -c "<config/term/scrollback size=1000000 growstep=100000/>" -r term
     ```
 - Global settings
   - on POSIX: `/etc/vtm/settings.xml`
@@ -56,6 +49,14 @@ graph LR
         </menu>
         ...
     ```
+- The plain xml-data could be specified in place of `<file>` in `--config <file>` option:
+  ```cmd
+  vtm -c "<config><term><scrollback size=1000000/></term></config>" -r term
+  ```
+  or (using compact syntax)
+  ```cmd
+  vtm -c "<config/term/scrollback size=1000000/>" -r term
+  ```
 
 ## Configuration body format (settings.xml)
 
@@ -78,8 +79,8 @@ Configuration body format is a slightly modified XML-format which allows to stor
    - `\a`  ASCII 0x07 BEL
    - `\n`  ASCII 0x0A LF
    - `\\`  ASCII 0x5C Backslash
-   - `\"`  ASCII 0x22 Quotes
-   - `\'`  ASCII 0x27 Single quote
+   - `\"`  ASCII 0x22 Quotes (iif a value literal is enclosed in `"`)
+   - `\'`  ASCII 0x27 Single quote (iif a value literal is enclosed in `'`)
    - `$0`  Current module full path
 
 Let's take the following object hierarchy as an example:

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -248,7 +248,7 @@ All value literals containing spaces must be enclosed in double or single quotes
 
 Value type | Format
 -----------|-----------------
-`RGBA`     | `#rrggbbaa` \| `0xaarrggbb` \| `rrr,ggg,bbb,aaa` \| 256-color index
+`RGBA`     | Hex: `#rrggbbaa` \| Hex: `0xaarrggbb` \| Decimal: `r,g,b,a` \| 256-color index: `i`
 `boolean`  | `true` \| `false` \| `yes` \| `no` \| `1` \| `0` \| `on` \| `off` \| `undef`
 `string`   | _UTF-8 text string_
 `x;y`      | _integer_ <any_delimeter> _integer_

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -49,7 +49,7 @@ graph LR
         </menu>
         ...
     ```
-- The plain xml-data could be specified in place of `<file>` in `--config <file>` option:
+- The plain xml-data could be specified in place of `<file>` in `--config <file>` option:  
   `command line`:
   ```bash
   vtm -c "<config><term><scrollback size=1000000/></term></config>" -r term

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -50,11 +50,13 @@ graph LR
         ...
     ```
 - The plain xml-data could be specified in place of `<file>` in `--config <file>` option:
-  ```cmd
+  `command line`:
+  ```bash
   vtm -c "<config><term><scrollback size=1000000/></term></config>" -r term
   ```
   or (using compact syntax)
-  ```cmd
+  `command line`:
+  ```bash
   vtm -c "<config/term/scrollback size=1000000/>" -r term
   ```
 
@@ -73,6 +75,8 @@ Configuration body format is a slightly modified XML-format which allows to stor
  - Each object can be defined in any way, either using an XML-attribute or an XML-subobject syntax:
    - `<... name=value />`, `<...> <name> "value" </name> </...>`, and `<...> <name=value /> </...>` has the same meaning.
  - The object name that ending in an asterisk indicates that this object is not an object, but it is a template for all subsequent objects with the same name in the same scope. See `Template Example` below.
+ - Compact syntax is allowed.
+   - `<node0><node1><thing name=value/></node1></node0>` and `<node0/node1/thing name=value/>` has the same meaning.
  - Escaped characters:
    - `\e`  ASCII 0x1B ESC
    - `\t`  ASCII 0x09 TAB

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -78,10 +78,11 @@ Configuration body format is a slightly modified XML-format which allows to stor
  - Compact syntax is allowed.
    - `<node0><node1><thing name=value/></node1></node0>` and `<node0/node1/thing name=value/>` has the same meaning.
  - Escaped characters with special meaning:
-   - `\e`  ASCII 0x1B ESC
-   - `\t`  ASCII 0x09 TAB
    - `\a`  ASCII 0x07 BEL
+   - `\t`  ASCII 0x09 TAB
    - `\n`  ASCII 0x0A LF
+   - `\r`  ASCII 0x0D CF
+   - `\e`  ASCII 0x1B ESC
    - `\\`  ASCII 0x5C Backslash
    - `$0`  Current module full path
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -54,7 +54,7 @@ graph LR
   ```bash
   vtm -c "<config><term><scrollback size=1000000/></term></config>" -r term
   ```
-  or (using compact syntax)
+  or (using compact syntax)  
   `command line`:
   ```bash
   vtm -c "<config/term/scrollback size=1000000/>" -r term

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -77,14 +77,12 @@ Configuration body format is a slightly modified XML-format which allows to stor
  - The object name that ending in an asterisk indicates that this object is not an object, but it is a template for all subsequent objects with the same name in the same scope. See `Template Example` below.
  - Compact syntax is allowed.
    - `<node0><node1><thing name=value/></node1></node0>` and `<node0/node1/thing name=value/>` has the same meaning.
- - Escaped characters:
+ - Escaped characters with special meaning:
    - `\e`  ASCII 0x1B ESC
    - `\t`  ASCII 0x09 TAB
    - `\a`  ASCII 0x07 BEL
    - `\n`  ASCII 0x0A LF
    - `\\`  ASCII 0x5C Backslash
-   - `\"`  ASCII 0x22 Quotes (iif a value literal is enclosed in `"`)
-   - `\'`  ASCII 0x27 Single quote (iif a value literal is enclosed in `'`)
    - `$0`  Current module full path
 
 Let's take the following object hierarchy as an example:

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -777,7 +777,7 @@ namespace netxs::app::tile
             else  // Add application.
             {
                 utf::trim_front(utf8, " ");
-                auto menuid = utf::get_tail(utf8, " ,)").str();
+                auto menuid = utf::take_front(utf8, " ,)").str();
                 if (menuid.empty()) return slot;
 
                 utf::trim_front(utf8, " ,");

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1863,8 +1863,7 @@ namespace netxs::ansi
                         }
                         if (next == tail)
                         {
-                            //utf8 = { head, prev }; //todo Clang 13.0.0 doesn't get it // preserve ESC at the end
-                            utf8 = view{ &(*head), (size_t)(prev - head) }; // preserve ESC at the end
+                            utf8 = { head, prev }; // preserve ESC at the end
                             return utf8;
                         }
                     }
@@ -1879,8 +1878,7 @@ namespace netxs::ansi
                             {
                                 if (tail - step < 8)
                                 {
-                                    //utf8 = { head, prev }; //todo Clang 13.0.0 doesn't get it // preserve ESC at the end
-                                    utf8 = view{ &(*head), (size_t)(prev - head) }; // preserve ESC at the end
+                                    utf8 = { head, prev }; // preserve ESC at the end
                                 }
                                 else
                                 {
@@ -1901,8 +1899,7 @@ namespace netxs::ansi
                         }
                         if (next == tail)
                         {
-                            //utf8 = { head, prev }; //todo Clang 13.0.0 doesn't get it // preserve ESC at the end
-                            utf8 = view{ &(*head), (size_t)(prev - head) }; // preserve ESC at the end
+                            utf8 = { head, prev }; // preserve ESC at the end
                             return utf8;
                         }
                     }
@@ -1926,8 +1923,7 @@ namespace netxs::ansi
                         }
                         if (next == tail)
                         {
-                            //utf8 = { head, prev }; //todo Clang 13.0.0 doesn't get it // preserve ESC at the end
-                            utf8 = view{ &(*head), (size_t)(prev - head) }; // preserve ESC at the end
+                            utf8 = { head, prev }; // preserve ESC at the end
                             return utf8;
                         }
                     }
@@ -1945,8 +1941,7 @@ namespace netxs::ansi
                     {
                         if (++next == tail)
                         {
-                            //utf8 = { head, prev }; //todo Clang 13.0.0 doesn't get it // preserve ESC at the end
-                            utf8 = view{ &(*head), (size_t)(prev - head) }; // preserve ESC at the end
+                            utf8 = { head, prev }; // preserve ESC at the end
                         }
                     }
                     // test Esc + byte: ESC 7 8 D E H M ...
@@ -1983,8 +1978,7 @@ namespace netxs::ansi
                 }
                 else
                 {
-                    //utf8 = { head, prev }; //todo Clang 13.0.0 doesn't get it // preserve ESC at the end
-                    utf8 = view{ &(*head), (size_t)(prev - head) }; // preserve ESC at the end
+                    utf8 = { head, prev }; // preserve ESC at the end
                     return utf8;
                 }
             }

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.13";
+    static const auto version = "v0.9.99.14";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -463,7 +463,7 @@ namespace netxs::app::shared
     namespace load
     {
         template<bool Print = faux>
-        auto settings(view defaults, view cli_config_path, view patch)
+        auto settings(view defaults, qiew cli_config_path, view patch)
         {
             auto conf = xmls{ defaults };
             auto load = [&](qiew shadow)
@@ -506,9 +506,10 @@ namespace netxs::app::shared
                 log(prompt::pads, "Not found");
                 return faux;
             };
-            auto frag = utf::dequote(cli_config_path);
-            if (!frag.starts_with("<config")) frag = {}; // The configuration fragment could be specified directly in place of the configuration file path.
-            if (frag || !load(cli_config_path)) // Merge explicitly specified settings.
+            auto utf8 = text{ cli_config_path };
+            utf::dequote(utf8);
+            auto frag = utf8.starts_with("<config"); // The configuration fragment could be specified directly in place of the configuration file path.
+            if (frag || !load(utf8)) // Merge explicitly specified settings.
             {
                 load(app::shared::sys_config); // Merge system-wide settings.
                 load(app::shared::usr_config); // Merge user-wise settings.
@@ -516,8 +517,8 @@ namespace netxs::app::shared
             conf.fuse<Print>(patch); // Apply dtvt patch.
             if (frag)
             {
-                log("%%Apply the specified configuration fragment:\n%body%", prompt::apps, ansi::hi(frag));
-                conf.fuse<Print>(frag);
+                log("%%Apply the specified configuration fragment:\n%body%", prompt::apps, ansi::hi(utf8));
+                conf.fuse<Print>(utf8);
             }
             return conf;
         }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1947,10 +1947,7 @@ struct impl : consrv
         }
         auto decode_char(utfx code)
         {
-            static constexpr auto c0_wchr = { L'\0',L'☺', L'☻', L'♥', L'♦', L'♣', L'♠', L'•', L'◘', L'○', L'◙', L'♂', L'♀', L'♪', L'♫', L'☼',
-                                              L'►', L'◄', L'↕', L'‼', L'¶', L'§', L'▬', L'↨', L'↑', L'↓', L'→', L'←', L'∟', L'↔', L'▲', L'▼',
-                                              L'⌂' };
-                 if (code < 0x20 || code == 0x7F) code = *(c0_wchr.begin() + std::min<size_t>(code, c0_wchr.size() - 1));
+                 if (code < 0x20 || code == 0x7F) code = *(utf::c0_wchr.begin() + std::min<size_t>(code, utf::c0_wchr.size() - 1));
             else if (code < OEMtoBMP.size())      code = OEMtoBMP[code];
             else                                  code = defchar();
             return (wchr)code;
@@ -1973,12 +1970,9 @@ struct impl : consrv
         }
         auto decode(utfx code, text& toUTF8)
         {
-            static constexpr auto c0_view = { " "sv, "☺"sv, "☻"sv, "♥"sv, "♦"sv, "♣"sv, "♠"sv, "•"sv, "◘"sv, "○"sv, "◙"sv, "♂"sv, "♀"sv, "♪"sv, "♫"sv, "☼"sv,
-                                              "►"sv, "◄"sv, "↕"sv, "‼"sv, "¶"sv, "§"sv, "▬"sv, "↨"sv, "↑"sv, "↓"sv, "→"sv, "←"sv, "∟"sv, "↔"sv, "▲"sv, "▼"sv,
-                                              "⌂"sv };
             if (code < 0x20 || code == 0x7F)
             {
-                toUTF8 += *(c0_view.begin() + std::min<size_t>(code, c0_view.size() - 1));
+                toUTF8 += *(utf::c0_view.begin() + std::min<size_t>(code, utf::c0_view.size() - 1));
             }
             else
             {

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -682,7 +682,7 @@ struct impl : consrv
             if (src_map.empty()) return;
 
             auto rest = qiew{ line };
-            auto crop = utf::get_tail<faux>(rest, " \r\n");
+            auto crop = utf::take_front<faux>(rest, " \r\n");
             auto iter = src_map.find(utf::to_low(crop));
             if (iter == src_map.end()) return;
 
@@ -692,7 +692,7 @@ struct impl : consrv
             auto result = text{};
             while (data)
             {
-                result += utf::get_tail<faux>(data, "$");
+                result += utf::take_front<faux>(data, "$");
                 if (data.size() >= 2)
                 {
                     auto s = utf::pop_front(data, 2);

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -27,6 +27,7 @@
     #pragma comment(lib, "User32")
     #pragma comment(lib, "UserEnv")
     #pragma comment(lib, "AdvAPI32") // ::StartService() for arm arch
+    #pragma comment(lib, "Shell32")  // ::CommandLineToArgvW() for arm arch
 
 #else
 

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3794,8 +3794,7 @@ namespace netxs::ui
                     while (size.y-- > 0)
                     {
                         auto oldsz = batch.size;
-                        //auto proto = core::span{ curit, (size_t)size.x };
-                        auto proto = core::span{ &(*curit), (size_t)size.x }; //todo Clang 13.0.0 doesn't accept an iterator as an arg in the span ctor.
+                        auto proto = core::span{ curit, (size_t)size.x };
                         auto curln = line{ curid++, style, proto, width };
                         curln.shrink(block.mark());
                         batch.insert(start, std::move(curln));

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -579,6 +579,7 @@ namespace netxs::utf
         constexpr qiew(char const& v) noexcept : view(&v, 1) { }
         constexpr qiew(view const& v) noexcept : view(v) { }
                   qiew(text const& v) noexcept : view(v) { }
+        constexpr qiew(char const* ptr, auto&&... len) noexcept : view(ptr, std::forward<decltype(len)>(len)...) { }
         constexpr qiew& operator = (qiew const&) noexcept = default;
 
                  operator text () const { return text{ data(), size() }; }

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -581,7 +581,7 @@ namespace netxs::utf
         constexpr qiew(view const& v) noexcept : view(v) { }
                   qiew(text const& v) noexcept : view(v) { }
                   qiew(char const& v) noexcept : view(&v, 1) { }
-        constexpr qiew(auto* ptr, auto&&... len) noexcept : view(ptr, std::forward<decltype(len)>(len)...) { }
+        constexpr qiew(char const* ptr, auto&&... len) noexcept : view(ptr, std::forward<decltype(len)>(len)...) { }
         template<class Iter>
         constexpr qiew(Iter begin, Iter end) noexcept : view(begin, end) { }
         constexpr qiew& operator = (qiew const&) noexcept = default;

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -575,8 +575,8 @@ namespace netxs::utf
         constexpr qiew(view const& v) noexcept : view(v) { }
                   qiew(text const& v) noexcept : view(v) { }
                   qiew(char const& v) noexcept : view(&v, 1) { }
-        template<class T, class ...Args>
-        constexpr qiew(T* ptr, Args&&... len) noexcept : view(ptr, std::forward<Args>(len)...) { }
+        constexpr qiew(auto* ptr, auto&&... len) noexcept : view(ptr, std::forward<decltype(len)>(len)...) { }
+        constexpr qiew(auto begin, auto end) noexcept : view(begin, end) { }
         constexpr qiew& operator = (qiew const&) noexcept = default;
 
                  operator text () const { return text{ data(), size() }; }
@@ -1616,55 +1616,48 @@ namespace netxs::utf
         trim_back (utf8, delims);
         return utf8;
     }
-    auto get_quote(view& utf8, view delims, view skip = {}) // Without quotes.
+    auto quote(text utf8) // Add quotes around, and escape the quotes inside.
     {
+        auto crop = text{};
+        crop.reserve(utf8.size() * 2 + 2);
+        crop.push_back('\"');
         auto head = utf8.begin();
         auto tail = utf8.end();
-        auto coor = find_char(head, tail, delims);
-        if (std::distance(coor, tail) < 2)
+        while (head != tail)
         {
-            utf8 = view{};
-            return utf8;
+            auto c = *head++;
+            if (c == '\"') crop.push_back('\\');
+            crop.push_back(c);
         }
-        ++coor;
-        auto stop = find_char(coor, tail, delims);
-        if (stop == tail)
-        {
-            utf8 = view{};
-            return utf8;
-        }
-        //todo Clang 13.0.0 doesn't get it
-        //auto crop = view{ coor, stop };
-        auto crop = view{ &(*coor), (size_t)(stop - coor) };
-
-        utf8.remove_prefix(crop.size() + 2);
-        if (!skip.empty()) trim_front(utf8, skip);
+        crop.push_back('\"');
         return crop;
     }
-    auto get_quote(view& utf8) // With quotes.
+    void dequote(text& utf8) // Remove the quotes around if there are any, and un-escape the quotes inside.
     {
-        if (utf8.size() < 2)
+        if (utf8.size())
         {
-            utf8 = view{};
-            return utf8;
+            auto q = utf8.front();
+            if (utf8.size() > 1 && (q == '\'' || q == '\"') && utf8.back() == q)
+            {
+                auto iter = utf8.begin();
+                auto head = std::next(utf8.begin());
+                auto tail = std::prev(utf8.end());
+                while (head != tail)
+                {
+                    auto c = *head++;
+                    if (c == '\\' && head != tail && *head == q) // Drop escaping back slash.
+                    {
+                        head++;
+                        *iter++ = q;
+                    }
+                    else *iter++ = c;
+                }
+                utf8.resize(iter - utf8.begin());
+            }
         }
-        auto quot = utf8.front();
-        auto head = utf8.begin();
-        auto tail = utf8.end();
-        auto stop = find_char(head + 1, tail, quot);
-        if (stop == tail)
-        {
-            utf8 = view{};
-            return utf8;
-        }
-        //todo Clang 13.0.0 doesn't get it
-        //auto crop = view{ head, stop + 1 };
-        auto crop = view{ &(*head), (size_t)(stop + 1 - head) };
-        utf8.remove_prefix(crop.size());
-        return crop;
     }
     template<bool Lazy = true>
-    auto get_tail(view& utf8, view delims)
+    auto take_front(view& utf8, view delims)
     {
         auto head = utf8.begin();
         auto tail = utf8.end();
@@ -1673,87 +1666,73 @@ namespace netxs::utf
         {
             if constexpr (Lazy)
             {
-                utf8 = view{};
+                utf8 = {};
                 return qiew{ utf8 };
             }
             else
             {
                 auto crop = qiew{ utf8 };
-                utf8 = view{};
+                utf8 = {};
                 return crop;
             }
         }
-        //todo Clang 13.0.0 doesn't get it
-        //auto str = view{ head, stop };
-        auto str = qiew{ &(*head), (size_t)(stop - head) };
-        //utf8.remove_prefix(std::distance(head, stop));
+        auto str = qiew{ head, stop };
         utf8.remove_prefix(str.size());
         return str;
     }
+    auto take_quote(view& utf8, char delim) // Take the fragment inside the quotes (shadow).
+    {
+        if (utf8.size() < 2)
+        {
+            utf8 = {};
+            return utf8;
+        }
+        auto head = utf8.begin();
+        auto tail = utf8.end();
+        auto coor = head + 1;
+        auto stop = find_char(coor, tail, delim);
+        if (stop == tail)
+        {
+            utf8 = {};
+            return utf8;
+        }
+        auto crop = view{ coor, stop };
+        utf8.remove_prefix(crop.size() + 2);
+        return crop;
+    }
+    auto get_quote(view& utf8) // Get the quoted fragment, including quotes.
+    {
+        if (utf8.size() < 2)
+        {
+            utf8 = {};
+            return utf8;
+        }
+        auto quot = utf8.front();
+        auto head = utf8.begin();
+        auto tail = utf8.end();
+        auto stop = find_char(head + 1, tail, quot);
+        if (stop == tail)
+        {
+            utf8 = {};
+            return utf8;
+        }
+        auto crop = view{ head, stop + 1 };
+        utf8.remove_prefix(crop.size());
+        return crop;
+    }
     auto get_word(view& utf8, view delims = " ")
     {
-        return get_tail<faux>(utf8, delims);
-    }
-    auto quote(text utf8)
-    {
-        if (utf8.empty() || utf8.find(' ') != text::npos)
-        {
-                 if (utf8.find('\"') == text::npos) utf8 = '\"' + utf8 + '\"';
-            else if (utf8.find('\'') == text::npos) utf8 = '\'' + utf8 + '\'';
-            else
-            {
-                auto crop = text{};
-                auto head = utf8.begin();
-                auto tail = utf8.end();
-                crop.reserve(utf8.capacity());
-                crop.push_back('\"');
-                while (head != tail)
-                {
-                    auto c = *head++;
-                    if (c == '\\')
-                    {
-                        crop.push_back(c);
-                        if (head != tail) crop.push_back(*head++);
-                    }
-                    else if (c == '\"')
-                    {
-                        crop.push_back('\\');
-                        crop.push_back(c);
-                    }
-                    else crop.push_back(c);
-                }
-                crop.push_back('\"');
-                std::swap(crop, utf8);
-            }
-        }
-        return utf8;
-    }
-    auto dequote(qiew utf8)
-    {
-        if (utf8.size() > 1) 
-        {
-            auto c = utf8.front();
-            if ((c == '\'' || c == '"') && utf8.back() == c)
-            {
-                utf8.remove_prefix(1);
-                utf8.remove_suffix(1);
-            }
-        }
-        return utf8;
+        return take_front<faux>(utf8, delims);
     }
     // utf: Split text line into quoted tokens.
-    auto tokenize(view utf8, auto&& args, bool dequote = faux)
+    auto tokenize(view utf8, auto&& args)
     {
         utf8 = utf::trim(utf8);
         while (utf8.size())
         {
             auto c = utf8.front();
-            if (c == '\'' || c == '"')
-            {
-                args.emplace_back(dequote ? utf::get_quote(utf8, view{ &c, 1 })
-                                          : utf::get_quote(utf8));
-            }
-            else args.emplace_back(utf::get_word(utf8));
+            if (c == '\'' || c == '"') args.emplace_back(utf::get_quote(utf8));
+            else                       args.emplace_back(utf::get_word(utf8));
             utf::trim_front(utf8);
         }
         return args;

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -582,7 +582,8 @@ namespace netxs::utf
                   qiew(text const& v) noexcept : view(v) { }
                   qiew(char const& v) noexcept : view(&v, 1) { }
         constexpr qiew(auto* ptr, auto&&... len) noexcept : view(ptr, std::forward<decltype(len)>(len)...) { }
-        constexpr qiew(auto begin, auto end) noexcept : view(begin, end) { }
+        template<class Iter>
+        constexpr qiew(Iter begin, Iter end) noexcept : view(begin, end) { }
         constexpr qiew& operator = (qiew const&) noexcept = default;
 
                  operator text () const { return text{ data(), size() }; }

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -564,7 +564,7 @@ namespace netxs::utf
 
     struct qiew : public view
     {
-        using span = std::span<char>;
+        using view::view;
 
         struct hash
         {
@@ -575,15 +575,10 @@ namespace netxs::utf
             auto operator()(qiew lhs, qiew rhs) const { return lhs.compare(rhs) == 0; }
         };
 
-        constexpr qiew() noexcept : view() { }
         constexpr qiew(qiew const&) = default;
-        constexpr qiew(span const& v) noexcept : view(v.data(), v.size()) { }
+        constexpr qiew(char const& v) noexcept : view(&v, 1) { }
         constexpr qiew(view const& v) noexcept : view(v) { }
                   qiew(text const& v) noexcept : view(v) { }
-                  qiew(char const& v) noexcept : view(&v, 1) { }
-        constexpr qiew(char const* ptr, auto&&... len) noexcept : view(ptr, std::forward<decltype(len)>(len)...) { }
-        template<class Iter>
-        constexpr qiew(Iter begin, Iter end) noexcept : view(begin, end) { }
         constexpr qiew& operator = (qiew const&) noexcept = default;
 
                  operator text () const { return text{ data(), size() }; }

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -8,18 +8,22 @@
 
 namespace netxs::xml
 {
-    auto escape(qiew line)
+    auto escape(qiew line, auto... quote)
     {
         auto crop = text{};
         crop.reserve(line.size() * 2);
         while (line)
         {
             auto c = line.pop_front();
+            if constexpr (sizeof...(quote))
+            if (((c == quote && (crop.push_back('\\'), crop.push_back(quote), true))||...))
+            {
+                continue;
+            }
             switch (c)
             {
                 case '\033': crop.push_back('\\'); crop.push_back('e' ); break;
                 case   '\\': crop.push_back('\\'); crop.push_back('\\'); break;
-                case   '\"': crop.push_back('\\'); crop.push_back('\"'); break;
                 case   '\n': crop.push_back('\\'); crop.push_back('n' ); break;
                 case   '\r': crop.push_back('\\'); crop.push_back('r' ); break;
                 case   '\t': crop.push_back('\\'); crop.push_back('t' ); break;
@@ -31,34 +35,40 @@ namespace netxs::xml
         }
         return crop;
     }
-    auto unescape(qiew line)
+    auto unescape(qiew line, text& crop, auto... quote)
     {
-        auto crop = text{};
-        crop.reserve(line.size());
+        crop.reserve(crop.size() + line.size());
         while (line)
         {
             auto c = line.pop_front();
             if (c == '\\' && line)
             {
                 c = line.pop_front();
+                if constexpr (sizeof...(quote))
+                if (((c == quote && (crop.push_back(quote), true))||...))
+                {
+                    continue;
+                }
                 switch (c)
                 {
                     case 'e' : crop.push_back('\x1b'); break;
                     case 't' : crop.push_back('\t'  ); break;
-                    case 'r' : crop.push_back('\n'  ); break;
+                    case 'r' : crop.push_back('\r'  ); break;
                     case 'n' : crop.push_back('\n'  ); break;
                     case 'a' : crop.push_back('\a'  ); break;
-                    case '\"': crop.push_back('\"'  ); break;
-                    case '\'': crop.push_back('\''  ); break;
                     default:   crop.push_back('\\'  );
                                crop.push_back(c     ); break;
                 }
             }
             else crop.push_back(c);
         }
+    }
+    auto unescape(qiew line)
+    {
+        auto crop = text{};
+        xml::unescape(line, crop);
         return crop;
     }
-
     template<class T>
     auto take(qiew utf8) -> std::optional<T>
     {
@@ -504,9 +514,18 @@ namespace netxs::xml
             auto value() -> text
             {
                 auto crop = text{};
-                for (auto& v : body)
+                for (auto& value_placeholder : body)
                 {
-                    crop += xml::unescape(v->utf8);
+                    if (value_placeholder->kind == type::tag_value) // quotes tag_value quotes
+                    if (auto quote_placeholder = value_placeholder->prev.lock())
+                    if (quote_placeholder->utf8.size())
+                    if (quote_placeholder->kind == type::quotes)
+                    {
+                        auto quote = quote_placeholder->utf8.front();
+                        xml::unescape(value_placeholder->utf8, crop, quote);
+                        continue;
+                    }
+                    if (value_placeholder->utf8.size()) xml::unescape(value_placeholder->utf8, crop);
                 }
                 return crop;
             }
@@ -535,22 +554,25 @@ namespace netxs::xml
                         {
                             if (value.size())
                             {
-                                equal_placeholder->utf8 = " = ";
+                                equal_placeholder->utf8 = "=";
                                 quote_placeholder->utf8 = "\"";
                                 if (value_placeholder->next) value_placeholder->next->utf8 = "\"";
+                                value_placeholder->utf8 = xml::escape(value, '\"');
                             }
                             else
                             {
                                 equal_placeholder->utf8 = "";
                                 quote_placeholder->utf8 = "";
                                 if (value_placeholder->next) value_placeholder->next->utf8 = "";
+                                value_placeholder->utf8 = "";
                             }
                         }
-                        else log(prompt::xml, "Equal sign not found");
+                        else log("%%Equal sign placeholder not found", prompt::xml);
+                        return;
                     }
                     value_placeholder->utf8 = xml::escape(value);
                 }
-                else log(prompt::xml, "Unexpected assignment to ", name->utf8);
+                else log("%%Unexpected assignment to '%%'", prompt::xml, name->utf8);
             }
             template<class T>
             auto take(qiew attr, T fallback = {})
@@ -592,7 +614,7 @@ namespace netxs::xml
                     }
                     if (val.size())
                     {
-                        if (utf::check_any(val, rawtext_delims)) data += "=\"" + xml::escape(val) + "\"";
+                        if (utf::check_any(val, rawtext_delims)) data += "=\"" + xml::escape(val, '\"') + '\"'; //todo should we use origial quotes here?
                         else                                     data += '='   + xml::escape(val) + ' ';
                     }
                 }
@@ -658,7 +680,7 @@ namespace netxs::xml
               root{ ptr::shared<elem>()}
         {
             read(data);
-            if (page.fail) log(prompt::xml, "Inconsistent xml data from ", file.empty() ? "memory"sv : file, ":\n", page.show(), "\n");
+            if (page.fail) log("%%Inconsistent xml data from %file%:\n%config%\n", prompt::xml, file.empty() ? "memory"sv : file, page.show());
         }
         template<bool WithTemplate = faux>
         auto take(view path)
@@ -729,7 +751,7 @@ namespace netxs::xml
         {
             page.fail = true;
             page.append(type::error, msg);
-            log(prompt::xml, msg, " at ", page.file, ":", page.lines());
+            log("%%%msg% at %page.file%:%lines%", prompt::xml, msg, page.file, page.lines());
         }
         auto fail(type last, type what)
         {
@@ -794,7 +816,7 @@ namespace netxs::xml
         }
         auto name(view& data)
         {
-            auto item = utf::get_tail(data, token_delims).str();
+            auto item = utf::take_front(data, token_delims).str();
             utf::to_low(item);
             return item;
         }
@@ -806,15 +828,15 @@ namespace netxs::xml
                 auto delim = data.front();
                 if (delim != '\'' && delim != '\"')
                 {
-                    auto crop = utf::get_tail(data, rawtext_delims);
+                    auto crop = utf::take_front(data, rawtext_delims);
                                page.append(type::quotes);
                     item_ptr = page.append(kind, crop);
                                page.append(type::quotes);
                 }
                 else
                 {
+                    auto crop = utf::take_quote(data, delim);
                     auto delim_view = view(&delim, 1);
-                    auto crop = utf::get_quote(data, delim_view);
                                page.append(type::quotes, delim_view);
                     item_ptr = page.append(kind, crop);
                                page.append(type::quotes, delim_view);
@@ -842,9 +864,9 @@ namespace netxs::xml
                 case type::end_token:     utf::eat_tail(data, token_delims); break;
                 case type::raw_text:
                 case type::quotes:
-                case type::tag_value:     body(data, type::raw_text);             break;
-                case type::spaces:        utf::trim_front(data, whitespaces);     break;
-                case type::na:            utf::get_tail<faux>(data, find_start);  break;
+                case type::tag_value:     body(data, type::raw_text);         break;
+                case type::spaces:        utf::trim_front(data, whitespaces); break;
+                case type::na:            utf::take_front(data, find_start);  break;
                 case type::compact:
                 case type::unknown:       if (data.size()) data.remove_prefix(1); break;
                 default: break;
@@ -1255,7 +1277,7 @@ namespace netxs::xml
             auto test = !!homelist.size();
             if (!test)
             {
-                log("%% %err%xml path not found: %path%%nil%", prompt::xml, ansi::err(), homepath, ansi::nil());
+                log("%%%err%xml path not found: %path%%nil%", prompt::xml, ansi::err(), homepath, ansi::nil());
             }
             return test;
         }
@@ -1263,7 +1285,7 @@ namespace netxs::xml
         {
             if (cwdstack.empty())
             {
-                log(prompt::xml, "CWD stack is empty");
+                log("%%CWD stack is empty", prompt::xml);
             }
             else
             {
@@ -1301,7 +1323,7 @@ namespace netxs::xml
             if (tempbuff.size()) crop = tempbuff.back()->value();
             else
             {
-                if constexpr (!Quiet) log("%prompt%%red% xml path not found: %nil%%path%", prompt::xml, ansi::fgc(redlt), ansi::nil(), frompath);
+                if constexpr (!Quiet) log("%%%red% xml path not found: %nil%%path%", prompt::xml, ansi::fgc(redlt), ansi::nil(), frompath);
                 return defval;
             }
             tempbuff.clear();
@@ -1381,7 +1403,7 @@ namespace netxs::xml
             auto run_config = xml::document{ utf8_xml, filepath };
             if constexpr (Print)
             {
-                log(prompt::xml, "Settings from ", filepath.empty() ? "memory"sv : filepath, ":\n", run_config.page.show());
+                log("%%Settings from %file%:\n%config%", prompt::xml, filepath.empty() ? "memory"sv : filepath, run_config.page.show());
             }
             auto proc = [&](auto node_ptr, auto path, auto proc) -> void
             {
@@ -1397,7 +1419,6 @@ namespace netxs::xml
                 }
                 else
                 {
-                    auto value = node.value();
                     if (dest_list.size())
                     {
                         auto& dest = dest_list.front();
@@ -1421,7 +1442,7 @@ namespace netxs::xml
                                 auto rewrite = sub_list.end() != std::find_if(sub_list.begin(), sub_list.end(), [](auto& a){ return a->base; });
                                 document->join(path + "/" + sub_name, sub_list, rewrite);
                             }
-                            else log(prompt::xml, "Unexpected tag without data: ", sub_name);
+                            else log("%%Unexpected tag without data: %tag%", prompt::xml, sub_name);
                         }
                     }
                     else

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -203,9 +203,14 @@ int main(int argc, char* argv[])
                 "\n    vtm.selected(<id>)            │ Set selected menu item using specified <id>."
                 "\n    vtm.shutdown()                │ Terminate the running desktop session."
                 "\n"
-                "\n    The following characters in commands will be de-escaped:"
-                "\n        \\e, \\t, \\r, \\n, \\a, \\\\  For every occurrence."
-                "\n        \\\" or \\'                IIF a literal is enclosed in corresponding quotes."
+                "\n  Escaped characters with special meaning:"
+                "\n"
+                "\n    \\e  ASCII 0x1B ESC"
+                "\n    \\t  ASCII 0x09 TAB"
+                "\n    \\a  ASCII 0x07 BEL"
+                "\n    \\n  ASCII 0x0A LF"
+                "\n    \\\\  ASCII 0x5C Backslash"
+                "\n    $0  Current module full path"
                 "\n");
             return 0;
         }

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -176,11 +176,13 @@ int main(int argc, char* argv[])
                 "\n        - Overlay system-wide settings from " + os::path::expand(app::shared::sys_config).second + "."
                 "\n        - Overlay user-wise settings from "   + os::path::expand(app::shared::usr_config).second + "."
                 "\n    - Overlay the settings received from the DirectVT Gateway."
+                "\n    - Overlay the settings from the plain xml-data."
                 "\n"
-                "\n    It is possible to specify plain xml-data to modify current settings:"
-                "\n    (detected by the `<config` literal)"
+                "\n    The plain xml-data could be specified in place of <file> in '--config <file>' option:"
                 "\n"
                 "\n      vtm -c \"<config><term><scrollback size=1000000/></term></config>\" -r term"
+                "\n      or (using compact syntax)"
+                "\n      vtm -c \"<config/term/scrollback size=1000000/>\" -r term"
                 "\n"
                 "\n  Script commands:"
                 "\n"
@@ -201,7 +203,9 @@ int main(int argc, char* argv[])
                 "\n    vtm.selected(<id>)            │ Set selected menu item using specified <id>."
                 "\n    vtm.shutdown()                │ Terminate the running desktop session."
                 "\n"
-                "\n    The following characters in script commands will be de-escaped: \\e \\t \\r \\n \\a \\\" \\' \\\\"
+                "\n    The following characters in commands will be de-escaped:"
+                "\n        \\e, \\t, \\r, \\n, \\a, \\\\  For every occurrence."
+                "\n        \\\" or \\'                Iif a literal is enclosed in corresponding quotes."
                 "\n");
             return 0;
         }
@@ -215,7 +219,8 @@ int main(int argc, char* argv[])
         }
         else if (getopt.match("-x", "--script"))
         {
-            script = xml::unescape(getopt.next());
+            script = getopt.next();
+            utf::dequote(script);
         }
         else
         {

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -205,10 +205,11 @@ int main(int argc, char* argv[])
                 "\n"
                 "\n  Escaped characters with special meaning:"
                 "\n"
-                "\n    \\e  ASCII 0x1B ESC"
-                "\n    \\t  ASCII 0x09 TAB"
                 "\n    \\a  ASCII 0x07 BEL"
+                "\n    \\t  ASCII 0x09 TAB"
                 "\n    \\n  ASCII 0x0A LF"
+                "\n    \\r  ASCII 0x0D CR"
+                "\n    \\e  ASCII 0x1B ESC"
                 "\n    \\\\  ASCII 0x5C Backslash"
                 "\n    $0  Current module full path"
                 "\n");

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -205,7 +205,7 @@ int main(int argc, char* argv[])
                 "\n"
                 "\n    The following characters in commands will be de-escaped:"
                 "\n        \\e, \\t, \\r, \\n, \\a, \\\\  For every occurrence."
-                "\n        \\\" or \\'                Iif a literal is enclosed in corresponding quotes."
+                "\n        \\\" or \\'                IIF a literal is enclosed in corresponding quotes."
                 "\n");
             return 0;
         }

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -2074,8 +2074,9 @@ namespace netxs::app::vtm
                     }
                     return std::pair{ func, args };
                 };
-                auto backup = std::move(script.cmd);
-                auto shadow = utf::dequote(backup);
+                auto backup = xml::unescape(script.cmd);
+                auto shadow = qiew{ backup };
+                script.cmd.clear();
                 utf::trim_front(shadow, delims);
                 while (shadow)
                 {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -2074,9 +2074,9 @@ namespace netxs::app::vtm
                     }
                     return std::pair{ func, args };
                 };
-                auto backup = xml::unescape(script.cmd);
+                xml::unescape(script.cmd);
+                auto backup = std::move(script.cmd);
                 auto shadow = qiew{ backup };
-                script.cmd.clear();
                 utf::trim_front(shadow, delims);
                 while (shadow)
                 {

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -258,7 +258,7 @@ R"==(
 )==" // MSVC2022: C2026 String too big, trailing characters truncated.
 R"==(
     <term>  <!-- Base settings for the Term app. It can be partially overridden by the menu item's config subarg. -->
-        <sendinput=""/>  <!-- Send input on startup. E.g. sendinput="echo test\n" -->
+        <sendinput=""/>  <!-- Send input on startup. E.g. sendinput="echo \"test\"\n" -->
         <cwdsync=" cd $P\n"/>  <!-- Command to sync the current working directory. When 'Sync' is active, $P (case sensitive) will be replaced with the current path received via OSC9;9 notification. Prefixed with a space to avoid touching command history. -->
         <scrollback>
             <size=40000    />   <!-- Initial scrollback buffer size. -->


### PR DESCRIPTION
### Changes

- Fix recursive escaping ([Nested quotation](https://en.wikipedia.org/wiki/Nested_quotation)).
  `command-line`:
  ```cmd
  vtm -t -c "<config/term/sendinput=\"vtm -t -c \\\"<config/term/sendinput=\\\\\\\"echo \\\\\\\\\\\\\\\"test\\\\\\\\\\\\\\\"\\\\\\\"/>\\\" -r term\"/>" -r term
  ```
  `command-line`:
  ```cmd
  vtm -t -c "<config/term/sendinput='echo \'test\''/>" -r term
  ```