### PR TITLE
Try to fix command line args escaping

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.15";
+    static const auto version = "v0.9.99.16";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -109,7 +109,7 @@ struct consrv
                              sizeof(refdrv),
                                     nullptr,
                                     nullptr);
-        auto wcmd = utf::to_utf(cfg.cmd);
+        auto wcmd = utf::to_utf(os::nt::retokenize(cfg.cmd));
         auto wcwd = utf::to_utf(cfg.cwd);
         auto wenv = utf::to_utf(os::env::add(cfg.env += "VTM=1\0"sv));
         auto ret = ::CreateProcessW(nullptr,                             // lpApplicationName
@@ -5009,7 +5009,7 @@ struct impl : consrv
             auto wndname = text{ "vtmConsoleWindowClass" };
             auto wndproc = [](HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
-                ok<faux>(debugmode ? 0 : 1, win32prompt, "GUI message: hWnd=", utf::to_hex_0x(hWnd), " uMsg=", utf::to_hex_0x(uMsg), " wParam=", utf::to_hex_0x(wParam), " lParam=", utf::to_hex_0x(lParam));
+                //ok<faux>(debugmode ? 0 : 1, win32prompt, "GUI message: hWnd=", utf::to_hex_0x(hWnd), " uMsg=", utf::to_hex_0x(uMsg), " wParam=", utf::to_hex_0x(wParam), " lParam=", utf::to_hex_0x(lParam));
                 auto w = (impl*)::GetWindowLongPtrW(hWnd, GWLP_USERDATA);
                 if (!w) return ::DefWindowProcW(hWnd, uMsg, wParam, lParam);
                 switch (uMsg)

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -534,7 +534,7 @@ namespace netxs::os
                     mscmd.push_back(' ');
                 }
                 if (args.size()) mscmd.pop_back(); // Pop last space.
-                if (cmd_shim) log("%%Command line: '%mscmd%' (special case for cmd.exe)", prompt::os, ansi::hi(utf::debase437(mscmd)));
+                if (cmd_shim) log("%%Command line: %mscmd% (special case for cmd.exe)", prompt::os, ansi::hi(utf::debase437(mscmd)));
                 else
                 {
                     log("%%Command line: %mscmd%", prompt::os, ansi::hi(utf::debase437(mscmd)));

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1956,9 +1956,10 @@ namespace netxs::os
             auto crop = path.starts_with("~/")    ? os::path::home / path.substr(2 /* trim `~` */)
                       : path.starts_with("/etc/") ? os::path::etc  / path.substr(5 /* trim "/etc" */)
                                                   : fs::path{ path };
-            auto crop_str = utf::to_utf(crop.wstring());
-            utf::replace_all(crop_str, "\\", "/");
-            crop_str = utf::quote(crop_str);
+            auto utf8 = utf::to_utf(crop.wstring());
+            utf::replace_all(utf8, "\\", "/");
+            auto crop_str = text{};
+            utf::quote(utf8, crop_str, '\"');
             return std::pair{ crop, crop_str };
         }
     }
@@ -2418,8 +2419,8 @@ namespace netxs::os
                         auto& utf8 = *iter++;
                         if (utf8.empty()
                          || utf8.front() == '\"'
-                         || utf8.front() == '\''
-                         || utf8.find(' ') != text::npos) utf::quote(utf8, crop);
+                         || utf8.find(' ') != text::npos) utf::quote(utf8, crop, '\"');
+                        else if (utf8.front() == '\'')    utf::quote(utf8, crop, '\'');
                         else                              crop += utf8;
                     }
                 }

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1653,8 +1653,6 @@ namespace netxs::utf
             {
                 case '\033': *iter++ = '\\'; *iter++ = 'e' ; break;
                 case   '\\': *iter++ = '\\'; *iter++ = '\\'; break;
-                case   '\"': *iter++ = '\\'; *iter++ = '\"'; break;
-                case   '\'': *iter++ = '\\'; *iter++ = '\''; break;
                 case   '\n': *iter++ = '\\'; *iter++ = 'n' ; break;
                 case   '\r': *iter++ = '\\'; *iter++ = 'r' ; break;
                 case   '\t': *iter++ = '\\'; *iter++ = 't' ; break;
@@ -1712,21 +1710,15 @@ namespace netxs::utf
         unescape(utf8, dest);
         return dest;
     }
