### PR TITLE
Change `Exclusive Keyboard Mode` to `Alternate Keyboard Mode`

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -161,7 +161,7 @@ The list of hotkey actions is slightly different from the list of window menu ac
 Value                        | Unique for hotkeys | Default Hotkey               | Description
 -----------------------------|--------------------|------------------------------|------------
 Drop                         |                    |                              | Drop all events for the specified key combination. No further processing.
-DropIfRepeats                |                    |                              | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
+DropAutoRepeat               |                    |                              | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
 ToggleExclusiveKeybd         | x                  | `Ctrl-Alt`, `Alt-Ctrl`       | Toggle exclusive keyboard mode. In exclusive mode, all keyboard events are ignored by higher levels.
 TerminalFindNext             |                    | `Alt+RightArrow`             | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
 TerminalFindPrev             |                    | `Alt+LeftArrow`              | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -160,9 +160,9 @@ The list of hotkey actions is slightly different from the list of window menu ac
 
 Value                        | Unique for hotkeys | Default Hotkey               | Description
 -----------------------------|--------------------|------------------------------|------------
-Drop                         |                    |                              | Drop all events for the specified key combination. No further processing.
-DropAutoRepeat               |                    |                              | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
-ToggleExclusiveKeybd         | x                  | `Ctrl-Alt`, `Alt-Ctrl`       | Toggle exclusive keyboard mode. In exclusive mode, all keyboard events are ignored by higher levels.
+Drop                         | x                  |                              | Drop all events for the specified key combination. No further processing.
+DropAutoRepeat               | x                  |                              | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
+ToggleHotkeyMode             | x                  | `Ctrl-Alt`, `Alt-Ctrl`       | Toggle hotkey mode between mode=0 (deafult) and mode=1.
 TerminalFindNext             |                    | `Alt+RightArrow`             | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
 TerminalFindPrev             |                    | `Alt+LeftArrow`              | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
 TerminalViewportOnePageUp    | x                  | `Shift+Ctrl+PageUp`          | Scroll one page up.
@@ -303,11 +303,23 @@ TerminalSelectionOneShot     |                    |                             
                 </notes>
             </item>
         </menu>
-        <hotkeys key*>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.   -->
+    </term>
+    <hotkeys>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.   -->
+        <tui key*>  <!-- TUI matrix layer key bindings. The mode=0 is implicitly used by default. -->
+            <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
+            <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (reversed release order). -->
+            <key="Ctrl-Alt"              action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=1 by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl"              action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=1 by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Ctrl-Alt" mode=1       action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=0 (default) by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl" mode=1       action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=0 (default) by pressing and releasing Alt-Ctrl (reversed releasing). -->
+        </tui>
+        <term key*>
             <key="Alt+RightArrow"        action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Alt+LeftArrow"         action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"     action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
             <key="Shift+Ctrl+PageDown"   action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
+            <key="Ctrl+PageUp"   mode=1  action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
+            <key="Ctrl+PageDown" mode=1  action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
             <key="Shift+Alt+LeftArrow"   action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
             <key="Shift+Alt+RightArrow"  action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
             <key="Shift+Ctrl+UpArrow"    action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
@@ -333,10 +345,8 @@ TerminalSelectionOneShot     |                    |                             
             <key=""                      action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
             <key="Esc"                   action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
             <key=""                      action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. The argument can be the one of the following values 0:'none', 1:'text', 2:'ansi', 3:'rich', 4:'html', 5:'protected'. -->
-            <key="Ctrl-Alt"              action=ToggleExclusiveKeybd/>              <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl"              action=ToggleExclusiveKeybd/>              <!-- Toggle exclusive keyboard mode by pressing and releasing Alt-Ctrl. -->
-        </hotkeys>
-    </term>
+        </term>
+    </hotkeys>
 </config>
 ```
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -345,7 +345,7 @@ Configuration record                       | Interpretation
 Action                         | Default key combination  | Available at layer  | Description
 -------------------------------|--------------------------|---------------------|------------
 `Drop`                         |                          | All layers          | Drop all events for the specified key combination. No further processing.
-`DropIfRepeats`                |                          | All layers          | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
+`DropAutoRepeat`               |                          | All layers          | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
 `ToggleDebugOverlay`           |                          | TUI matrix          | Toggle debug overlay.
 `ToggleExclusiveKeybd`         | `Ctrl-Alt`, `Alt-Ctrl`   | Application         | Toggle exclusive keyboard mode. In exclusive mode, all keyboard events are ignored by higher layers. Exclusive keyboard mode is automatically disabled when refocusing.
 `IncreaseCellHeight`           | `CapsLock+UpArrow`       | Native GUI window   | Increase the text cell height by one pixel.
@@ -793,15 +793,15 @@ Notes
         <gui key*>  <!-- Native GUI window layer key bindings. -->
             <key="CapsLock+UpArrow"      action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
             <key="CapsLock+DownArrow"    action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->
-            <key="Ctrl+0"                action=DropIfRepeats/>           <!-- Don't repeat the Reset text cell height. -->
+            <key="Ctrl+0"                action=DropAutoRepeat/>          <!-- Don't repeat the Reset text cell height. -->
             <key="Ctrl+0"                action=ResetCellHeight/>         <!-- Reset text cell height. -->
-            <key="Alt+Enter"             action=DropIfRepeats/>           <!-- Don't repeat the Toggle fullscreen mode. -->
+            <key="Alt+Enter"             action=DropAutoRepeat/>          <!-- Don't repeat the Toggle fullscreen mode. -->
             <key="Alt+Enter"             action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
-            <key="Ctrl+CapsLock"         action=DropIfRepeats/>           <!-- Don't repeat the Toggle text antialiasing mode. -->
+            <key="Ctrl+CapsLock"         action=DropAutoRepeat/>          <!-- Don't repeat the Toggle text antialiasing mode. -->
             <key="Ctrl+CapsLock"         action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
-            <key="Ctrl+Shift+F11"        action=DropIfRepeats/>           <!-- Don't repeat the Roll font list backward. -->
+            <key="Ctrl+Shift+F11"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list backward. -->
             <key="Ctrl+Shift+F11"        action=RollFontsBackward/>       <!-- Roll font list backward. -->
-            <key="Ctrl+Shift+F12"        action=DropIfRepeats/>           <!-- Don't repeat the Roll font list forward. -->
+            <key="Ctrl+Shift+F12"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list forward. -->
             <key="Ctrl+Shift+F12"        action=RollFontsForward/>        <!-- Roll font list forward. -->
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. -->
@@ -826,9 +826,9 @@ Notes
             <key="Shift+Ctrl+DownArrow"  action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
             <key="Shift+Ctrl+LeftArrow"  action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
             <key="Shift+Ctrl+RightArrow" action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
-            <key="Shift+Ctrl+Home"       action=DropIfRepeats/>                     <!-- Don't repeat the Scroll to the scrollback top. -->
+            <key="Shift+Ctrl+Home"       action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback top. -->
             <key="Shift+Ctrl+Home"       action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+End"        action=DropIfRepeats/>                     <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
+            <key="Shift+Ctrl+End"        action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
             <key="Shift+Ctrl+End"        action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
             <key=""                      action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
             <key=""                      action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -303,13 +303,14 @@ Application `app_name` | `<config/hotkeys/app_name/>` | Application layer key bi
 The syntax for defining key combination bindings is:
 
 ```xml
