### PR TITLE
Make GUI window key bindings configurable

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -323,7 +323,7 @@ Configuration record                       | Interpretation
 `<key="Key+Chord" action=Drop/>`           | Suppress the key combination "Key+Chord".
 `<key=""          action="NameOfAction"/>` | Do nothing.
 
-### Available actions
+#### Available actions
 
 Action                         | Default key combination  | Level               | Description
 -------------------------------|--------------------------|---------------------|------------

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -332,7 +332,6 @@ Action                         | Default key combination  | Level               
 `ResetCellHeight`              | `Ctrl+Key0`              | Native GUI window   | Reset text cell height.
 `ToggleFullscreenMode`         | `Alt+Enter`              | Native GUI window   | Toggle fullscreen mode.
 `ToggleAntialiasingMode`       | `Ctrl+CapsLock`          | Native GUI window   | Toggle text antialiasing mode.
-`CloseGuiWindow`               | `Home+End`, `End+Home`   | Native GUI window   | Close GUI window.
 `RollFontsBackward`            | `Ctrl+Shift+F11`         | Native GUI window   | Roll font list backward.
 `RollFontsForward`             | `Ctrl+Shift+F12`         | Native GUI window   | Roll font list forward.
 `FocusPrevWindow`              | `Ctrl+PageUp`            | Desktop environment | Switch focus to the next desktop window.
@@ -367,6 +366,8 @@ Action                         | Default key combination  | Level               
 `TerminalSelectionCopy`        |                          | Builtin terminal    | Сopy selection to clipboard.
 `TerminalSelectionCancel`      | `Esc`                    | Builtin terminal    | Deselect a selection.
 `TerminalSelectionOneShot`     |                          | Builtin terminal    | One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed.
+`Drop`                         |                          | All levels          | Drop the key press.
+`DropIfRepeats`                |                          | All levels          | Drop the key press if it is repeating. This binding should be specified before the main action for the key combination.
 
 ### DirectVT configuration payload received from the parent process
 
@@ -417,7 +418,7 @@ Notes
 <file="/path/to/override_defaults.xml"/>  <!-- Reference to the base configuration. -->
 <config>
     <gui>  <!-- GUI mode related settings. (win32 platform only for now) -->
-        <antialiasing=off/>   <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
+        <antialiasing=on/>    <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
         <cellheight=20/>      <!-- Text cell height in physical pixels. Note: The width of the text cell depends on the primary font (the first one in the font list). -->
         <gridsize=""/>        <!-- Window initial grid size "width,height" in text cells. If gridsize="" or gridsize=0,0, then the size of the GUI window is left to the OS window manager. -->
         <wincoor=""/>         <!-- Window initial coordinates "x,y" (top-left corner on the desktop in physical pixels). If wincoor="", then the position of the GUI window is left to the OS window manager. -->
@@ -433,12 +434,15 @@ Notes
         <hotkeys key*>
             <key="CapsLock+UpArrow"   action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
             <key="CapsLock+DownArrow" action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->
+            <key="Ctrl+Key0"          action=DropIfRepeats/>           <!-- Don't repeat the Reset text cell height. -->
             <key="Ctrl+Key0"          action=ResetCellHeight/>         <!-- Reset text cell height. -->
+            <key="Alt+Enter"          action=DropIfRepeats/>           <!-- Don't repeat the Toggle fullscreen mode. -->
             <key="Alt+Enter"          action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
+            <key="Ctrl+CapsLock"      action=DropIfRepeats/>           <!-- Don't repeat the Toggle text antialiasing mode. -->
             <key="Ctrl+CapsLock"      action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
-            <key="Home+End"           action=CloseGuiWindow/>          <!-- Close GUI window. -->
-            <key="End+Home"           action=CloseGuiWindow/>
+            <key="Ctrl+Shift+F11"     action=DropIfRepeats/>           <!-- Don't repeat the Roll font list backward. -->
             <key="Ctrl+Shift+F11"     action=RollFontsBackward/>       <!-- Roll font list backward. -->
+            <key="Ctrl+Shift+F12"     action=DropIfRepeats/>           <!-- Don't repeat the Roll font list forward. -->
             <key="Ctrl+Shift+F12"     action=RollFontsForward/>        <!-- Roll font list forward. -->
         </hotkeys>
     </gui>
