### PR TITLE
Fix waiting for console attached processes to exit

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.33";
+    static const auto version = "v0.9.99.34";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4321,9 +4321,9 @@ namespace netxs::os
                 termsize = cfg.win;
                 auto trailer = [&, cmd = cfg.cmd]
                 {
+                    auto exitcode = termlink->wait(); // Wait all attached processes to exit (waiting for conversations to complete, send pending writebuf).
                     if (attached.exchange(faux))
                     {
-                        auto exitcode = termlink->wait();
                         log("%%Process '%cmd%' exited with code %code%", prompt::vtty, ansi::hi(utf::debase437(cmd)), utf::to_hex_0x(exitcode));
                         writesyn.notify_one(); // Interrupt writing thread.
                         terminal.onexit(exitcode, "", signaled.exchange(true)); // Only if the process terminates on its own (not forced by sighup).

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7770,7 +7770,7 @@ namespace netxs::ui
                         //todo configurable Ctrl+Ins, Shift+Ins etc.
                         if (gear.handled) return; // Don't pass registered keyboard shortcuts.
                         if (io_log) log(prompt::key, ansi::hi(input::key::map::data(gear.keycode).name), gear.pressed ? " pressed" : " released");
-                        if (gear.pressed && gear.meta(hids::anyShift) && gear.meta(hids::anyCtrl))
+                        if (target == &normal && gear.pressed && gear.meta(hids::anyShift) && gear.meta(hids::anyCtrl))
                         {
                                  if (gear.keycode == input::key::LeftArrow  && gear.meta(hids::anyAlt)){ base::riseup<tier::preview>(e2::form::upon::scroll::bypage::x, { .vector = dot_10  }); gear.set_handled(); return; }
                             else if (gear.keycode == input::key::RightArrow && gear.meta(hids::anyAlt)){ base::riseup<tier::preview>(e2::form::upon::scroll::bypage::x, { .vector = -dot_10 }); gear.set_handled(); return; }


### PR DESCRIPTION
### Changes

- Fix waiting for console attached processes to exit.
  Issue: Far Manager launched from the command shell could be blocked when closing the built-in terminal with the `X` button.
- Suppress terminal hardcoded hotkeys when alternate buffer mode is active.