-    void quote(view utf8, text& dest) // Escape, add quotes around and append the result to the dest.
+    void quote(view utf8, text& dest, char quote) // Escape, add quotes around and append the result to the dest.
     {
         auto start = dest.size();
         dest.resize(start + utf8.size() * 2 + 2);
         auto iter = dest.begin() + start;
-        *iter++ = '\"';
-        _escape(utf8, iter);
-        *iter++ = '\"';
+        *iter++ = quote;
+        _escape(utf8, iter, quote);
+        *iter++ = quote;
         dest.resize(iter - dest.begin());
-    }
-    auto quote(view utf8) // Escape, add quotes around and return the result.
-    {
-        auto dest = text{};
-        quote(utf8, dest);
-        return dest;
     }
     template<bool Lazy = true>
     auto take_front(view& utf8, view delims)

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1542,13 +1542,14 @@ namespace netxs::utf
             while (code);
         }
     }
-    // utf: Return a string without control chars (replace all ctrls with cp437).
+    // utf: Return a string without control chars (replace all ctrls with "cp437" glyphs).
     auto debase437(qiew utf8)
     {
         auto buff = text{};
         debase437(utf8, buff);
         return buff;
     }
+    // utf: Find char position ignoring backslashed.
     auto _find_char(auto head, auto tail, auto hittest)
     {
         while (head != tail)
@@ -1559,11 +1560,13 @@ namespace netxs::utf
         }
         return head;
     }
+    // utf: Find char position ignoring backslashed.
     template<class Iter>
     auto find_char(Iter head, Iter tail, view delims)
     {
         return _find_char(head, tail, [&](char c){ return delims.find(c) != view::npos; });
     }
+    // utf: Find char position ignoring backslashed.
     template<class Iter>
     auto find_char(Iter head, Iter tail, char delim)
     {

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -452,14 +452,15 @@ namespace netxs::xml
             }
             auto take_value()
             {
-                auto crop = text{};
-                for (auto& value_placeholder : body) if (value_placeholder->utf8.size())
+                auto value = text{};
+                for (auto& value_placeholder : body)
                 {
-                    utf::unescape(value_placeholder->utf8, crop);
+                    value += value_placeholder->utf8;
                 }
-                return crop;
+                utf::unescape(value);
+                return value;
             }
-            void init_value(qiew value)
+            void init_value(qiew value, bool unescaped = true)
             {
                 if (body.size())
                 {
@@ -492,7 +493,8 @@ namespace netxs::xml
                         }
                         else log("%%Equal sign placeholder not found", prompt::xml);
                     }
-                    utf::escape(value, value_placeholder->utf8);
+                    if (unescaped) utf::escape(value, value_placeholder->utf8, '\"');
+                    else           value_placeholder->utf8 = value;
                 }
                 else log("%%Unexpected assignment to '%%'", prompt::xml, name->utf8);
             }
@@ -501,7 +503,12 @@ namespace netxs::xml
                 if (body.size())
                 if (body.size() != node.body.size() || !std::equal(body.begin(), body.end(), node.body.begin(), [&](auto& s, auto& d){ return s->utf8 == d->utf8; }))
                 {
-                    init_value(node.take_value());
+                    auto value = text{};
+                    for (auto& value_placeholder : body)
+                    {
+                        value += value_placeholder->utf8;
+                    }
+                    init_value(value, faux);
                 }
             }
             template<class T>
@@ -541,7 +548,7 @@ namespace netxs::xml
                     if (crop.size())
                     {
                         data.push_back('=');
-                        utf::quote(crop, data);
+                        utf::quote(crop, data, '\"');
                     }
                 }
 


### PR DESCRIPTION
### Changes

- Try to fix command line arguments escaping.
  Test case 1. `command line`:
  ```pwsh
  vtm -r term pwsh -Command "& { gci | % { \"`\"Item: $_`\"\" }}; exit 1"
  ```
  Test case 2. `command line`:
  ```cmd
    vtm -r term cmd /k echo "Hello, ""world!"""
  ```