@@ -790,7 +794,9 @@ Notes
             <key="Shift+Ctrl+DownArrow"  action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
             <key="Shift+Ctrl+LeftArrow"  action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
             <key="Shift+Ctrl+RightArrow" action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
+            <key="Shift+Ctrl+Home"       action=DropIfRepeats/>                     <!-- Don't repeat the Scroll to the scrollback top. -->
             <key="Shift+Ctrl+Home"       action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
+            <key="Shift+Ctrl+End"        action=DropIfRepeats/>                     <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
             <key="Shift+Ctrl+End"        action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
             <key=""                      action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
             <key=""                      action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -295,7 +295,6 @@ Level                  | Config section               | Description
 -----------------------|------------------------------|------------
 Native GUI window      | `<config/gui/hotkeys/>`      | Native GUI window management key bindings.
 Desktop environment    | `<config/desktop/hotkeys/>`  | Taskbar and window management key bindings.
-Builtin terminal       | `<config/term/hotkeys/>`     | Terminal emulator specific key bindings.
 Application `app_name` | `<config/app_name/hotkeys/>` | Application specific key bindings.
 
 #### Syntax
@@ -320,13 +319,14 @@ Configuration record                       | Interpretation
 `<key="Key+Chord" action=NameOfAction/>`   | Append existing bindings using an indirect reference (the `NameOfAction` variable without quotes).
 `<key="Key+Chord" action="NameOfAction"/>` | Append existing bindings with the directly specified command "NameOfAction".
 `<key="Key+Chord" action=""/>`             | Remove all existing bindings for the specified key combination "Key+Chord".
-`<key="Key+Chord" action=Drop/>`           | Suppress the key combination "Key+Chord".
 `<key=""          action="NameOfAction"/>` | Do nothing.
 
 #### Available actions
 
-Action                         | Default key combination  | Level               | Description
+Action                         | Default key combination  | Available at level  | Description
 -------------------------------|--------------------------|---------------------|------------
+`Drop`                         |                          | All levels          | Drop all events for the specified key combination. No further processing.
+`DropIfRepeats`                |                          | All levels          | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
 `IncreaseCellHeight`           | `CapsLock+UpArrow`       | Native GUI window   | Increase the text cell height by one pixel.
 `DecreaseCellHeight`           | `CapsLock+DownArrow`     | Native GUI window   | Decrease the text cell height by one pixel.
 `ResetCellHeight`              | `Ctrl+Key0`              | Native GUI window   | Reset text cell height.
@@ -334,40 +334,38 @@ Action                         | Default key combination  | Level               
 `ToggleAntialiasingMode`       | `Ctrl+CapsLock`          | Native GUI window   | Toggle text antialiasing mode.
 `RollFontsBackward`            | `Ctrl+Shift+F11`         | Native GUI window   | Roll font list backward.
 `RollFontsForward`             | `Ctrl+Shift+F12`         | Native GUI window   | Roll font list forward.