-<key="Key+Chord" action="NameOfAction"/>
+<key="Key+Chord" action="NameOfAction" mode=N/> <!-- mode=0 can be omitted.  -->
 ```
 
 Tag      | Value
 ---------|--------
 `key`    | The text string containing the key combination.
 `action` | The action name.
+`mode`   | Hotkey mode for which mapping is being done (mode=0 by default). Either `mode=0` or `mode=1` are allowed.
 
 The following joiners are allowed for combining keys:
 
@@ -333,12 +334,13 @@ The required key combination sequence can be generated on the Info page, accessi
 
 #### Interpretation
 
-Configuration record                       | Interpretation
--------------------------------------------|-----------------
-`<key="Key+Chord" action=NameOfAction/>`   | Append existing bindings using an indirect reference (the `NameOfAction` variable without quotes).
-`<key="Key+Chord" action="NameOfAction"/>` | Append existing bindings with the directly specified command "NameOfAction".
-`<key="Key+Chord" action=""/>`             | Remove all existing bindings for the specified key combination "Key+Chord".
-`<key=""          action="NameOfAction"/>` | Do nothing.
+Configuration record                              | Interpretation
+--------------------------------------------------|-----------------
+`<key="Key+Chord" action=NameOfAction/>`          | Append existing bindings using an indirect reference (the `NameOfAction` variable without quotes).
+`<key="Key+Chord" action="NameOfAction"/>`        | Append existing bindings with the directly specified command "NameOfAction".
+`<key="Key+Chord" action="NameOfAction" mode=1/>` | Append existing bindings for mode=1.
+`<key="Key+Chord" action=""/>`                    | Remove all existing bindings for the specified key combination "Key+Chord".
+`<key=""          action="NameOfAction"/>`        | Do nothing.
 
 #### Available actions
 
@@ -347,7 +349,7 @@ Action                         | Default key combination  | Available at layer  
 `Drop`                         |                          | All layers          | Drop all events for the specified key combination. No further processing.
 `DropAutoRepeat`               |                          | All layers          | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
 `ToggleDebugOverlay`           |                          | TUI matrix          | Toggle debug overlay.
-`ToggleExclusiveKeybd`         | `Ctrl-Alt`, `Alt-Ctrl`   | Application         | Toggle exclusive keyboard mode. In exclusive mode, all keyboard events are ignored by higher layers. Exclusive keyboard mode is automatically disabled when refocusing.
+`ToggleHotkeyMode`             | `Ctrl-Alt`, `Alt-Ctrl`   | TUI matrix          | Toggle hotkey mode between mode=0 (deafult) and mode=1.
 `IncreaseCellHeight`           | `CapsLock+UpArrow`       | Native GUI window   | Increase the text cell height by one pixel.
 `DecreaseCellHeight`           | `CapsLock+DownArrow`     | Native GUI window   | Decrease the text cell height by one pixel.
 `ResetCellHeight`              | `Ctrl+Key0`              | Native GUI window   | Reset text cell height.
@@ -790,7 +792,7 @@ Notes
         </menu>
     </defapp>
     <hotkeys>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.  -->
-        <gui key*>  <!-- Native GUI window layer key bindings. -->
+        <gui key*>  <!-- Native GUI window layer key bindings. key* here is to clear all previous bindings and start a new list. -->
             <key="CapsLock+UpArrow"      action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
             <key="CapsLock+DownArrow"    action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->
             <key="Ctrl+0"                action=DropAutoRepeat/>          <!-- Don't repeat the Reset text cell height. -->
@@ -804,9 +806,13 @@ Notes
             <key="Ctrl+Shift+F12"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list forward. -->
             <key="Ctrl+Shift+F12"        action=RollFontsForward/>        <!-- Roll font list forward. -->
         </gui>
-        <tui key*>  <!-- TUI matrix layer key bindings. -->
+        <tui key*>  <!-- TUI matrix layer key bindings. The mode=0 is implicitly used by default. -->
             <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (Reverse release order). -->
+            <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (reversed release order). -->
+            <key="Ctrl-Alt"              action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=1 by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl"              action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=1 by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Ctrl-Alt" mode=1       action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=0 (default) by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl" mode=1       action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=0 (default) by pressing and releasing Alt-Ctrl (reversed releasing). -->
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"           action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
@@ -820,6 +826,8 @@ Notes
             <key="Alt+LeftArrow"         action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"     action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
             <key="Shift+Ctrl+PageDown"   action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
+            <key="Ctrl+PageUp"   mode=1  action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
+            <key="Ctrl+PageDown" mode=1  action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
             <key="Shift+Alt+LeftArrow"   action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
             <key="Shift+Alt+RightArrow"  action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
             <key="Shift+Ctrl+UpArrow"    action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
@@ -847,8 +855,6 @@ Notes
             <key=""                      action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
             <key="Esc"                   action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
             <key=""                      action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. -->
-            <key="Ctrl-Alt"              action=ToggleExclusiveKeybd/>              <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt. In exclusive mode, all keyboard events are ignored by higher levels. -->
-            <key="Alt-Ctrl"              action=ToggleExclusiveKeybd/>              <!-- Toggle exclusive keyboard mode by pressing and releasing Alt-Ctrl. -->
         </term>
     </hotkeys>
 </config>

--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -24,19 +24,19 @@
 </thead>
 <tbody>
   <tr>
-    <th>Ctrl-Alt ²</th>
-    <td colspan="9">Toggle exclusive keyboard mode</td>
+    <th>Ctrl-Alt ¹</th>
+    <td colspan="9">Toggle alternate keyboard mode</td>
   </tr>
   <tr>
-    <th>F10 ²</th>
+    <th>F10 ¹</th>
     <td colspan="9">Disconnect all users and shutdown if there are no apps running</td>
   </tr>
   <tr>
-    <th>Shift+F7 ²</th>
+    <th>Shift+F7 ¹</th>
     <td colspan="9">Leave current session</td>
   </tr>
   <tr>
-    <th>Ctrl+PageUp/PageDown ²</th>
+    <th>Ctrl+PageUp/PageDown ¹</th>
     <td colspan="9">Switch focus between running apps</td>
   </tr>
   <tr>
@@ -161,24 +161,24 @@
     <th></th>
     <th>GUI window</th>
     <th>Resizing grips</th>
-    <th>Window 1px-height row (in fullscreen mode)¹</th>
+    <th>Window 1px-height row (in fullscreen mode)²</th>
   </tr>
 </thead>
 <tbody>
   <tr>
-    <th>Alt+Enter ²</th>
+    <th>Alt+Enter ¹</th>
     <td colspan="3">Toggle fullscreen mode</td>
   </tr>
   <tr>
-    <th>Ctrl+CapsLock ²</th>
+    <th>Ctrl+CapsLock ¹</th>
     <td colspan="3">Toggle antialiasing mode</td>
   </tr>
   <tr>
-    <th>CapsLock+UpArrow/DownArrow ²</th>
+    <th>CapsLock+UpArrow/DownArrow ¹</th>
     <td colspan="3">Scale cell size</td>
   </tr>
   <tr>
-    <th>CapsLock+0 ²</th>
+    <th>CapsLock+0 ¹</th>
     <td colspan="3">Reset cell size</td>
   </tr>
   <tr>
@@ -214,5 +214,31 @@
 </tbody>
 </table>
 
-¹ — In fullscreen mode, the GUI window reserves a 1px high area at the top for forwarding mouse events.  
-² — Key bindings can be customized using the settings.
+## Built-in Terminal
+
+<table>
+  <thead>
+    <tr><th>Hotkey ¹</th>              <th>Default action</th></tr>
+  </thead>
+  <tbody>
+    <tr><th>Alt+RightArrow</th>        <td>Highlight next match of selected text fragment. Clipboard content is used if no active selection.</td></tr>
+    <tr><th>Alt+LeftArrow</th>         <td>Highlight previous match of selected text fragment. Clipboard content is used if no active selection.</td></tr>
+    <tr><th>Shift+Ctrl+PageUp</th>     <td>Scroll one page up.</td></tr>
+    <tr><th>Shift+Ctrl+PageDown</th>   <td>Scroll one page down.</td></tr>
+    <tr><th>Shift+Alt+LeftArrow</th>   <td>Scroll one page to the left.</td></tr>
+    <tr><th>Shift+Alt+RightArrow</th>  <td>Scroll one page to the right.</td></tr>
+    <tr><th>Shift+Ctrl+UpArrow</th>    <td>Scroll one line up.</td></tr>
+    <tr><th>Shift+Ctrl+DownArrow</th>  <td>Scroll one line down.</td></tr>
+    <tr><th>Shift+Ctrl+LeftArrow</th>  <td>Scroll one cell to the left.</td></tr>
+    <tr><th>Shift+Ctrl+RightArrow</th> <td>Scroll one cell to the right.</td></tr>
+    <tr><th>Shift+Ctrl+Home</th>       <td>Don't repeat the Scroll to the scrollback top.</td></tr>
+    <tr><th>Shift+Ctrl+Home</th>       <td>Scroll to the scrollback top.</td></tr>
+    <tr><th>Shift+Ctrl+End</th>        <td>Don't repeat the Scroll to the scrollback bottom (reset viewport position).</td></tr>
+    <tr><th>Shift+Ctrl+End</th>        <td>Scroll to the scrollback bottom (reset viewport position).</td></tr>
+  </tbody>
+</table>
+
+---
+
+¹ — Key bindings can be customized using settings.  
+² — In fullscreen mode, the GUI window reserves a 1px high area at the top for forwarding mouse events.

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -131,7 +131,7 @@ namespace netxs::app::desk
                                 {
                                     window.bell::signal(tier::release, e2::form::size::minimize, gear);
                                 }
-                                else pro::focus::set(data_src, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                                else pro::focus::set(data_src, gear.id, pro::focus::solo::on);
                             }
                             else // Jump to window.
                             {
@@ -159,7 +159,7 @@ namespace netxs::app::desk
                                     {
                                         window.bell::signal(tier::release, e2::form::size::minimize, gear);
                                     }
-                                    pro::focus::set(data_src, gear.id, pro::focus::solo::off, pro::focus::flip::off);
+                                    pro::focus::set(data_src, gear.id, pro::focus::solo::off);
                                 }
                                 gear.dismiss(true); // Suppress double click.
                             }
@@ -174,7 +174,7 @@ namespace netxs::app::desk
                                 {
                                     window.bell::signal(tier::release, e2::form::size::minimize, gear);
                                 }
-                                else pro::focus::set(data_src, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                                else pro::focus::set(data_src, gear.id, pro::focus::solo::on);
                                 gear.dismiss();
                             }
                         }
@@ -421,7 +421,7 @@ namespace netxs::app::desk
                         boss.LISTEN(tier::release, events::ui::focus::any, gear, window.tracker)
                         {
                             auto deed = boss.bell::protos(tier::release);
-                                 if (deed == events::ui::focus::set.id) pro::focus::set(window.This(), gear.id, pro::focus::solo::off, pro::focus::flip::off);
+                                 if (deed == events::ui::focus::set.id) pro::focus::set(window.This(), gear.id, pro::focus::solo::off);
                             else if (deed == events::ui::focus::off.id) pro::focus::off(window.This(), gear.id);
                         };
                     });

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -278,7 +278,7 @@ namespace netxs::app::tile
                                 {
                                     auto gear_id_list = pro::focus::get(parent_ptr); // Expropriate all foci.
                                     world_ptr->bell::signal(tier::request, vtm::events::handoff, what); // Attach to the world.
-                                    pro::focus::set(what.applet, gear_id_list, pro::focus::solo::off, pro::focus::flip::off, true); // Refocus.
+                                    pro::focus::set(what.applet, gear_id_list, pro::focus::solo::off, true); // Refocus.
                                     master.base::riseup(tier::release, e2::form::proceed::quit::one, true); // Destroy placeholder.
                                 }
 
@@ -292,11 +292,11 @@ namespace netxs::app::tile
                         };
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear)
                         {
-                            pro::focus::set(boss.This(), gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                            pro::focus::set(boss.This(), gear.id, pro::focus::solo::on);
                         };
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::middle, gear)
                         {
-                            pro::focus::set(boss.This(), gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                            pro::focus::set(boss.This(), gear.id, pro::focus::solo::on);
                         };
                         boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent)
                         {
@@ -483,8 +483,7 @@ namespace netxs::app::tile
                             if (ratio == min_ratio)
                             {
                                 node->set_ratio(saved_ratio);
-                                pro::focus::set(boss.This(), gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off
-                                                                                               : pro::focus::solo::on, pro::focus::flip::off, true);
+                                pro::focus::set(boss.This(), gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off : pro::focus::solo::on, true);
                             }
                             else
                             {
@@ -525,7 +524,7 @@ namespace netxs::app::tile
                             auto app = app_window(what);
                             boss.attach(app);
                             app->bell::signal(tier::anycast, e2::form::upon::started);
-                            pro::focus::set(what.applet, gear_id_list, pro::focus::solo::mix, pro::focus::flip::off, true);
+                            pro::focus::set(what.applet, gear_id_list, pro::focus::solo::mix, true);
                         }
                     };
                     boss.LISTEN(tier::release, e2::form::proceed::swap, item_ptr)
@@ -543,7 +542,7 @@ namespace netxs::app::tile
                                 boss.attach(item_ptr);
                             }
                             else item_ptr = boss.This();
-                            pro::focus::set(boss.back(), gear_id_list, pro::focus::solo::off, pro::focus::flip::off);
+                            pro::focus::set(boss.back(), gear_id_list, pro::focus::solo::off);
                         }
                         else
                         {
@@ -564,7 +563,7 @@ namespace netxs::app::tile
                                 {
                                     auto gear_id_list = pro::focus::get(boss.This());
                                     item_ptr = boss.pop_back();
-                                    pro::focus::set(boss.back(), gear_id_list, pro::focus::solo::off, pro::focus::flip::off);
+                                    pro::focus::set(boss.back(), gear_id_list, pro::focus::solo::off);
                                 }
                                 else
                                 {
@@ -591,7 +590,7 @@ namespace netxs::app::tile
                     boss.LISTEN(tier::anycast, app::tile::events::ui::select, gear)
                     {
                         auto item_ptr = boss.back();
-                        if (item_ptr->base::kind() != base::node) pro::focus::set(item_ptr, gear.id, pro::focus::solo::off, pro::focus::flip::off);
+                        if (item_ptr->base::kind() != base::node) pro::focus::set(item_ptr, gear.id, pro::focus::solo::off);
                         else                                      pro::focus::off(item_ptr, gear.id); // Exclude grips.
                     };
                     boss.LISTEN(tier::preview, e2::form::size::enlarge::any, gear, -, (oneoff = subs{}))
@@ -622,7 +621,7 @@ namespace netxs::app::tile
                                 };
                                 auto just_copy = fullscreen_item;
                                 boss.base::riseup(tier::release, e2::form::proceed::attach, fullscreen_item);
-                                pro::focus::set(just_copy, gear_id_list, pro::focus::solo::off, pro::focus::flip::off); // Handover all foci.
+                                pro::focus::set(just_copy, gear_id_list, pro::focus::solo::off); // Handover all foci.
                                 boss.base::reflow();
                             }
                         }
@@ -650,8 +649,8 @@ namespace netxs::app::tile
                             auto slot_1 = newnode->attach(slot::_1, empty_1->branch(curitem));
                             auto slot_2 = newnode->attach(slot::_2, empty_2);
                             boss.attach(newnode);
-                            pro::focus::set(slot_1->back(), gear_id, pro::focus::solo::off, pro::focus::flip::off); // Handover all foci.
-                            pro::focus::set(slot_2->back(), gear_id, pro::focus::solo::off, pro::focus::flip::off);
+                            pro::focus::set(slot_1->back(), gear_id, pro::focus::solo::off); // Handover all foci.
+                            pro::focus::set(slot_2->back(), gear_id, pro::focus::solo::off);
                         }
                     };
                     boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, fast)
@@ -674,7 +673,7 @@ namespace netxs::app::tile
                             {
                                 auto gear_id_list = pro::focus::get(boss.This());
                                 auto deleted_item = boss.pop_back(); // Throw away.
-                                pro::focus::set(boss.back(), gear_id_list, pro::focus::solo::off, pro::focus::flip::off);
+                                pro::focus::set(boss.back(), gear_id_list, pro::focus::solo::off);
                             }
                             else if (boss.count() == 1) // Remove empty slot, reorganize.
                             {
@@ -718,7 +717,7 @@ namespace netxs::app::tile
                         {
                             gear_id_list.push_back(gear.id);
                         }
-                        pro::focus::set(app, gear_id_list, pro::focus::solo::off, pro::focus::flip::off);
+                        pro::focus::set(app, gear_id_list, pro::focus::solo::off);
                     };
                     boss.LISTEN(tier::release, events::backup, empty_slot_list)
                     {
@@ -964,8 +963,8 @@ namespace netxs::app::tile
                             auto gear_id_list = pro::focus::get(boss.This()); // Seize all foci.
                             auto item_ptr = boss.pop_back();
                             item_ptr->bell::signal(tier::release, e2::form::size::restore, item_ptr);
-                            pro::focus::set(boss.back(), foci_list, pro::focus::solo::off, pro::focus::flip::off, true); // Restore saved foci.
-                            pro::focus::set(item_ptr, gear_id_list, pro::focus::solo::off, pro::focus::flip::off); // Apply item's foci.
+                            pro::focus::set(boss.back(), foci_list, pro::focus::solo::off, true); // Restore saved foci.
+                            pro::focus::set(item_ptr, gear_id_list, pro::focus::solo::off); // Apply item's foci.
                             foci_list.clear();
                         }
 

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -130,7 +130,7 @@ namespace netxs::app::shared
         {
             if (std::exchange(*esc_pressed, faux) != *esc_pressed) boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
         });
-        keybd.template bind<tier::preview>( "Esc", "DropIfRepeats");
+        keybd.template bind<tier::preview>( "Esc", "DropAutoRepeat");
         keybd.template bind<tier::release>( "Esc", "WindowClosePreview");
         keybd.template bind<tier::preview>("-Esc", "WindowClose");
         keybd.template bind<tier::release>( "Any", "CancelWindowClose");
@@ -151,13 +151,13 @@ namespace netxs::app::shared
         keybd.bind("DownArrow" , "ScrollLineDown"      );
         keybd.bind("LeftArrow" , "ScrollCharLeft"      );
         keybd.bind("RightArrow", "ScrollCharRight"     );
-        keybd.bind("Home"      , "DropIfRepeats"       );
+        keybd.bind("Home"      , "DropAutoRepeat"      );
         keybd.bind("Home"      , "ScrollTop"           );
-        keybd.bind("End"       , "DropIfRepeats"       );
+        keybd.bind("End"       , "DropAutoRepeat"      );
         keybd.bind("End"       , "ScrollEnd"           );
-        keybd.bind("F11"       , "DropIfRepeats"       );
+        keybd.bind("F11"       , "DropAutoRepeat"      );
         keybd.bind("F11"       , "ToggleMaximize"      );
-        keybd.bind("F12"       , "DropIfRepeats"       );
+        keybd.bind("F12"       , "DropAutoRepeat"      );
         keybd.bind("F12"       , "ToggleFullscreen"    );
         keybd.bind("Ctrl-Alt"  , "ToggleExclusiveKeybd");
         keybd.bind("Alt-Ctrl"  , "ToggleExclusiveKeybd");

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.43";
+    static const auto version = "v0.9.99.44";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -116,7 +116,7 @@ namespace netxs::app::shared
         auto esc_pressed = ptr::shared(faux);
         keybd.proc("WindowClose", [&, esc_pressed](hids& gear)
         {
-            if (!gear.is_exclusive() && *esc_pressed)
+            if (*esc_pressed)
             {
                 boss.bell::signal(tier::anycast, e2::form::proceed::quit::one, true);
                 gear.set_handled(true);
@@ -130,37 +130,40 @@ namespace netxs::app::shared
         {
             if (std::exchange(*esc_pressed, faux) != *esc_pressed) boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
         });
-        keybd.template bind<tier::preview>( "Esc", "DropAutoRepeat");
-        keybd.template bind<tier::release>( "Esc", "WindowClosePreview");
-        keybd.template bind<tier::preview>("-Esc", "WindowClose");
-        keybd.template bind<tier::release>( "Any", "CancelWindowClose");
-        keybd.proc("ScrollPageUp"        , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); } });
-        keybd.proc("ScrollPageDown"      , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); } });
-        keybd.proc("ScrollLineUp"        , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 3 }}); } });
-        keybd.proc("ScrollLineDown"      , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-3 }}); } });
-        keybd.proc("ScrollCharLeft"      , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 3, 0 }}); } });
-        keybd.proc("ScrollCharRight"     , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-3, 0 }}); } });
-        keybd.proc("ScrollTop"           , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); } });
-        keybd.proc("ScrollEnd"           , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); } });
-        keybd.proc("ToggleMaximize"      , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); }}); // Refocus-related operations require execution outside of keyboard events.
-        keybd.proc("ToggleFullscreen"    , [&](hids& gear){ if (!gear.is_exclusive()) { scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); }});
-        keybd.proc("ToggleExclusiveKeybd", [&](hids& gear){ if (!gear.is_exclusive()) gear.set_exclusive(boss.This()); else gear.set_exclusive(); });
-        keybd.bind("PageUp"    , "ScrollPageUp"        );
-        keybd.bind("PageDown"  , "ScrollPageDown"      );
-        keybd.bind("UpArrow"   , "ScrollLineUp"        );
-        keybd.bind("DownArrow" , "ScrollLineDown"      );
-        keybd.bind("LeftArrow" , "ScrollCharLeft"      );
-        keybd.bind("RightArrow", "ScrollCharRight"     );
-        keybd.bind("Home"      , "DropAutoRepeat"      );
-        keybd.bind("Home"      , "ScrollTop"           );
-        keybd.bind("End"       , "DropAutoRepeat"      );
-        keybd.bind("End"       , "ScrollEnd"           );
-        keybd.bind("F11"       , "DropAutoRepeat"      );
-        keybd.bind("F11"       , "ToggleMaximize"      );
-        keybd.bind("F12"       , "DropAutoRepeat"      );
-        keybd.bind("F12"       , "ToggleFullscreen"    );
-        keybd.bind("Ctrl-Alt"  , "ToggleExclusiveKeybd");
-        keybd.bind("Alt-Ctrl"  , "ToggleExclusiveKeybd");
+        keybd.proc("ScrollPageUp"    , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
+        keybd.proc("ScrollPageDown"  , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
+        keybd.proc("ScrollLineUp"    , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 3 }}); });
+        keybd.proc("ScrollLineDown"  , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-3 }}); });
+        keybd.proc("ScrollCharLeft"  , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 3, 0 }}); });
+        keybd.proc("ScrollCharRight" , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-3, 0 }}); });
+        keybd.proc("ScrollTop"       , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
+        keybd.proc("ScrollEnd"       , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
+        //todo use sptr for gear when enqueueing (dangling reference)
+        keybd.proc("ToggleMaximize"  , [&](hids& gear){ scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); }); // Refocus-related operations require execution outside of keyboard eves.
+        keybd.proc("ToggleFullscreen", [&](hids& gear){ scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); });
+        auto binding = [&](auto mode)
+        {
+            keybd.template bind<tier::preview>( "Esc", "DropAutoRepeat"    , mode);
+            keybd.template bind<tier::release>( "Esc", "WindowClosePreview", mode);
+            keybd.template bind<tier::preview>("-Esc", "WindowClose"       , mode);
+            keybd.template bind<tier::release>( "Any", "CancelWindowClose" , mode);
+            keybd.bind("PageUp"    , "ScrollPageUp"    , mode);
+            keybd.bind("PageDown"  , "ScrollPageDown"  , mode);
+            keybd.bind("UpArrow"   , "ScrollLineUp"    , mode);
+            keybd.bind("DownArrow" , "ScrollLineDown"  , mode);
+            keybd.bind("LeftArrow" , "ScrollCharLeft"  , mode);
+            keybd.bind("RightArrow", "ScrollCharRight" , mode);
+            keybd.bind("Home"      , "DropAutoRepeat"  , mode);
+            keybd.bind("Home"      , "ScrollTop"       , mode);
+            keybd.bind("End"       , "DropAutoRepeat"  , mode);
+            keybd.bind("End"       , "ScrollEnd"       , mode);
+            keybd.bind("F11"       , "DropAutoRepeat"  , mode);
+            keybd.bind("F11"       , "ToggleMaximize"  , mode);
+            keybd.bind("F12"       , "DropAutoRepeat"  , mode);
+            keybd.bind("F12"       , "ToggleFullscreen", mode);
+        };
+        binding(0);
+        binding(1);
     };
 
     using builder_t = std::function<ui::sptr(eccc, xmls&)>;
@@ -680,7 +683,7 @@ namespace netxs::app::shared
             //todo implement 'fonts/font/file' - font file path/url
             gui_config.fontlist.push_back(f->take_value());
         }
-        auto keybinds = config.list("/config/gui/hotkeys/key");
+        auto keybinds = config.list("/config/hotkeys/gui/key");
         for (auto keybind_ptr : keybinds)
         {
             auto& keybind = *keybind_ptr;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -451,6 +451,7 @@ namespace netxs::events::userland
                         EVENT_XS( find    , ui::focus_test_t   ), // request: Check the focus.
                         EVENT_XS( next    , ui::focus_test_t   ), // request: Next hop count.
                         EVENT_XS( check   , bool               ), // anycast: Check any focus.
+                        EVENT_XS( hotkey  , si32               ), // release: Hotkeymode.
                         GROUP_XS( focus   , const id_t         ), // release: Has any keybd focus.
                         GROUP_XS( command , si32               ), // release: Hotkey command preview.
 

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1145,7 +1145,7 @@ namespace netxs::ui
                 //if (auto target = local ? applet : base::parent())
                 if (auto target = nexthop.lock())
                 {
-                    pro::focus::set(target, gear.id, pro::focus::solo::off, pro::focus::flip::off, true);
+                    pro::focus::set(target, gear.id, pro::focus::solo::off, true);
                 }
                 oneoff_focus.reset();
             };

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1921,8 +1921,8 @@ namespace netxs::ui
                         if (!gear.handled) _dispatch<tier::preview>(gear, input::key::kmap::any_key);
                     }
                 };
-                proc("Drop",          [](hids& gear){ gear.set_handled(); });
-                proc("DropIfRepeats", [](hids& gear){ if (gear.keystat == input::key::repeated) gear.set_handled(); });
+                proc("Drop",           [](hids& gear){ gear.set_handled(); });
+                proc("DropAutoRepeat", [](hids& gear){ if (gear.keystat == input::key::repeated) gear.set_handled(); });
             }
 
             template<si32 Tier = tier::release>

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -863,6 +863,7 @@ namespace netxs::directvt
                                         (fp2d, click))
         STRUCT_macro(focus_cut,         (id_t, gear_id))
         STRUCT_macro(focus_set,         (id_t, gear_id) (si32, solo))
+        STRUCT_macro(hotkey_mode,       (id_t, gear_id) (si32, mode))
         STRUCT_macro(fullscrn,          (id_t, gear_id))
         STRUCT_macro(maximize,          (id_t, gear_id))
         STRUCT_macro(header,            (id_t, window_id) (text, utf8))
@@ -1414,6 +1415,7 @@ namespace netxs::directvt
             X(jgc_list         ) /* List of jumbo GC.                             */\
             X(focus_cut        ) /* Request to focus cut.                         */\
             X(focus_set        ) /* Request to focus set.                         */\
+            X(hotkey_mode      ) /* Request hotkey mode to set.                   */\
             X(fullscrn         ) /* Notify/Request to fullscreen.                 */\
             X(maximize         ) /* Request to maximize window.                   */\
             X(header           ) /* Set window title.                             */\

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2856,7 +2856,7 @@ namespace netxs::gui
         }
         void keybd_send_state(si32 virtcod = {}, si32 keystat = {}, si32 scancod = {}, bool extflag = {}, view cluster = {}, bool synth = faux)
         {
-            if (auto hotkey_mode_changed = virtcod == 0 && (keymod ^ hotkey) & input::hids::HotkeyMode) // Send empty key to update hotkey mode state.
+            if (virtcod == 0 && (keymod ^ hotkey) & input::hids::HotkeyMode) // Send empty key to update hotkey mode state if it is changed.
             {
                 auto& gear = *stream.gears;
                 netxs::set_flag<input::hids::HotkeyMode>(keymod, hotkey);

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1807,21 +1807,24 @@ namespace netxs::gui
             void handle(s11n::xs::focus_set        lock)
             {
                 auto& item = lock.thing;
-                if (item.solo < 0) // Exclusive keyboard mode: -1: set, -2: reset.
+                if (owner.mfocus.focused()) // We are the focus tree endpoint. Signal back the focus set up.
                 {
-                    gears->set_exclusive(item.solo == -1 ? owner.This() : netxs::sptr<base>{}); // Exclusive mode will be reset automatically when focus is changed.
+                    auto seed = owner.bell::signal(tier::release, hids::events::keybd::focus::bus::on, { .id = item.gear_id, .solo = item.solo, .item = owner.This() });
                 }
-                else
+                else owner.window_post_command(ipc::take_focus);
+                if (item.solo == ui::pro::focus::solo::on) // Set solo focus.
                 {
-                    if (owner.mfocus.focused()) // We are the focus tree endpoint. Signal back the focus set up.
-                    {
-                        auto seed = owner.bell::signal(tier::release, hids::events::keybd::focus::bus::on, { .id = item.gear_id, .solo = item.solo, .item = owner.This() });
-                    }
-                    else owner.window_post_command(ipc::take_focus);
-                    if (item.solo == ui::pro::focus::solo::on) // Set solo focus.
-                    {
-                        owner.window_post_command(ipc::solo_focus);
-                    }
+                    owner.window_post_command(ipc::solo_focus);
+                }
+            }
+            void handle(s11n::xs::hotkey_mode      lock)
+            {
+                auto& k = lock.thing;
+                auto guard = owner.sync();
+                if (auto gear_ptr = owner.bell::getref<hids>(k.gear_id))
+                {
+                    owner.hotkey = k.mode;
+                    owner.window_post_command(ipc::sync_state);
                 }
             }
             void handle(s11n::xs::syskeybd         lock)
@@ -1964,6 +1967,7 @@ namespace netxs::gui
         regs  fields; // winbase: Text input field list.
         evnt  stream; // winbase: DirectVT event proxy.
         kmap  chords; // winbase: Pressed key table (key chord).
+        si32  hotkey; // winbase: Alternate hotkey mode.
 
         winbase(auth& indexer, std::list<text>& font_names, si32 cell_height, bool antialiasing, span blink_rate, twod grip_cell, std::list<std::pair<text, text>>& hotkeys)
             : base{ indexer },
@@ -1994,7 +1998,8 @@ namespace netxs::gui
               heldby{ 0x0 },
               whlacc{ 0.f },
               wdelta{ 24.f },
-              stream{ *this, *os::dtvt::client }
+              stream{ *this, *os::dtvt::client },
+              hotkey{ 0 }
         {
             wkeybd.proc("IncreaseCellHeight"    , [&](hids& gear){ gear.set_handled(); IncreaseCellHeight(1.f); });
             wkeybd.proc("DecreaseCellHeight"    , [&](hids& gear){ gear.set_handled(); IncreaseCellHeight(-1.f);});
@@ -2004,7 +2009,8 @@ namespace netxs::gui
             wkeybd.proc("RollFontsBackward"     , [&](hids& gear){ gear.set_handled(); RollFontList(feed::rev);  });
             wkeybd.proc("RollFontsForward"      , [&](hids& gear){ gear.set_handled(); RollFontList(feed::fwd);  });
             wkeybd.proc("_ResetWheelAccumulator", [&](hids& /*gear*/){ whlacc = {}; });
-            wkeybd.bind<tier::preview>("-Ctrl", "_ResetWheelAccumulator");
+            wkeybd.bind<tier::preview>("-Ctrl", "_ResetWheelAccumulator", 0);
+            wkeybd.bind<tier::preview>("-Ctrl", "_ResetWheelAccumulator", 1);
             for (auto& [chord, action] : hotkeys) wkeybd.bind<tier::preview>(chord, action);
         }
 
@@ -2845,12 +2851,36 @@ namespace netxs::gui
                 {
                     keybd_send_block(block); // Send multifocus events.
                 }
-                return gear.is_exclusive() || wkeybd.filter<tier::preview>(gear);
+                return wkeybd.filter<tier::preview>(gear);
             });
         }
         void keybd_send_state(si32 virtcod = {}, si32 keystat = {}, si32 scancod = {}, bool extflag = {}, view cluster = {}, bool synth = faux)
         {
-            auto state  = 0;
+            if (auto hotkey_mode_changed = virtcod == 0 && (keymod ^ hotkey) & input::hids::HotkeyMode) // Send empty key to update hotkey mode state.
+            {
+                auto& gear = *stream.gears;
+                netxs::set_flag<input::hids::HotkeyMode>(keymod, hotkey);
+                netxs::set_flag<input::hids::HotkeyMode>(gear.ctlstat, hotkey);
+                auto temp = syskeybd{}; //todo same code in system.hpp:4918
+                std::swap(temp.vkchord, gear.vkchord);
+                std::swap(temp.scchord, gear.scchord);
+                std::swap(temp.chchord, gear.chchord);
+                std::swap(temp.cluster, gear.cluster);
+                std::swap(temp.keystat, gear.keystat);
+                gear.virtcod = 0;
+                gear.scancod = 0;
+                gear.keycode = 0;
+                gear.payload = input::keybd::type::keypress;
+                stream_keybd(gear);
+                std::swap(temp.vkchord, gear.vkchord);
+                std::swap(temp.scchord, gear.scchord);
+                std::swap(temp.chchord, gear.chchord);
+                std::swap(temp.cluster, gear.cluster);
+                std::swap(temp.keystat, gear.keystat);
+                return;
+            }
+
+            auto state = hotkey;
             auto cs = 0;
             if (extflag) cs |= input::key::ExtendedKey;
             if (synth)
@@ -3067,7 +3097,7 @@ namespace netxs::gui
                         stream.m.ctlstat = keymod;
                         keybd.syncto(gear);
                         gear.gear_id = gear.bell::id; // Restore gear id.
-                        if (gear.is_exclusive() || wkeybd.filter<tier::preview>(gear))
+                        if (wkeybd.filter<tier::preview>(gear))
                         {
                             stream.keybd(gear);
                         }

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -813,7 +813,6 @@ namespace netxs::input
     {
         id_t   id{}; // foci: Gear id.
         si32 solo{}; // foci: Exclusive focus request.
-        bool flip{}; // foci: Toggle focus request.
         bool skip{}; // foci: Ignore focusable object, just activate it.
         sptr what{}; // foci: Replacement item.
         sptr item{}; // foci: Next focused item.

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1447,6 +1447,7 @@ namespace netxs::input
             NumLock  = 1 << 12, // ⇭ Num Lock
             CapsLock = 1 << 13, // ⇪ Caps Lock
             ScrlLock = 1 << 14, // ⇳ Scroll Lock (⤓)
+            HkeyMode = 1 << 28, // Alternate hotkey mode
             AltGr    = LAlt   | LCtrl,
             anyCtrl  = LCtrl  | RCtrl,
             anyAlt   = LAlt   | RAlt,
@@ -1732,7 +1733,7 @@ namespace netxs::input
             static constexpr auto mask = netxs::events::level_mask(hids::events::mouse::button::any.id);
             static constexpr auto base = mask & hids::events::mouse::button::any.id;
             alive = true;
-            hids::ctlstat = new_ctlstate;
+            keybd::ctlstat = new_ctlstate;
             mouse::coord = new_coord;
             mouse::click = new_click;
             mouse::whlfp = new_whlfp;
@@ -1743,7 +1744,7 @@ namespace netxs::input
             mouse::load_button_state(new_button_state);
         }
 
-        auto meta(si32 ctl_key = -1) { return hids::ctlstat & ctl_key; }
+        auto meta(si32 ctl_key = -1) { return keybd::ctlstat & ctl_key; }
 
         // hids: Stop handeling this event.
         void dismiss(bool set_nodbl = faux)
@@ -1776,7 +1777,7 @@ namespace netxs::input
             }
             #endif
             disabled = faux;
-            hids::ctlstat = m.ctlstat;
+            keybd::ctlstat = m.ctlstat;
             mouse::update(m, idmap);
         }
         void take(syskeybd& k)
@@ -1990,7 +1991,7 @@ namespace netxs::input
 
             if (keystat != input::key::released)
             {
-                auto s = hids::ctlstat;
+                auto s = keybd::ctlstat;
                 auto v = keybd::keycode & -2; // Generic keys only
                 auto c = keybd::cluster.empty() ? 0 : keybd::cluster.front();
 

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7716,36 +7716,36 @@ namespace netxs::ui
             publish_property(ui::term::events::search::status, [&](auto& v){ v = target->selection_button(); });
             selection_selmod(config.def_selmod);
 
-            chords.proc("TerminalFindPrev",                 [&](hids& gear){ gear.set_handled(); selection_search(gear, feed::rev); });
-            chords.proc("TerminalFindNext",                 [&](hids& gear){ gear.set_handled(); selection_search(gear, feed::fwd); });
-            chords.proc("TerminalViewportOnePageLeft",      [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = { 1, 0 }}); });
-            chords.proc("TerminalViewportOnePageRight",     [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = {-1, 0 }}); });
-            chords.proc("TerminalViewportOneCharLeft",      [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 1, 0 }}); });
-            chords.proc("TerminalViewportOneCharRight",     [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-1, 0 }}); });
-            chords.proc("TerminalViewportOneCharUp",        [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 1 }}); });
-            chords.proc("TerminalViewportOneCharDown",      [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-1 }}); });
-            chords.proc("TerminalViewportOnePageUp",        [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
-            chords.proc("TerminalViewportOnePageDown",      [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
-            chords.proc("TerminalViewportTop",              [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
-            chords.proc("TerminalViewportEnd",              [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
-            chords.proc("TerminalSelectionCancel",          [&](hids& gear){ if (!selection_active()) return; gear.set_handled(); exec_cmd(commands::ui::deselect); });
-            chords.proc("TerminalToggleCwdSync",            [&](hids& gear){ gear.set_handled(); base::riseup(tier::preview, ui::term::events::toggle::cwdsync, true); });
-            chords.proc("TerminalToggleWrapMode",           [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::togglewrp); });
-            chords.proc("TerminalQuit",                     [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::sighup);    });
-            chords.proc("TerminalRestart",                  [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::restart);   });
-            chords.proc("TerminalToggleFullscreen",         [&](hids& gear){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); }); // Refocus-related operations require execution outside of keyboard events.
-            chords.proc("TerminalToggleMaximize",           [&](hids& gear){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); });
-            chords.proc("TerminalUndo",                     [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::undo);      });
-            chords.proc("TerminalRedo",                     [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::redo);      });
-            chords.proc("TerminalClipboardPaste",           [&](hids& gear){ gear.set_handled(); paste(gear);                       });
-            chords.proc("TerminalClipboardWipe",            [&](hids& gear){ gear.set_handled(); gear.clear_clipboard();            });
-            chords.proc("TerminalSwitchCopyMode",           [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::togglesel); });
-            chords.proc("TerminalSelectionCopy",            [&](hids& gear){ gear.set_handled(); copy(gear);                        });
-            chords.proc("TerminalToggleSelectionMode",      [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::toggleselalt); });
-            chords.proc("TerminalSelectionOneShot",         [&](hids& gear){ gear.set_handled(); set_oneshot(mime::textonly);       });
-            chords.proc("TerminalViewportCopy",             [&](hids& gear){ gear.set_handled(); prnscrn(gear);                     });
-            chords.proc("TerminalToggleStdioLog",           [&](hids& gear){ gear.set_handled(); set_log(!io_log); ondata<true>();  });
-            chords.proc("ToggleExclusiveKeybd",             [&](hids& gear){ if (!gear.is_exclusive()) gear.set_exclusive(This()); else gear.set_exclusive(); });
+            chords.proc("TerminalFindPrev",             [&](hids& gear){ gear.set_handled(); selection_search(gear, feed::rev); });
+            chords.proc("TerminalFindNext",             [&](hids& gear){ gear.set_handled(); selection_search(gear, feed::fwd); });
+            chords.proc("TerminalViewportOnePageLeft",  [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = { 1, 0 }}); });
+            chords.proc("TerminalViewportOnePageRight", [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = {-1, 0 }}); });
+            chords.proc("TerminalViewportOneCharLeft",  [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 1, 0 }}); });
+            chords.proc("TerminalViewportOneCharRight", [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-1, 0 }}); });
+            chords.proc("TerminalViewportOneCharUp",    [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 1 }}); });
+            chords.proc("TerminalViewportOneCharDown",  [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-1 }}); });
+            chords.proc("TerminalViewportOnePageUp",    [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
+            chords.proc("TerminalViewportOnePageDown",  [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
+            chords.proc("TerminalViewportTop",          [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
+            chords.proc("TerminalViewportEnd",          [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
+            chords.proc("TerminalSelectionCancel",      [&](hids& gear){ if (!selection_active()) return; gear.set_handled(); exec_cmd(commands::ui::deselect); });
+            chords.proc("TerminalToggleCwdSync",        [&](hids& gear){ gear.set_handled(); base::riseup(tier::preview, ui::term::events::toggle::cwdsync, true); });
+            chords.proc("TerminalToggleWrapMode",       [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::togglewrp); });
+            chords.proc("TerminalQuit",                 [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::sighup);    });
+            chords.proc("TerminalRestart",              [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::restart);   });
+            //todo use wptr for gear when enqueueing
+            chords.proc("TerminalToggleFullscreen",     [&](hids& gear){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); }); // Refocus-related operations require execution outside of keyboard events.
+            chords.proc("TerminalToggleMaximize",       [&](hids& gear){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); });
+            chords.proc("TerminalUndo",                 [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::undo);      });
+            chords.proc("TerminalRedo",                 [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::redo);      });
+            chords.proc("TerminalClipboardPaste",       [&](hids& gear){ gear.set_handled(); paste(gear);                       });
+            chords.proc("TerminalClipboardWipe",        [&](hids& gear){ gear.set_handled(); gear.clear_clipboard();            });
+            chords.proc("TerminalSwitchCopyMode",       [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::togglesel); });
+            chords.proc("TerminalSelectionCopy",        [&](hids& gear){ gear.set_handled(); copy(gear);                        });
+            chords.proc("TerminalToggleSelectionMode",  [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::toggleselalt); });
+            chords.proc("TerminalSelectionOneShot",     [&](hids& gear){ gear.set_handled(); set_oneshot(mime::textonly);       });
+            chords.proc("TerminalViewportCopy",         [&](hids& gear){ gear.set_handled(); prnscrn(gear);                     });
+            chords.proc("TerminalToggleStdioLog",       [&](hids& gear){ gear.set_handled(); set_log(!io_log); ondata<true>();  });
             chords.load<tier::release>(xml_config, "/config/hotkeys/term/key");
 
             LISTEN(tier::general, e2::timer::tick, timestamp) // Update before world rendering.
@@ -8038,14 +8038,19 @@ namespace netxs::ui
                     if (auto gear_ptr = owner.bell::getref<hids>(k.gear_id))
                     if (auto parent_ptr = owner.base::parent())
                     {
-                        if (k.solo < 0) // Exclusive keyboard mode: -1: set, -2: reset.
-                        {
-                            gear_ptr->set_exclusive(k.solo == -1 ? owner.This() : sptr{}); // Exclusive mode will be reset automatically when focus is changed.
-                        }
-                        else
-                        {
-                            auto seed = parent_ptr->base::riseup(tier::preview, hids::events::keybd::focus::set, { .id = k.gear_id, .solo = k.solo, .item = owner.This() });
-                        }
+                        auto seed = parent_ptr->base::riseup(tier::preview, hids::events::keybd::focus::set, { .id = k.gear_id, .solo = k.solo, .item = owner.This() });
+                    }
+                }
+            }
+            void handle(s11n::xs::hotkey_mode         lock)
+            {
+                auto& k = lock.thing;
+                if (owner.active)
+                {
+                    auto guard = owner.sync();
+                    if (auto gear_ptr = owner.bell::getref<hids>(k.gear_id))
+                    {
+                        gear_ptr->set_hotkey_mode(k.mode);
                     }
                 }
             }
@@ -8060,7 +8065,7 @@ namespace netxs::ui
                     {
                         auto& gear = *gear_ptr;
                         //todo should we use temp gear object here?
-                        gear.alive   = true;
+                        gear.alive = true;
                         k.syncto(gear);
                         do
                         {
@@ -8226,6 +8231,7 @@ namespace netxs::ui
                     owner.base::riseup(tier::preview, e2::form::prop::cwd, path);
                 });
             }
+
             evnt(dtvt& owner)
                 : s11n{ *this, owner.id },
                   input_fields_handler{ owner },

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -338,7 +338,7 @@ namespace netxs::ui
                     auto gear_test = owner.base::riseup(tier::request, e2::form::state::keybd::find, { gear.id, 0 });
                     if (gear_test.second == 0)
                     {
-                        pro::focus::set(owner.This(), gear.id, pro::focus::solo::off, pro::focus::flip::off);
+                        pro::focus::set(owner.This(), gear.id, pro::focus::solo::off);
                     }
                     owner.base::riseup(tier::preview, e2::form::layout::expose);
                 }
@@ -348,8 +348,8 @@ namespace netxs::ui
                     auto gear_test = owner.base::riseup(tier::request, e2::form::state::keybd::find, { gear.id, 0 });
                     if (gear_test.second == 0)
                     {
-                        pro::focus::set(owner.This(), gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off
-                                                                                        : pro::focus::solo::on, pro::focus::flip::on);
+                        if (pro::focus::test(owner, gear)) pro::focus::off(owner.This(), gear.id);
+                        else                               pro::focus::set(owner.This(), gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off : pro::focus::solo::on);
                     }
                     owner.base::riseup(tier::preview, e2::form::layout::expose);
                 }
@@ -7134,7 +7134,7 @@ namespace netxs::ui
             auto data = get_clipboard_text(gear);
             if (data.size())
             {
-                pro::focus::set(this->This(), gear.id, pro::focus::solo::off, pro::focus::flip::off);
+                pro::focus::set(this->This(), gear.id, pro::focus::solo::off);
                 _paste(data);
                 return true;
             }
@@ -7142,9 +7142,8 @@ namespace netxs::ui
         }
         auto _copy(hids& gear, text const& data)
         {
-            auto form = selmod == mime::disabled ? mime::textonly
-                                                 : selmod;
-            pro::focus::set(this->This(), gear.id, pro::focus::solo::off, pro::focus::flip::off);
+            auto form = selmod == mime::disabled ? mime::textonly : selmod;
+            pro::focus::set(this->This(), gear.id, pro::focus::solo::off);
             gear.set_clipboard(target->panel, data, form);
         }
         auto copy(hids& gear)
@@ -7187,7 +7186,7 @@ namespace netxs::ui
             auto gear_test = base::riseup(tier::request, e2::form::state::keybd::find, { gear.id, 0 });
             if (!gear_test.second) // Set exclusive focus on right click.
             {
-                pro::focus::set(This(), gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                pro::focus::set(This(), gear.id, pro::focus::solo::on);
             }
             if ((selection_active() && copy(gear))
              || (selection_passed() && paste(gear)))
@@ -7209,7 +7208,7 @@ namespace netxs::ui
             }
             if (utf8.size())
             {
-                pro::focus::set(this->This(), gear.id, pro::focus::solo::off, pro::focus::flip::off);
+                pro::focus::set(this->This(), gear.id, pro::focus::solo::off);
                 follow[axis::X] = true;
                 if (bpmode)
                 {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -175,7 +175,7 @@ namespace netxs::app::vtm
 
                 window_ptr->bell::signal(tier::release, e2::form::upon::vtree::attached, boss.base::This());
                 window_ptr->bell::signal(tier::anycast, vtm::events::attached, boss.base::This());
-                pro::focus::set(window_ptr, gear_id_list, pro::focus::solo::on, pro::focus::flip::off, true); // Refocus.
+                pro::focus::set(window_ptr, gear_id_list, pro::focus::solo::on, true); // Refocus.
             }
             void unbind(type restore = type::full)
             {
@@ -213,7 +213,7 @@ namespace netxs::app::vtm
                     }
                 }
                 what.applet.reset();
-                pro::focus::set(window_ptr, gear_id_list, pro::focus::solo::on, pro::focus::flip::off, true); // Refocus.
+                pro::focus::set(window_ptr, gear_id_list, pro::focus::solo::on, true); // Refocus.
             }
         };
 
@@ -337,7 +337,7 @@ namespace netxs::app::vtm
                     auto coord = gear.coord + area.coor;
                     if (!area.hittest(coord))
                     {
-                        pro::focus::set(boss.This(), gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                        pro::focus::set(boss.This(), gear.id, pro::focus::solo::on);
                         appear(coord);
                     }
                     gear.dismiss();
@@ -752,7 +752,7 @@ namespace netxs::app::vtm
                     if (true /*...*/) //todo lookup taskbar kb shortcuts
                     {
                         //...
-                        //pro::focus::set(applet, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                        //pro::focus::set(applet, gear.id, pro::focus::solo::on);
                         
                     }
                     else
@@ -891,7 +891,7 @@ namespace netxs::app::vtm
                 auto& window = *window_ptr;
                 window.bell::signal(tier::release, e2::form::layout::selected, gear);
                 if (!maximized) jump_to(window);
-                pro::focus::set(window_ptr, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                pro::focus::set(window_ptr, gear.id, pro::focus::solo::on);
             }
             //gear.dismiss();
             this->bell::expire(tier::preview); //todo temp
@@ -1296,8 +1296,7 @@ namespace netxs::app::vtm
                         if (boss.hidden) // Restore if it is hidden.
                         {
                             boss.hidden = faux;
-                            pro::focus::set(This, gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off
-                                                                                    : pro::focus::solo::on, pro::focus::flip::off, true);
+                            pro::focus::set(This, gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off : pro::focus::solo::on, true);
                         }
                         else // Hide if visible and refocus.
                         {
@@ -1327,7 +1326,7 @@ namespace netxs::app::vtm
                                     while (window != This && ((gearid && gearid != gear.owner.id) || (hidden == true || !viewport.hittest(window->center()))));
                                     if (window != This)
                                     {
-                                        pro::focus::set(window, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                                        pro::focus::set(window, gear.id, pro::focus::solo::on);
                                         This.reset();
                                     }
                                 }
@@ -1366,11 +1365,11 @@ namespace netxs::app::vtm
                     };
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear)
                     {
-                        pro::focus::set(boss.This(), gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                        pro::focus::set(boss.This(), gear.id, pro::focus::solo::on);
                     };
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::middle, gear)
                     {
-                        pro::focus::set(boss.This(), gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                        pro::focus::set(boss.This(), gear.id, pro::focus::solo::on);
                     };
                     boss.LISTEN(tier::release, e2::form::proceed::quit::any, fast)
                     {
@@ -1413,7 +1412,7 @@ namespace netxs::app::vtm
                         what.applet = window_ptr;
                         boss.bell::enqueue(boss.This(), [&](auto& /*boss*/)
                         {
-                            pro::focus::set(boss.This(), gear.id, pro::focus::solo::on, pro::focus::flip::off, true); // Refocus to demultifocus.
+                            pro::focus::set(boss.This(), gear.id, pro::focus::solo::on, true); // Refocus to demultifocus.
                         });
                         window_ptr->base::riseup(tier::request, e2::form::prop::ui::header, what.header);
                         window_ptr->base::riseup(tier::request, e2::form::prop::ui::footer, what.footer);
@@ -1466,7 +1465,7 @@ namespace netxs::app::vtm
                         else
                         {
                             boss.base::riseup(tier::preview, e2::form::layout::expose); // Multiple windows coubld be maximized at the same time.
-                            pro::focus::set(window_ptr, gear.id, pro::focus::solo::on, pro::focus::flip::off, true);
+                            pro::focus::set(window_ptr, gear.id, pro::focus::solo::on, true);
                             auto owner_id = gear.owner.id;
                             saved_area = boss.base::area();
                             saved_area.coor -= viewport.coor;
@@ -1930,7 +1929,7 @@ namespace netxs::app::vtm
                     what.square.size = winsize ? winsize : viewport.size * 3 / 4;
                     if (auto window = create(what))
                     {
-                        pro::focus::set(window, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                        pro::focus::set(window, gear.id, pro::focus::solo::on);
                         window->bell::signal(tier::anycast, e2::form::upon::created, gear); // Tile should change the menu item.
                              if (appbase.winform == shared::win::state::maximized) window->bell::signal(tier::preview, e2::form::size::enlarge::maximize, gear);
                         else if (appbase.winform == shared::win::state::minimized) window->bell::signal(tier::preview, e2::form::size::minimize, gear);
@@ -1944,7 +1943,7 @@ namespace netxs::app::vtm
                     what.square.size = winsize;
                     if (auto window = create(what))
                     {
-                        pro::focus::set(window, id_t{}, pro::focus::solo::on, pro::focus::flip::off);
+                        pro::focus::set(window, id_t{}, pro::focus::solo::on);
                         yield = utf::concat(window->id);
                     }
                 }
@@ -1970,7 +1969,7 @@ namespace netxs::app::vtm
                         //{
                         //    log(prompt::hall, "Objects count: ", items.size());
                         //};
-                        pro::focus::set(window, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                        pro::focus::set(window, gear.id, pro::focus::solo::on);
                         window->bell::signal(tier::anycast, e2::form::upon::created, gear); // Tile should change the menu item.
                         auto& cfg = dbase.menu[what.menuid];
                              if (cfg.winform == shared::win::state::maximized) window->bell::signal(tier::preview, e2::form::size::enlarge::maximize, gear);
@@ -2141,8 +2140,7 @@ namespace netxs::app::vtm
             auto count = 0;
             for (auto& window_ptr : foci)
             {
-                pro::focus::set(window_ptr, id_t{}, count++ ? pro::focus::solo::off // Reset all foci on the first item.
-                                                            : pro::focus::solo::on, pro::focus::flip::off);
+                pro::focus::set(window_ptr, id_t{}, count++ ? pro::focus::solo::off : pro::focus::solo::on); // Reset all foci on the first item.
             }
             if constexpr (debugmode)
             {
@@ -2228,7 +2226,7 @@ namespace netxs::app::vtm
                         {
                             auto owner_id = last_ptr->bell::signal(tier::request, e2::form::state::maximized);
                             if (owner_id && owner_id != gear_ptr->owner.id) continue;
-                            pro::focus::set(last_ptr, gear_id, pro::focus::solo::off, pro::focus::flip::off);
+                            pro::focus::set(last_ptr, gear_id, pro::focus::solo::off);
                         }
                     }
                 }

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -380,15 +380,15 @@ R"==(
         <gui key*>  <!-- Native GUI window layer key bindings. -->
             <key="CapsLock+UpArrow"      action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
             <key="CapsLock+DownArrow"    action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->
-            <key="Ctrl+0"                action=DropIfRepeats/>           <!-- Don't repeat the Reset text cell height. -->
+            <key="Ctrl+0"                action=DropAutoRepeat/>          <!-- Don't repeat the Reset text cell height. -->
             <key="Ctrl+0"                action=ResetCellHeight/>         <!-- Reset text cell height. -->
-            <key="Alt+Enter"             action=DropIfRepeats/>           <!-- Don't repeat the Toggle fullscreen mode. -->
+            <key="Alt+Enter"             action=DropAutoRepeat/>          <!-- Don't repeat the Toggle fullscreen mode. -->
             <key="Alt+Enter"             action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
-            <key="Ctrl+CapsLock"         action=DropIfRepeats/>           <!-- Don't repeat the Toggle text antialiasing mode. -->
+            <key="Ctrl+CapsLock"         action=DropAutoRepeat/>          <!-- Don't repeat the Toggle text antialiasing mode. -->
             <key="Ctrl+CapsLock"         action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
-            <key="Ctrl+Shift+F11"        action=DropIfRepeats/>           <!-- Don't repeat the Roll font list backward. -->
+            <key="Ctrl+Shift+F11"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list backward. -->
             <key="Ctrl+Shift+F11"        action=RollFontsBackward/>       <!-- Roll font list backward. -->
-            <key="Ctrl+Shift+F12"        action=DropIfRepeats/>           <!-- Don't repeat the Roll font list forward. -->
+            <key="Ctrl+Shift+F12"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list forward. -->
             <key="Ctrl+Shift+F12"        action=RollFontsForward/>        <!-- Roll font list forward. -->
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. -->
@@ -413,9 +413,9 @@ R"==(
             <key="Shift+Ctrl+DownArrow"  action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
             <key="Shift+Ctrl+LeftArrow"  action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
             <key="Shift+Ctrl+RightArrow" action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
-            <key="Shift+Ctrl+Home"       action=DropIfRepeats/>                     <!-- Don't repeat the Scroll to the scrollback top. -->
+            <key="Shift+Ctrl+Home"       action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback top. -->
             <key="Shift+Ctrl+Home"       action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+End"        action=DropIfRepeats/>                     <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
+            <key="Shift+Ctrl+End"        action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
             <key="Shift+Ctrl+End"        action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
             <key=""                      action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
             <key=""                      action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -376,7 +376,7 @@ R"==(
             <slim=menu/slim/>          <!-- Link to global <config/set/menu/slim>. -->
         </menu>
     </defapp>
-    <hotkeys>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.  -->
+    <hotkeys>  <!-- The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop. -->
         <gui key*>  <!-- Native GUI window layer key bindings. key* here is to clear all previous bindings and start a new list. -->
             <key="CapsLock+UpArrow"      action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
             <key="CapsLock+DownArrow"    action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -377,7 +377,7 @@ R"==(
         </menu>
     </defapp>
     <hotkeys>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.  -->
-        <gui key*>  <!-- Native GUI window layer key bindings. -->
+        <gui key*>  <!-- Native GUI window layer key bindings. key* here is to clear all previous bindings and start a new list. -->
             <key="CapsLock+UpArrow"      action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
             <key="CapsLock+DownArrow"    action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->
             <key="Ctrl+0"                action=DropAutoRepeat/>          <!-- Don't repeat the Reset text cell height. -->
@@ -391,9 +391,13 @@ R"==(
             <key="Ctrl+Shift+F12"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list forward. -->
             <key="Ctrl+Shift+F12"        action=RollFontsForward/>        <!-- Roll font list forward. -->
         </gui>
-        <tui key*>  <!-- TUI matrix layer key bindings. -->
+        <tui key*>  <!-- TUI matrix layer key bindings. The mode=0 is implicitly used by default. -->
             <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (Reverse release order). -->
+            <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (reversed release order). -->
+            <key="Ctrl-Alt"              action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=1 by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl"              action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=1 by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Ctrl-Alt" mode=1       action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=0 (default) by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl" mode=1       action=ToggleHotkeyMode/>    <!-- Toggle hotkey mode to mode=0 (default) by pressing and releasing Alt-Ctrl (reversed releasing). -->
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"           action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
@@ -407,6 +411,8 @@ R"==(
             <key="Alt+LeftArrow"         action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"     action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
             <key="Shift+Ctrl+PageDown"   action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
+            <key="Ctrl+PageUp"   mode=1  action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
+            <key="Ctrl+PageDown" mode=1  action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
             <key="Shift+Alt+LeftArrow"   action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
             <key="Shift+Alt+RightArrow"  action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
             <key="Shift+Ctrl+UpArrow"    action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
@@ -434,8 +440,6 @@ R"==(
             <key=""                      action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
             <key="Esc"                   action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
             <key=""                      action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. -->
-            <key="Ctrl-Alt"              action=ToggleExclusiveKeybd/>              <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt. In exclusive mode, all keyboard events are ignored by higher levels. -->
-            <key="Alt-Ctrl"              action=ToggleExclusiveKeybd/>              <!-- Toggle exclusive keyboard mode by pressing and releasing Alt-Ctrl. -->
         </term>
     </hotkeys>
 </config>)=="


### PR DESCRIPTION
### Changes

- Change 'ToggleExclusiveKeybd' to 'ToggleHotkeyMode'. Now you can use two independent hotkey schemes (mode=0 or 1).
  ```xml
  <config>
    <hotkeys>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.  -->
      <tui key*>  <!-- TUI matrix layer key bindings. The mode=0 is implicitly used by default. -->
        <key="Ctrl-Alt"              action=ToggleHotkeyMode/> <!-- mode=0 binding for Toggle hotkey mode to mode=1 by pressing and releasing Ctrl-Alt. -->
        <key="Alt-Ctrl"              action=ToggleHotkeyMode/> <!-- mode=0 binding for Toggle hotkey mode to mode=1 by pressing and releasing Alt-Ctrl (reversed releasing). -->
        <key="Ctrl-Alt" mode=1       action=ToggleHotkeyMode/> <!-- mode=1 binding for Toggle hotkey mode to mode=0 (default) by pressing and releasing Ctrl-Alt. -->
        <key="Alt-Ctrl" mode=1       action=ToggleHotkeyMode/> <!-- mode=1 binding for Toggle hotkey mode to mode=0 (default) by pressing and releasing Alt-Ctrl (reversed releasing). -->
      </tui>
      <term key*>  <!-- key* here is to clear all previous bindings and start a new list. -->
        <key="Shift+Ctrl+PageUp"     action=TerminalViewportOnePageUp/>   <!-- mode=0 binding for Scroll one page up. -->
        <key="Shift+Ctrl+PageDown"   action=TerminalViewportOnePageDown/> <!-- mode=0 binding for Scroll one page down. -->
        <key="Ctrl+PageUp"   mode=1  action=TerminalViewportOnePageUp/>   <!-- mode=1 binding for Scroll one page up. -->
        <key="Ctrl+PageDown" mode=1  action=TerminalViewportOnePageDown/> <!-- mode=1 binding for Scroll one page down. -->
      </term>
    </hotkeys>
  </config>
  ```
- Rename DropIfRepeats to DropAutoRepeat.