### PR TITLE
Add support for Unicode escape sequences in the form `\u{XXX}` or `\uXXX`

### DIFF
--- a/doc/character_geometry.md
+++ b/doc/character_geometry.md
@@ -55,6 +55,44 @@ Users can explicitly specify the size of the character matrix (by zeroing `_xy`)
 - Screenshot:  
   ![image](https://github.com/user-attachments/assets/5c6d0e5c-ba36-4602-a626-95f64042c67f)
 
+### Helper functions
+
+Example functions for converting between modifier codepoints and character matrix parameter tuples `wh_xy`.
+
+```c++
+struct wh_xy
+{
+    int w, h, x, y;
+};
+static int p(int n) { return n * (n + 1) / 2; }
+const int kx = 8; // Max width of the character matrix.
+const int ky = 4; // Max height of the character matrix.
+const int mx = p(kx + 1); // Lookup table boundaries.
+const int my = p(ky + 1); //
+const int unicode_block = 0xD0000; // Unicode codepoint block for geometry modifiers.
+
+// Returns the modifier codepoint value for the specified tuple w, h, x, y.
+static int modifier(int w, int h, int x, int y) { return unicode_block + p(w) + x + (p(h) + y) * mx; };
+
+// Returns a tuple w, h, x, y for the specified codepoint modifier using a static lookup table.
+static wh_xy matrix(int codepoint)
+{
+    static auto lut = []
+    {
+        auto v = std::vector(mx * my, wh_xy{});
+        for (auto w = 1; w <= kx; w++)
+        for (auto h = 1; h <= ky; h++)
+        for (auto y = 0; y <= h; y++)
+        for (auto x = 0; x <= w; x++)
+        {
+            v[p(w) + x + (p(h) + y) * mx] = wh_xy{ w, h, x, y };
+        }
+        return v;
+    }();
+    return lut[codepoint - unicode_block];
+}
+```
+
 ## Grapheme cluster boundaries
 
 By default, grapheme clustering occurs according to `Unicode UAX #29` https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundary_Rules.

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -35,6 +35,8 @@ Option                  | Description
 `-r`, `--`, `--run`     | Run desktop applet standalone.
 `<type>`                | Desktop applet to run.
 `<args...>`             | Desktop applet arguments.
+`--env <var=val>`       | Set environment variable.
+`--cwd <path>`          | Set current working directory.
 
 The plain xml-data could be specified in place of `<file>` in `--config <file>` option:
 - `command-line`:

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -87,6 +87,7 @@ Characters | Expanded to
 `\r`       | ASCII 0x0D CR
 `\e`       | ASCII 0x1B ESC
 `\\`       | ASCII 0x5C Backslash
+`\u`       | A Unicode escape sequence in the form `\u{XXX}` or `\uXXX`, where `XXX` is the hexadecimal codepoint value.
 `$0`       | Current module full path
 
 ### Usage Examples

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -76,6 +76,7 @@ The file list is built in the following order from the following sources:
    - `\r`  ASCII 0x0D CF
    - `\e`  ASCII 0x1B ESC
    - `\\`  ASCII 0x5C Backslash
+   - `\u`  A Unicode escape sequence in the form `\u{XXX}` or `\uXXX`, where `XXX` is the hexadecimal codepoint value.
    - `$0`  Current module full path (it only expands in cases where it makes sense)
 
 Let's take the following object hierarchy as an example:

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.19";
+    static const auto version = "v0.9.99.20";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1856,8 +1856,9 @@ namespace netxs::os
                 utf::split(subset, '\0', [&](qiew rec)
                 {
                     if (rec.empty()) return;
-                    auto var = rec.substr(0, rec.find('=', 1)); // 1: Skip the first char to support cmd.exe's strange subdirs like =A:=A:\Dir.
-                    auto val = rec.substr(var.size() + 1/*=*/);
+                    auto pos = rec.find('=', 1); // 1: Skip the first char to support cmd.exe's strange subdirs like =A:=A:\Dir.
+                    auto var = rec.substr(0, pos);
+                    auto val = rec.substr(pos + 1/*=*/);
                     env_map[var] = val;
                 });
             };
@@ -1898,6 +1899,15 @@ namespace netxs::os
                 auto val = value.str();
                 ok(::setenv(var.c_str(), val.c_str(), 1), "::setenv()", os::unexpected);
             #endif
+        }
+        // os::env: Set envvar value.
+        auto set(qiew variable_value)
+        {
+            if (variable_value.size() < 2) return;
+            auto pos = variable_value.find('=', 1); // 1: Skip the first char to support cmd.exe's strange subdirs like =A:=A:\Dir.
+            auto var = variable_value.substr(0, pos);
+            auto val = variable_value.substr(pos + 1/*=*/);
+            set(var, val);
         }
         // os::env: Unset envvar.
         auto unset(qiew variable)
@@ -1972,6 +1982,13 @@ namespace netxs::os
             auto err = std::error_code{};
             auto cwd = std::filesystem::current_path(err).string();
             return cwd;
+        }
+        // os::env: Set current working directory.
+        auto cwd(text path)
+        {
+            auto err = std::error_code{};
+            if (path.size()) fs::current_path(path, err);
+            return !!err;
         }
     }
 

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1663,7 +1663,7 @@ namespace netxs::utf
                         auto shadow = qiew{ next, tail };
                         if (auto v = to_int<si32, 16>(shadow))
                         if (auto codepoint = v.value(); codepoint >= 0 && codepoint <= 0x10FFFF)
-                        if (!quoted || shadow.size() && shadow.pop_front() == '}')
+                        if (!quoted || (shadow.size() && shadow.pop_front() == '}'))
                         {
                             _to_utf(iter, codepoint); // This expansion cannot cause overflow.
                             head = tail - shadow.size();

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -29,7 +29,25 @@ int main(int argc, char* argv[])
     }
     else while (getopt)
     {
-        if (getopt.match("--svc"))
+        if (getopt.match("--cwd"))
+        {
+            auto path = getopt.next();
+            if (path.size())
+            {
+                if (os::env::cwd(path)) log("%%Set current working directory to '%path%'", prompt::os, path);
+                else                    log("%%Failed to set current working directory to '%path%'", prompt::os, ansi::err(path));
+            }
+        }
+        else if (getopt.match("--env"))
+        {
+            auto var_val = getopt.next();
+            if (var_val.size())
+            {
+                log("%%Set environment variable '%var_val%'", prompt::os, var_val);
+                os::env::set(var_val);
+            }
+        }
+        else if (getopt.match("--svc"))
         {
             auto ok = os::process::dispatch();
             return ok ? 0 : 1;
@@ -151,6 +169,8 @@ int main(int argc, char* argv[])
                 "\n    -r, --, --run        Run desktop applet standalone."
                 "\n    <type>               Desktop applet to run."
                 "\n    <args...>            Desktop applet arguments."
+                "\n    --env <var=val>      Set environment variable."
+                "\n    --cwd <path>         Set current working directory."
                 "\n"
                 "\n    Desktop applet             │ Type │ Arguments"
                 "\n    ───────────────────────────┼──────┼─────────────────────────────────────────────────"


### PR DESCRIPTION
### Changes

- Add support for Unicode escape sequences in the form `\u{XXX}` or `\uXXX` in settings.xml.
- Add `--cwd <path>` and `--env <var=val>` CLI options.