-`FocusPrevWindow`              | `Ctrl+PageUp`            | Desktop environment | Switch focus to the next desktop window.
-`FocusNextWindow`              | `Ctrl+PageDown`          | Desktop environment | Switch focus to the previous desktop window.
-`Disconnect`                   | `Shift+F7`               | Desktop environment | Disconnect from the desktop.
-`TryToQuit`                    | `F10`                    | Desktop environment | Shut down the desktop server if no applications are running.
-`TerminalFindNext`             | `Alt+RightArrow`         | Builtin terminal    | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
-`TerminalFindPrev`             | `Alt+LeftArrow`          | Builtin terminal    | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
-`TerminalViewportOnePageUp`    | `Shift+Ctrl+PageUp`      | Builtin terminal    | Scroll one page up.
-`TerminalViewportOnePageDown`  | `Shift+Ctrl+PageDown`    | Builtin terminal    | Scroll one page down.
-`TerminalViewportOnePageLeft`  | `Shift+Alt+LeftArrow`    | Builtin terminal    | Scroll one page to the left.
-`TerminalViewportOnePageRight` | `Shift+Alt+RightArrow`   | Builtin terminal    | Scroll one page to the right.
-`TerminalViewportOneCharUp`    | `Shift+Ctrl+UpArrow`     | Builtin terminal    | Scroll one line up.
-`TerminalViewportOneCharDown`  | `Shift+Ctrl+DownArrow`   | Builtin terminal    | Scroll one line down.
-`TerminalViewportOneCharLeft`  | `Shift+Ctrl+LeftArrow`   | Builtin terminal    | Scroll one cell to the left.
-`TerminalViewportOneCharRight` | `Shift+Ctrl+RightArrow`  | Builtin terminal    | Scroll one cell to the right.
-`TerminalViewportTop`          | `Shift+Ctrl+Home`        | Builtin terminal    | Scroll to the scrollback top.
-`TerminalViewportEnd`          | `Shift+Ctrl+End`         | Builtin terminal    | Scroll to the scrollback bottom (reset viewport position).
-`TerminalViewportCopy`         |                          | Builtin terminal    | Сopy viewport to clipboard.
-`TerminalClipboardPaste`       |                          | Builtin terminal    | Paste from clipboard.
-`TerminalClipboardWipe`        |                          | Builtin terminal    | Reset clipboard.
-`TerminalUndo`                 |                          | Builtin terminal    | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
-`TerminalRedo`                 |                          | Builtin terminal    | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
-`TerminalToggleCwdSync`        |                          | Builtin terminal    | Toggle the current working directory sync mode.
-`TerminalToggleWrapMode`       |                          | Builtin terminal    | Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is.
-`TerminalToggleSelectionMode`  |                          | Builtin terminal    | Toggle between linear and rectangular selection form.
-`TerminalToggleFullscreen`     |                          | Builtin terminal    | Toggle fullscreen mode.
-`TerminalToggleStdioLog`       |                          | Builtin terminal    | Stdin/stdout log toggle.
-`TerminalQuit`                 |                          | Builtin terminal    | Terminate runnning console apps and close terminal.
-`TerminalRestart`              |                          | Builtin terminal    | Terminate runnning console apps and restart current session.
-`TerminalSwitchCopyMode`       |                          | Builtin terminal    | Switch terminal text selection copy mode.
-`TerminalSelectionCopy`        |                          | Builtin terminal    | Сopy selection to clipboard.
-`TerminalSelectionCancel`      | `Esc`                    | Builtin terminal    | Deselect a selection.
-`TerminalSelectionOneShot`     |                          | Builtin terminal    | One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed.
-`Drop`                         |                          | All levels          | Drop the key press.
-`DropIfRepeats`                |                          | All levels          | Drop the key press if it is repeating. This binding should be specified before the main action for the key combination.
+`FocusPrevWindow`              | `Ctrl+PageUp`            | Desktop             | Switch focus to the next desktop window.
+`FocusNextWindow`              | `Ctrl+PageDown`          | Desktop             | Switch focus to the previous desktop window.
+`Disconnect`                   | `Shift+F7`               | Desktop             | Disconnect from the desktop.
+`TryToQuit`                    | `F10`                    | Desktop             | Shut down the desktop server if no applications are running.
+`TerminalFindNext`             | `Alt+RightArrow`         | Application         | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
+`TerminalFindPrev`             | `Alt+LeftArrow`          | Application         | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
+`TerminalViewportOnePageUp`    | `Shift+Ctrl+PageUp`      | Application         | Scroll one page up.
+`TerminalViewportOnePageDown`  | `Shift+Ctrl+PageDown`    | Application         | Scroll one page down.
+`TerminalViewportOnePageLeft`  | `Shift+Alt+LeftArrow`    | Application         | Scroll one page to the left.
+`TerminalViewportOnePageRight` | `Shift+Alt+RightArrow`   | Application         | Scroll one page to the right.
+`TerminalViewportOneCharUp`    | `Shift+Ctrl+UpArrow`     | Application         | Scroll one line up.
+`TerminalViewportOneCharDown`  | `Shift+Ctrl+DownArrow`   | Application         | Scroll one line down.
+`TerminalViewportOneCharLeft`  | `Shift+Ctrl+LeftArrow`   | Application         | Scroll one cell to the left.
+`TerminalViewportOneCharRight` | `Shift+Ctrl+RightArrow`  | Application         | Scroll one cell to the right.
+`TerminalViewportTop`          | `Shift+Ctrl+Home`        | Application         | Scroll to the scrollback top.
+`TerminalViewportEnd`          | `Shift+Ctrl+End`         | Application         | Scroll to the scrollback bottom (reset viewport position).
+`TerminalViewportCopy`         |                          | Application         | Сopy viewport to clipboard.
+`TerminalClipboardPaste`       |                          | Application         | Paste from clipboard.
+`TerminalClipboardWipe`        |                          | Application         | Reset clipboard.
+`TerminalUndo`                 |                          | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
+`TerminalRedo`                 |                          | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
+`TerminalToggleCwdSync`        |                          | Application         | Toggle the current working directory sync mode.
+`TerminalToggleWrapMode`       |                          | Application         | Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is.
+`TerminalToggleSelectionMode`  |                          | Application         | Toggle between linear and rectangular selection form.
+`TerminalToggleFullscreen`     |                          | Application         | Toggle fullscreen mode.
+`TerminalToggleStdioLog`       |                          | Application         | Stdin/stdout log toggle.
+`TerminalQuit`                 |                          | Application         | Terminate runnning console apps and close terminal.
+`TerminalRestart`              |                          | Application         | Terminate runnning console apps and restart current session.
+`TerminalSwitchCopyMode`       |                          | Application         | Switch terminal text selection copy mode.
+`TerminalSelectionCopy`        |                          | Application         | Сopy selection to clipboard.
+`TerminalSelectionCancel`      | `Esc`                    | Application         | Deselect a selection.
+`TerminalSelectionOneShot`     |                          | Application         | One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed.
 
 ### DirectVT configuration payload received from the parent process
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -333,8 +333,8 @@ Action                         | Default key combination  | Level               
 `ToggleFullscreenMode`         | `Alt+Enter`              | Native GUI window   | Toggle fullscreen mode.
 `ToggleAntialiasingMode`       | `Ctrl+CapsLock`          | Native GUI window   | Toggle text antialiasing mode.
 `CloseGuiWindow`               | `Home+End`, `End+Home`   | Native GUI window   | Close GUI window.
