### PR TITLE
Slightly improve vt-parsing performance

### DIFF
--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -1002,11 +1002,11 @@ namespace netxs::app::terminal
             auto& term_bgc = *term_bgc_ptr;
             auto winsz = ptr::shared(dot_00);
             auto visible = ptr::shared(slot1->back() != boss.This());
-            auto check_state = ptr::function([state = testy<bool>{ true }, winsz, visible](base& boss) mutable
+            auto check_state = ptr::function([state = true, winsz, visible](base& boss) mutable
             {
-                if (state(*visible || winsz->y != 1))
+                if (std::exchange(state, *visible || winsz->y != 1) != state)
                 {
-                    boss.RISEUP(tier::preview, e2::form::prop::ui::cache, state.last);
+                    boss.RISEUP(tier::preview, e2::form::prop::ui::cache, state);
                 }
             });
             boss.LISTEN(tier::release, e2::form::state::visible, menu_visible, -, (visible, check_state))

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1019,6 +1019,8 @@ namespace netxs::ansi
         void  sav()               { spare.set(*this);          } // mark: Save current SGR attributes.
         void  sfg(argb c)         { spare.fgc(c);              } // mark: Set default foreground color.
         void  sbg(argb c)         { spare.bgc(c);              } // mark: Set default background color.
+        auto  sfg()const          { return spare.fgc();        } // mark: Return default foreground color.
+        auto  sbg()const          { return spare.bgc();        } // mark: Return default background color.
         void  nil()               { this->set(spare);          } // mark: Restore saved SGR attributes.
         void  rfg()               { this->fgc(spare.fgc());    } // mark: Reset SGR Foreground color.
         void  rbg()               { this->bgc(spare.bgc());    } // mark: Reset SGR Background color.

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1424,7 +1424,11 @@ namespace netxs::ansi
             {
                 client->post(cluster);
             };
-            utf::decode(s, y, utf8, client->decsg);
+            auto a = [&](view plain)
+            {
+                client->ascii(plain);
+            };
+            utf::decode(s, y, a, utf8, client->decsg);
             client->flush();
         }
         // vt_parser: Static UTF-8/ANSI parser proc.
@@ -1742,10 +1746,29 @@ namespace netxs::ansi
                 data(len, cooked.pick());
             }
         }