-`RollFontsForward`             | `Ctrl+Shift+F11`         | Native GUI window   | Roll font list forward.
-`RollFontsBackward`            | `Ctrl+Shift+F12`         | Native GUI window   | Roll font list backward.
+`RollFontsBackward`            | `Ctrl+Shift+F11`         | Native GUI window   | Roll font list backward.
+`RollFontsForward`             | `Ctrl+Shift+F12`         | Native GUI window   | Roll font list forward.
 `FocusPrevWindow`              | `Ctrl+PageUp`            | Desktop environment | Switch focus to the next desktop window.
 `FocusNextWindow`              | `Ctrl+PageDown`          | Desktop environment | Switch focus to the previous desktop window.
 `Disconnect`                   | `Shift+F7`               | Desktop environment | Disconnect from the desktop.
@@ -437,9 +437,9 @@ Notes
             <key="Alt+Enter"          action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
             <key="Ctrl+CapsLock"      action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
             <key="Home+End"           action=CloseGuiWindow/>          <!-- Close GUI window. -->
-            <key="End+Home"           action=CloseGuiWindow/>          <!-- Close GUI window. -->
-            <key="Ctrl+Shift+F11"     action=RollFontsForward/>        <!-- Roll font list forward. -->
-            <key="Ctrl+Shift+F12"     action=RollFontsBackward/>       <!-- Roll font list backward. -->
+            <key="End+Home"           action=CloseGuiWindow/>
+            <key="Ctrl+Shift+F11"     action=RollFontsBackward/>       <!-- Roll font list backward. -->
+            <key="Ctrl+Shift+F12"     action=RollFontsForward/>        <!-- Roll font list forward. -->
         </hotkeys>
     </gui>
     <cursor>

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -733,11 +733,11 @@ namespace netxs::app::terminal
         };
         boss.LISTEN(tier::anycast, terminal::events::search::forward, gear)
         {
-            boss.search(gear, feed::fwd);
+            boss.selection_search(gear, feed::fwd);
         };
         boss.LISTEN(tier::anycast, terminal::events::search::reverse, gear)
         {
-            boss.search(gear, feed::rev);
+            boss.selection_search(gear, feed::rev);
         };
         boss.LISTEN(tier::anycast, terminal::events::data::paste, gear)
         {

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.39";
+    static const auto version = "v0.9.99.40";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -609,6 +609,7 @@ namespace netxs::app::shared
         twod gridsize{};
         si32 cellsize{};
         std::list<text> fontlist;
+        std::list<std::pair<text, text>> hotkeys;
     };
 
     auto get_gui_config(xmls& config)
@@ -627,6 +628,17 @@ namespace netxs::app::shared
             //todo implement 'fonts/font/file' - font file path/url
             gui_config.fontlist.push_back(f->take_value());
         }
+        auto keybinds = config.list("/config/gui/hotkeys/key");
+        for (auto keybind_ptr : keybinds)
+        {
+            auto& keybind = *keybind_ptr;
+            if (!keybind.fake)
+            {
+                auto chord = keybind.take_value();
+                auto action = keybind.take("action", ""s);
+                gui_config.hotkeys.push_back({ chord, action });
+            }
+        }
         return gui_config;
     }
     void splice(xipc client, gui_config_t& gc)
@@ -638,7 +650,7 @@ namespace netxs::app::shared
             auto connect = [&]
             {
                 auto event_domain = netxs::events::auth{};
-                auto window = event_domain.create<gui::window>(event_domain, gc.fontlist, gc.cellsize, gc.aliasing, gc.blinking);
+                auto window = event_domain.create<gui::window>(event_domain, gc.fontlist, gc.cellsize, gc.aliasing, gc.blinking, dot_21, gc.hotkeys);
                 window->connect(gc.winstate, gc.wincoord, gc.gridsize);
             };
             if (os::stdout_fd != os::invalid_fd)

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1882,7 +1882,7 @@ namespace netxs::ui
                         auto proc_ptr = proc_wptr.lock();
                         if (proc_ptr)
                         {
-                            (*proc_ptr)(gear);
+                            if (!gear.handled) (*proc_ptr)(gear);
                         }
                         return !proc_ptr;
                     });
@@ -1917,6 +1917,17 @@ namespace netxs::ui
                 proc("DropIfRepeats", [](hids& gear){ if (gear.keystat == input::key::repeated) gear.set_handled(); });
             }
 
+            template<si32 Tier = tier::release>
+            auto filter(hids& gear)
+            {
+                if (gear.payload == input::keybd::type::keypress)
+                {
+                    if (!gear.handled) _dispatch<Tier>(gear, gear.vkchord);
+                    if (!gear.handled) _dispatch<Tier>(gear, gear.chchord);
+                    if (!gear.handled) _dispatch<Tier>(gear, gear.scchord);
+                }
+                return !gear.handled;
+            }
             void proc(qiew name, func proc)
             {
                 api_map[name] = ptr::shared(std::move(proc));

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1913,7 +1913,8 @@ namespace netxs::ui
                         if (!gear.handled) _dispatch<tier::preview>(gear, gear.scchord);
                     }
                 };
-                proc("Drop", [](hids& gear){ gear.set_handled(); });
+                proc("Drop",          [](hids& gear){ gear.set_handled(); });
+                proc("DropIfRepeats", [](hids& gear){ if (gear.keystat == input::key::repeated) gear.set_handled(); });
             }
 
             void proc(qiew name, func proc)

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1991,12 +1991,11 @@ namespace netxs::gui
         {
             wkeybd.proc("IncreaseCellHeight"    , [&](hids& gear){ gear.set_handled(); IncreaseCellHeight(1.f); });
             wkeybd.proc("DecreaseCellHeight"    , [&](hids& gear){ gear.set_handled(); IncreaseCellHeight(-1.f);});
-            wkeybd.proc("ResetCellHeight"       , [&](hids& gear){ gear.set_handled(); if (gear.keystat != input::key::repeated) ResetCellHeight();        });
-            wkeybd.proc("ToggleFullscreenMode"  , [&](hids& gear){ gear.set_handled(); if (gear.keystat != input::key::repeated) ToggleFullscreenMode();   });
-            wkeybd.proc("ToggleAntialiasingMode", [&](hids& gear){ gear.set_handled(); if (gear.keystat != input::key::repeated) ToggleAntialiasingMode(); });
-            wkeybd.proc("CloseGuiWindow"        , [&](hids& gear){ gear.set_handled(); if (gear.keystat != input::key::repeated) CloseGuiWindow();         });
-            wkeybd.proc("RollFontsBackward"     , [&](hids& gear){ gear.set_handled(); if (gear.keystat != input::key::repeated) RollFontList(feed::rev);  });
-            wkeybd.proc("RollFontsForward"      , [&](hids& gear){ gear.set_handled(); if (gear.keystat != input::key::repeated) RollFontList(feed::fwd);  });
+            wkeybd.proc("ResetCellHeight"       , [&](hids& gear){ gear.set_handled(); ResetCellHeight();        });
+            wkeybd.proc("ToggleFullscreenMode"  , [&](hids& gear){ gear.set_handled(); ToggleFullscreenMode();   });
+            wkeybd.proc("ToggleAntialiasingMode", [&](hids& gear){ gear.set_handled(); ToggleAntialiasingMode(); });
+            wkeybd.proc("RollFontsBackward"     , [&](hids& gear){ gear.set_handled(); RollFontList(feed::rev);  });
+            wkeybd.proc("RollFontsForward"      , [&](hids& gear){ gear.set_handled(); RollFontList(feed::fwd);  });
             for (auto& [chord, action] : hotkeys) wkeybd.bind<tier::preview>(chord, action);
         }
 