-        void post(utf::frag const& cluster)
+        auto& get_ansi_marker()
         {
             static auto marker = ansi::marker{};
-
+            return marker;
+        }
+        void ascii(view plain)
+        {
+            assert(plain.length());
+            brush.txt(plain.back());
+            auto start = proto_cells.size();
+            proto_cells.resize(start + plain.length(), brush);
+            proto_count += (si32)plain.length();
+            auto iter = plain.begin();
+            auto head = proto_cells.begin() + start;
+            auto tail = std::prev(proto_cells.end());
+            while (head != tail)
+            {
+                auto& dst = *head++;
+                dst.gc.set(*iter++);
+            }
+        }
+        void post(utf::frag const& cluster)
+        {
             auto& utf8 = cluster.text;
             auto& attr = cluster.attr;
             if (auto v = attr.cmatrix)
@@ -1759,6 +1782,7 @@ namespace netxs::ansi
             }
             else
             {
+                auto& marker = get_ansi_marker();
                 if (auto set_prop = marker.setter[attr.control])
                 {
                     if (proto_cells.size())

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.25";
+    static const auto version = "v0.9.99.26";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2447,8 +2447,6 @@ namespace netxs
 
         struct szgrips
         {
-            using test = testy<twod>;
-
             twod origin; // szgrips: Grab's initial coord info.
             twod dtcoor; // szgrips: The form coor parameter change factor while resizing.
             twod sector; // szgrips: Active quadrant, x,y = {-1|+1}. Border widths.

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -697,6 +697,11 @@ namespace netxs::ui
                     show();
                 }
             }
+            // pro::caret: Get cursor background color.
+            auto bgc()
+            {
+                return mark.bgc();
+            }
             // pro::caret: Set cursor color.
             void color(cell c)
             {

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3974,11 +3974,11 @@ namespace netxs::gui
                 static auto xbttn = [](auto wParam){ return hi(wParam) == XBUTTON1 ? bttn::xbutton1 : bttn::xbutton2; };
                 static auto moved = [](auto lParam){ auto& p = *((WINDOWPOS*)lParam); return !(p.flags & SWP_NOMOVE); };
                 static auto coord = [](auto lParam){ auto& p = *((WINDOWPOS*)lParam); return twod{ p.x, p.y }; };
-                static auto hover_win = testy<HWND>{};
+                static auto hover_win = HWND{};
                 static auto hover_rec = TRACKMOUSEEVENT{ .cbSize = sizeof(TRACKMOUSEEVENT), .dwFlags = TME_LEAVE, .dwHoverTime = HOVER_DEFAULT };
                 switch (msg)
                 {
-                    case WM_MOUSEMOVE:        if (hover_win(hWnd)) ::TrackMouseEvent((hover_rec.hwndTrack = hWnd, &hover_rec));
+                    case WM_MOUSEMOVE:        if (std::exchange(hover_win, hWnd) != hover_win) ::TrackMouseEvent((hover_rec.hwndTrack = hWnd, &hover_rec));
                                               w->mouse_moved();                                  break; //todo mouse events are broken when IME is active (only work on lower rotated monitor half). TSF message pump?
                     case WM_TIMER:            w->timer_event(wParam);                            break;
                     case WM_MOUSELEAVE:       w->mouse_leave(); hover_win = {};                  break;

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1254,13 +1254,13 @@ namespace netxs::input
         span&       tooltip_timeout; // hids: .
         text        tooltip_data; // hids: Tooltip data.
         ui32        digest = 0; // hids: Tooltip digest.
-        testy<ui32> digest_tracker = 0; // hids: Tooltip changes tracker.
+        ui32        digest_tracker = 0; // hids: Tooltip changes tracker.
         ui32        tooltip_digest = 0; // hids: Tooltip digest.
         time        tooltip_time = {}; // hids: The moment to show tooltip.
         bool        tooltip_show = faux; // hids: Show tooltip or not.
         bool        tooltip_stop = true; // hids: Disable tooltip.
         bool        tooltip_set  = faux; // hids: Tooltip has been set.
-        testy<twod> tooltip_coor = {}; // hids: .
+        twod        tooltip_coor = {}; // hids: .
 
         si32 ctlstate = {};
 
@@ -1342,7 +1342,7 @@ namespace netxs::input
         }
         auto is_tooltip_changed()
         {
-            return digest_tracker(digest);
+            return std::exchange(digest_tracker, digest) != digest_tracker;
         }
         auto get_tooltip()
         {

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4288,7 +4288,7 @@ namespace netxs::os
         struct vtty
         {
             std::thread             stdwrite{};
-            testy<twod>             termsize{};
+            twod                    termsize{};
             flag                    attached{};
             flag                    signaled{};
             escx                    writebuf{};
@@ -4318,7 +4318,7 @@ namespace netxs::os
                 {
                     termlink = consrv::create(terminal);
                 }
-                termsize(cfg.win);
+                termsize = cfg.win;
                 auto trailer = [&, cmd = cfg.cmd]
                 {
                     if (attached.exchange(faux))

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -5927,27 +5927,26 @@ namespace netxs::ui
             text selection_pickup(si32 selmod) override
             {
                 auto yield = escx{};
-                auto len = testy<si64>{};
                 auto selbox = selection_selbox();
                 if (!selection_active()) return yield;
                 if (selmod != mime::textonly
                  && selmod != mime::safetext) yield.nil();
-                len = yield.size();
+                auto len = yield.size();
                 if (uptop.role != grip::idle)
                 {
                     bufferbase::selection_pickup(yield, upbox, uptop.coor, dntop.coor, selmod, selbox);
                 }
                 if (upmid.role != grip::idle)
                 {
-                    if (len(yield.size())) yield.eol();
+                    if (std::exchange(len, yield.size()) != len) yield.eol();
                     scroll_buf::selection_pickup(yield, selmod);
                 }
                 if (upend.role != grip::idle)
                 {
-                    if (len(yield.size())) yield.eol();
+                    if (std::exchange(len, yield.size()) != len) yield.eol();
                     bufferbase::selection_pickup(yield, dnbox, upend.coor, dnend.coor, selmod, selbox);
                 }
-                if (selbox && len(yield.size())) yield.eol();
+                if (selbox && std::exchange(len, yield.size()) != len) yield.eol();
                 return yield;
             }
             // scroll_buf: Highlight selection.

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -570,9 +570,12 @@ namespace netxs::ui
             using pals = std::remove_const_t<decltype(argb::vt256)>;
             using func = std::unordered_map<text, std::function<void(view)>>;
 
+            enum class type { invalid, rgbcolor, request };
+
             term& owner; // c_tracking: Terminal object reference.
             pals  color; // c_tracking: 16/256 colors palette.
             func  procs; // c_tracking: Handlers.
+            escx  reply; // c_tracking: Reply buffer.
 
             void reset()
             {
@@ -585,29 +588,48 @@ namespace netxs::ui
                 else if (c >= 'a' && c <= 'f') return c - 'a' + 10;
                 else                           return 0;
             }
-            std::optional<ui32> record(view& data) // ; rgb:00/00/00
+            auto record(view& data) -> std::pair<type, ui32> // ; rgb:.../.../...
             {
-                //todo implement request "?"
                 utf::trim_front(data, " ;");
-                if (data.length() >= 12 && data.starts_with("rgb:"))
+                if (data.size() && data.front() == '?') // If a "?" is given rather than a name or RGB specification, termimal should reply with a control sequence of the same form.
                 {
-                    auto r1 = to_byte(data[ 4]);
-                    auto r2 = to_byte(data[ 5]);
-                    auto g1 = to_byte(data[ 7]);
-                    auto g2 = to_byte(data[ 8]);
-                    auto b1 = to_byte(data[10]);
-                    auto b2 = to_byte(data[11]);
-                    data.remove_prefix(12); // rgb:00/00/00
-                    return { (b1 << 4 ) + (b2      )
-                           + (g1 << 12) + (g2 << 8 )
-                           + (r1 << 20) + (r2 << 16)
-                           + 0xFF000000 };
+                    data.remove_prefix(1);
+                    return { type::request, 0 };
                 }
-                return {};
+                else if (data.starts_with("rgb:"))
+                {
+                    auto get_color = [&](auto n)
+                    {
+                        auto r1 = to_byte(data[4]);
+                        auto r2 = to_byte(data[5]);
+                        auto g1 = to_byte(data[4 + n + 1]);
+                        auto g2 = to_byte(data[5 + n + 1]);
+                        auto b1 = to_byte(data[4 + (n + 1) * 2]);
+                        auto b2 = to_byte(data[5 + (n + 1) * 2]);
+                        data.remove_prefix(n * 3 + 4/*rgb:*/ + 2/*//*/);
+                        return (b1 << 4 ) + (b2      )
+                             + (g1 << 12) + (g2 << 8 )
+                             + (r1 << 20) + (r2 << 16)
+                             + 0xFF000000;
+                    };
+                    if (data.length() >= 12 && data[6] == '/' && data[9] == '/') // ; rgb:00/00/00
+                    {
+                        return { type::rgbcolor, get_color(2) };
+                    }
+                    else if (data.length() >= 15 && data[7] == '/' && data[11] == '/') // ; rgb:000/000/000
+                    {
+                        return { type::rgbcolor, get_color(3) };
+                    }
+                    else if (data.length() >= 18 && data[8] == '/' && data[13] == '/') // ; rgb:0000/0000/0000
+                    {
+                        return { type::rgbcolor, get_color(4) };
+                    }
+                }
+                return { type::invalid, 0 };
             }
-            void notsupported(text const& property, view data)
+            void notsupported(text const& property, view full_data, view unkn_data)
             {
-                log("%%Not supported: OSC=%property% DATA=%data% SIZE=%length% HEX=%hexdata%", prompt::term, property, data, data.length(), utf::buffer_to_hex(data));
+                log("%%Not supported: OSC=%property%\n\tDATA=%data%\n\tSIZE=%length%\n\tHEX=%hexdata%\n\tUNKN=%%", prompt::term, property, full_data, full_data.length(), utf::buffer_to_hex(full_data), ansi::err(unkn_data));
             }
 
             c_tracking(term& owner)
@@ -649,15 +671,25 @@ namespace netxs::ui
                 procs[ansi::osc_set_palette] = [&](view data) // ESC ] 4 ; 0;rgb:00/00/00;1;rgb:00/00/00;...
                 {
                     auto fails = faux;
+                    auto full_data = data;
                     while (data.length())
                     {
                         utf::trim_front(data, " ;");
+                        if (data.empty()) break;
                         if (auto v = utf::to_int(data))
                         {
                             auto n = std::clamp(v.value(), 0, 255);
-                            if (auto r = record(data))
+                            auto [t, r] = record(data);
+                            if (t == type::request)
                             {
-                                color[n] = r.value();
+                                auto c = argb{ color[n] };
+                                reply.osc(ansi::osc_set_palette, utf::fprint("%n%;rgb:%r%/%g%/%b%", n, utf::to_hex(c.chan.r),
+                                                                                                       utf::to_hex(c.chan.g),
+                                                                                                       utf::to_hex(c.chan.b)));
+                            }
+                            else if (t == type::rgbcolor)
+                            {
+                                color[n] = r;
                             }
                             else
                             {
@@ -671,7 +703,7 @@ namespace netxs::ui
                             break;
                         }
                     }
-                    if (fails) notsupported(ansi::osc_set_palette, data);
+                    if (fails) notsupported(ansi::osc_set_palette, full_data, data);
                 };
                 procs[ansi::osc_linux_reset] = [&](view /*data*/) // ESC ] R
                 {
@@ -679,27 +711,54 @@ namespace netxs::ui
                 };
                 procs[ansi::osc_set_fgcolor] = [&](view data) // ESC ] 10 ;rgb:00/00/00
                 {
-                    if (auto r = record(data))
+                    auto full_data = data;
+                    auto [t, r] = record(data);
+                    if (t == type::request)
                     {
-                        owner.target->brush.sfg(r.value());
+                        auto c = owner.target->brush.sfg();
+                        reply.osc(ansi::osc_set_fgcolor, utf::fprint("rgb:%r%/%g%/%b%", utf::to_hex(c.chan.r),
+                                                                                        utf::to_hex(c.chan.g),
+                                                                                        utf::to_hex(c.chan.b)));
                     }
-                    else notsupported(ansi::osc_set_fgcolor, data);
+                    else if (t == type::rgbcolor)
+                    {
+                        owner.target->brush.sfg(r);
+                    }
+                    else notsupported(ansi::osc_set_fgcolor, full_data, data);
                 };
                 procs[ansi::osc_set_bgcolor] = [&](view data) // ESC ] 11 ;rgb:00/00/00
                 {
-                    if (auto r = record(data))
+                    auto full_data = data;
+                    auto [t, r] = record(data);
+                    if (t == type::request)
                     {
-                        owner.target->brush.sbg(r.value());
+                        auto c = owner.target->brush.sbg();
+                        reply.osc(ansi::osc_set_bgcolor, utf::fprint("rgb:%r%/%g%/%b%", utf::to_hex(c.chan.r),
+                                                                                        utf::to_hex(c.chan.g),
+                                                                                        utf::to_hex(c.chan.b)));
                     }
-                    else notsupported(ansi::osc_set_bgcolor, data);
+                    else if (t == type::rgbcolor)
+                    {
+                        owner.target->brush.sbg(r);
+                    }
+                    else notsupported(ansi::osc_set_bgcolor, full_data, data);
                 };
                 procs[ansi::osc_caret_color] = [&](view data) // ESC ] 12 ;rgb:00/00/00
                 {
-                    if (auto r = record(data))
+                    auto full_data = data;
+                    auto [t, r] = record(data);
+                    if (t == type::request)
                     {
-                        owner.cursor.bgc(r.value());
+                        auto c = owner.cursor.bgc();
+                        reply.osc(ansi::osc_caret_color, utf::fprint("rgb:%r%/%g%/%b%", utf::to_hex(c.chan.r),
+                                                                                        utf::to_hex(c.chan.g),
+                                                                                        utf::to_hex(c.chan.b)));
                     }
-                    else notsupported(ansi::osc_caret_color, data);
+                    else if (t == type::rgbcolor)
+                    {
+                        owner.cursor.bgc(r);
+                    }
+                    else notsupported(ansi::osc_caret_color, full_data, data);
                 };
                 procs[ansi::osc_reset_crclr] = [&](view /*data*/)
                 {
@@ -721,6 +780,11 @@ namespace netxs::ui
                 if (proc != procs.end())
                 {
                     proc->second(data);
+                    if (reply.size())
+                    {
+                        owner.answer(reply);
+                        reply.clear();
+                    }
                 }
                 else log("%%Not supported: OSC=%property% DATA=%data% HEX=%hexdata%", prompt::term, property, data, utf::buffer_to_hex(data));
             }


### PR DESCRIPTION
### Changes

- Slightly improve vt-parsing performance.
- Implement `OSC 4/10/11/12` color requests.
  `command-line`:
  ```bash
  printf "\e]4;1;?\a"
  ```