@@ -2988,13 +2987,6 @@ namespace netxs::gui
                 set_aa_mode(!gcache.aamode);
             });
         }
-        void CloseGuiWindow()
-        {
-            bell::enqueue(This(), [&](auto& /*boss*/)
-            {
-                window_shutdown();
-            });
-        }
         void RollFontList(feed dir)
         {
             if (fcache.families.empty()) return;
@@ -3043,10 +3035,6 @@ namespace netxs::gui
                 else if (keybd_test_pressed(vkey::capslock) && keybd_test_pressed(vkey::key_0)) // Reset cell scaling.
                 {
                     ResetCellHeight();
-                }
-                else if (keybd_test_pressed(vkey::home) && keybd_test_pressed(vkey::end)) // Shutdown by Home+End.
-                {
-                    CloseGuiWindow();
                 }
                 else if (keybd_test_pressed(vkey::control) && keybd_test_pressed(vkey::shift) // Roll font list. Renumerate font list.
                       && (keybd_test_pressed(vkey::f11) || keybd_test_pressed(vkey::f12)))

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -532,7 +532,7 @@ namespace netxs::input
 
             using cmap = std::map<si32, chord_item_t>; // std::unordered_map doesn't sort items.
 
-            cmap keymap{}; // kmap: .
+            cmap pushed{}; // kmap: Pushed key map.
             bool keyout{}; // kmap: Some key has left the key chord.
 
             void reset(syskeybd& k)
@@ -540,13 +540,13 @@ namespace netxs::input
                 k.vkchord.clear();
                 k.scchord.clear();
                 k.chchord.clear();
-                keymap.clear();
+                pushed.clear();
                 keyout = {};
             }
             auto exist(si32 keyid)
             {
-                auto iter = keymap.find(keyid);
-                return iter != keymap.end();
+                auto iter = pushed.find(keyid);
+                return iter != pushed.end();
             }
             // Build key chords.
             // key chord is a set of 16-bit words: 0x000a 0x000b ... 0xffff 0xa 0xfe0e
@@ -578,7 +578,7 @@ namespace netxs::input
                     //log("key=%% pressed=%%", input::key::map::data(k.keycode).name, k.keystat);
                     if (k.keystat == input::key::released)
                     {
-                        keymap.erase(k.keycode);
+                        pushed.erase(k.keycode);
                     }
                     k.vkchord.clear();
                     k.scchord.clear();
@@ -589,7 +589,7 @@ namespace netxs::input
                     {
                         keyout = k.keystat == input::key::released;
                         //log(" erasing %%", k.keystat == input::key::released ? "key::released" : k.keystat == input::key::pressed ? "key::pressed" : "key::repeated");
-                        std::erase_if(keymap, [&](auto& rec)
+                        std::erase_if(pushed, [&](auto& rec)
                         {
                             auto& [keyid, val] = rec;
                             //log("\tcheck keyid=%%", input::key::map::data(keyid).name);
@@ -617,7 +617,7 @@ namespace netxs::input
                     }
                     if (k.keystat == input::key::pressed)
                     {
-                        auto& key = keymap[k.keycode];
+                        auto& key = pushed[k.keycode];
                         key.scode = k.scancod | (k.extflag ? 0x100 : 0); // Store the scan code of a pressed key.
                         key.index = k.virtcod; // Store the virtual code to check later that it is still pressed.
                         key.stamp = datetime::now();

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1965,10 +1965,14 @@ namespace netxs::input
             if (m_sav.changed != m_sys.changed) m_sav = m_sys;
             return !alive;
         }
+        auto is_exclusive()
+        {
+            return !ptr::is_empty(exclusive_wptr);
+        }
         void fire_keybd()
         {
             alive = true;
-            if (!ptr::is_empty(exclusive_wptr))
+            if (is_exclusive())
             if (auto target = exclusive_wptr.lock())
             {
                 target->bell::signal(tier::preview, hids::events::keybd::key::post, *this);

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -535,7 +535,7 @@ namespace netxs::input
             cmap pushed{}; // kmap: Pushed key map.
             bool keyout{}; // kmap: Some key has left the key chord.
 
-            void reset(syskeybd& k)
+            void reset(auto& k)
             {
                 k.vkchord.clear();
                 k.scchord.clear();
@@ -571,7 +571,7 @@ namespace netxs::input
                 chchord += cluster;
             }
             template<class P = noop>
-            void build(syskeybd& k, P test_key_released = {})
+            void build(auto& k, P test_key_released = {})
             {
                 if (k.keystat != input::key::repeated)
                 {
@@ -1597,6 +1597,7 @@ namespace netxs::input
             mouse::delay = props.dblclick_timeout;
             mouse::prime = dot_mx;
             mouse::coord = dot_mx;
+            keybd::gear_id = bell::id;
             bell::signal(tier::general, events::device::user::login, user_index);
         }
         virtual ~hids()

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -90,8 +90,6 @@ namespace netxs::ui
                     undo,
                     redo,
                     deselect,
-                    look_fwd,
-                    look_rev,
                 };
             };
             struct cursor // See pro::caret.
@@ -7398,10 +7396,6 @@ namespace netxs::ui
                 selection_moveto(delta);
             }
         }
-        void search(hids& gear, feed dir)
-        {
-            selection_search(gear, dir);
-        }
         void set_color(cell brush)
         {
             auto& console = *target;
@@ -7496,8 +7490,6 @@ namespace netxs::ui
                 case commands::ui::undo:         ipccon.undo(true);                   break;
                 case commands::ui::redo:         ipccon.undo(faux);                   break;
                 case commands::ui::deselect:     selection_cancel();                  break;
-                case commands::ui::look_fwd:     console.selection_search(feed::fwd); break;
-                case commands::ui::look_rev:     console.selection_search(feed::rev); break;
                 default: break;
             }
             if (cmd != commands::ui::togglesel && !console.selection_active())
@@ -7725,8 +7717,8 @@ namespace netxs::ui
             publish_property(ui::term::events::search::status, [&](auto& v){ v = target->selection_button(); });
             selection_selmod(config.def_selmod);
 
-            chords.proc("TerminalFindPrev",                 [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::look_rev); });
-            chords.proc("TerminalFindNext",                 [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::look_fwd); });
+            chords.proc("TerminalFindPrev",                 [&](hids& gear){ gear.set_handled(); selection_search(gear, feed::rev); });
+            chords.proc("TerminalFindNext",                 [&](hids& gear){ gear.set_handled(); selection_search(gear, feed::fwd); });
             chords.proc("TerminalViewportOnePageLeft",      [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = dot_10  }); });
             chords.proc("TerminalViewportOnePageRight",     [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = -dot_10 }); });
             chords.proc("TerminalViewportOneCharLeft",      [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 1, 0 }}); });

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -17,7 +17,7 @@ R"==(<!-- Ordered list of paths to settings files. -->
         </javascript>
     </scripting>
     <gui>  <!-- GUI mode related settings. (win32 platform only for now) -->
-        <antialiasing=off/>   <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
+        <antialiasing=on/>    <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
         <cellheight=20/>      <!-- Text cell height in physical pixels. Note: The width of the text cell depends on the primary font (the first one in the font list). -->
         <gridsize=""/>        <!-- Window initial grid size "width,height" in text cells. If gridsize="" or gridsize=0,0, then the size of the GUI window is left to the OS window manager. -->
         <wincoor=""/>         <!-- Window initial coordinates "x,y" (top-left corner on the desktop in physical pixels). If wincoor="", then the position of the GUI window is left to the OS window manager. -->
@@ -33,13 +33,16 @@ R"==(<!-- Ordered list of paths to settings files. -->
         <hotkeys key*>
             <key="CapsLock+UpArrow"   action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
             <key="CapsLock+DownArrow" action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->
+            <key="Ctrl+Key0"          action=DropIfRepeats/>           <!-- Don't repeat the Reset text cell height. -->
             <key="Ctrl+Key0"          action=ResetCellHeight/>         <!-- Reset text cell height. -->
+            <key="Alt+Enter"          action=DropIfRepeats/>           <!-- Don't repeat the Toggle fullscreen mode. -->
             <key="Alt+Enter"          action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
+            <key="Ctrl+CapsLock"      action=DropIfRepeats/>           <!-- Don't repeat the Toggle text antialiasing mode. -->
             <key="Ctrl+CapsLock"      action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
-            <key="Home+End"           action=CloseGuiWindow/>          <!-- Close GUI window. -->
-            <key="End+Home"           action=CloseGuiWindow/>
-            <key="Ctrl+Shift+F11"     action=RollFontsBackward/>        <!-- Roll font list backward. -->
-            <key="Ctrl+Shift+F12"     action=RollFontsForward/>       <!-- Roll font list forward. -->
+            <key="Ctrl+Shift+F11"     action=DropIfRepeats/>           <!-- Don't repeat the Roll font list backward. -->
+            <key="Ctrl+Shift+F11"     action=RollFontsBackward/>       <!-- Roll font list backward. -->
+            <key="Ctrl+Shift+F12"     action=DropIfRepeats/>           <!-- Don't repeat the Roll font list forward. -->
+            <key="Ctrl+Shift+F12"     action=RollFontsForward/>        <!-- Roll font list forward. -->
         </hotkeys>
     </gui>
     <cursor>
@@ -399,7 +402,9 @@ R"==(
             <key="Shift+Ctrl+DownArrow"  action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
             <key="Shift+Ctrl+LeftArrow"  action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
             <key="Shift+Ctrl+RightArrow" action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
+            <key="Shift+Ctrl+Home"       action=DropIfRepeats/>                     <!-- Don't repeat the Scroll to the scrollback top. -->
             <key="Shift+Ctrl+Home"       action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
+            <key="Shift+Ctrl+End"        action=DropIfRepeats/>                     <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
             <key="Shift+Ctrl+End"        action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
             <key=""                      action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
             <key=""                      action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -37,9 +37,9 @@ R"==(<!-- Ordered list of paths to settings files. -->
             <key="Alt+Enter"          action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
             <key="Ctrl+CapsLock"      action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
             <key="Home+End"           action=CloseGuiWindow/>          <!-- Close GUI window. -->
-            <key="End+Home"           action=CloseGuiWindow/>          <!-- Close GUI window. -->
-            <key="Ctrl+Shift+F11"     action=RollFontsForward/>        <!-- Roll font list forward. -->
-            <key="Ctrl+Shift+F12"     action=RollFontsBackward/>       <!-- Roll font list backward. -->
+            <key="End+Home"           action=CloseGuiWindow/>
+            <key="Ctrl+Shift+F11"     action=RollFontsBackward/>        <!-- Roll font list backward. -->
+            <key="Ctrl+Shift+F12"     action=RollFontsForward/>       <!-- Roll font list forward. -->
         </hotkeys>
     </gui>
     <cursor>


### PR DESCRIPTION
### Changes

- Make text anti-aliasing enabled by default.
- Make GUI window key bindings configurable.
- Introduce `Drop` and `DropIfRepeats` actions.
  Action                         | Description
  -------------------------------|-------------
  `Drop`                         | Drop all events for the specified key combination. No further processing.
  `DropIfRepeats`                | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
  ```xml
  <config>
    <gui>
      <hotkeys key*>
        <key="Alt+Enter" action=DropIfRepeats/>           <!-- Don't repeat the Toggle fullscreen mode. -->
        <key="Alt+Enter" action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
      </hotkeys>
    </gui>
  </config>
  ```