### PR TITLE
Allow keybinding to multiple actions

### DIFF
--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1419,16 +1419,19 @@ namespace netxs::ansi
         {
             auto s = [&](auto const& traits, qiew utf8)
             {
+                client->defer = faux;
                 intro.execute(traits.control, utf8, client); // Make one iteration using firstcmd and return.
                 return utf8;
             };
             auto y = [&](auto const& cluster)
             {
                 client->post(cluster);
+                client->defer = true;
             };
             auto a = [&](view plain)
             {
                 client->ascii(plain);
+                client->defer = true;
             };
             utf::decode(s, y, a, utf8, client->decsg);
             client->flush();
@@ -1694,6 +1697,7 @@ namespace netxs::ansi
         deco state{}; // parser: Parser style last state.
         mark brush{}; // parser: Parser brush.
         si32 decsg{}; // parser: DEC Special Graphics Mode.
+        bool defer{}; // parser: The last character was a cluster that could continue to grow.
 
     private:
         core::body proto_cells{}; // parser: Proto lyric.
@@ -1741,6 +1745,7 @@ namespace netxs::ansi
             }
             proto_count = 0;
             proto_cells.clear();
+            defer = faux;
         }
         auto empty() const
         {

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -662,7 +662,7 @@ namespace netxs::app::shared
         twod gridsize{};
         si32 cellsize{};
         std::list<text> fontlist;
-        std::list<std::tuple<text, text, si32>> hotkeys;
+        std::list<std::tuple<text, std::vector<text>, si32>> hotkeys;
     };
 
     auto get_gui_config(xmls& config)
@@ -685,13 +685,16 @@ namespace netxs::app::shared
         for (auto keybind_ptr : keybinds)
         {
             auto& keybind = *keybind_ptr;
-            if (!keybind.fake)
+            auto chord = keybind.take_value();
+            auto scheme = keybind.take("scheme", 0); //todo use text instead of si32 as a scheme identifier
+            auto action = keybind.take("action", ""s);
+            auto action_list = std::vector<text>{};
+            auto action_ptr_list = keybind.list("action");
+            for (auto action_ptr : action_ptr_list)
             {
-                auto chord = keybind.take_value();
-                auto action = keybind.take("action", ""s);
-                auto scheme = keybind.take("scheme", 0);
-                gui_config.hotkeys.push_back({ chord, action, scheme });
+                action_list.push_back(action_ptr->take_value());
             }
+            gui_config.hotkeys.push_back({ chord, action_list, scheme });
         }
         return gui_config;
     }

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.47";
+    static const auto version = "v0.9.99.48";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -163,7 +163,6 @@ namespace netxs::app::shared
             keybd.bind("F12"       , "ToggleFullscreen", mode);
         };
         binding(0);
-        binding(1);
     };
 
     using builder_t = std::function<ui::sptr(eccc, xmls&)>;

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1970,7 +1970,7 @@ namespace netxs::gui
         kmap  chords; // winbase: Pressed key table (key chord).
         si32  hotkey; // winbase: Alternate hotkey scheme.
 
-        winbase(auth& indexer, std::list<text>& font_names, si32 cell_height, bool antialiasing, span blink_rate, twod grip_cell, std::list<std::tuple<text, text, si32>>& hotkeys)
+        winbase(auth& indexer, std::list<text>& font_names, si32 cell_height, bool antialiasing, span blink_rate, twod grip_cell, std::list<std::tuple<text, std::vector<text>, si32>>& hotkeys)
             : base{ indexer },
               titles{ *this, "", "", faux },
               wfocus{ *this, ui::pro::focus::mode::relay },
@@ -2012,7 +2012,7 @@ namespace netxs::gui
             wkeybd.proc("_ResetWheelAccumulator", [&](hids& /*gear*/){ whlacc = {}; });
             wkeybd.bind<tier::preview>("-Ctrl", "_ResetWheelAccumulator", 0);
             wkeybd.bind<tier::preview>("-Ctrl", "_ResetWheelAccumulator", 1);
-            for (auto& [chord, action, scheme] : hotkeys) wkeybd.bind<tier::preview>(chord, action, scheme);
+            for (auto& [chord, action_list, scheme] : hotkeys) wkeybd.bind<tier::preview>(chord, action_list, scheme);
         }
 
         virtual bool layer_create(layer& s, winbase* host_ptr = nullptr, twod win_coord = {}, twod grid_size = {}, dent border_dent = {}, twod cell_size = {}) = 0;

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1403,7 +1403,50 @@ namespace netxs::ui
                                                     len.y * len.x);
             while (dst != end) *dst++ = blank;
         }
-
+        //todo make it 2D
+        // rich: Pop glyph matrix.
+        auto pop_cluster()
+        {
+            auto cluster = netxs::text{};
+            auto size = (si32)core::canvas.size();
+            if (size)
+            {
+                auto& back = canvas.back();
+                auto [w, h, x, y] = back.whxy();
+                if constexpr (debugmode) log("\tw=%%, h=%%, x=%%, y=%%", w, h, x, y);
+                if (w && x == w && size >= w)
+                {
+                    auto current_x = w - 1;
+                    auto head = canvas.rbegin() + 1;
+                    auto tail = head + current_x;
+                    while (head != tail)
+                    {
+                        auto& c = *head;
+                        if (!c.same_txt(back) || !c.like(back))
+                        {
+                            break;
+                        }
+                        auto [cw, ch, cx, cy] = c.whxy();
+                        if constexpr (debugmode) log("\t\tcurrent_x=%%, cw=%%, ch=%%, cx=%%, cy=%%", current_x, cw, ch, cx, cy);
+                        if (cw != w || ch != h || cy != y || cx != current_x)
+                        {
+                            break;
+                        }
+                        head++;
+                        current_x--;
+                    }
+                    if (head == tail)
+                    {
+                        cluster = back.txt();
+                        if (cluster.size())
+                        {
+                            core::crop(size - w);
+                        }
+                    }
+                }
+            }
+            return cluster;
+        }
         //todo unify
         auto& at(si32 p) const
         {
@@ -1439,7 +1482,27 @@ namespace netxs::ui
         para(id_t id, auto utf8)      { brush.link(id); ansi::parse(utf8, this);               }
         para(auto utf8)               {                 ansi::parse(utf8, this);               }
         auto& operator  = (auto utf8) { wipe(brush);    ansi::parse(utf8, this); return *this; }
-        auto& operator += (auto utf8) {                 ansi::parse(utf8, this); return *this; }
+        auto& operator += (auto utf8)
+        {
+            if (parser::defer && caret && caret == length())
+            {
+                if constexpr (debugmode) log("try to reassemble cluster=", lyric->back().txt());
+                auto last_cluster = lyric->pop_cluster();
+                if (caret != length())
+                {
+                    caret = length();
+                    auto reassembled_cluster = text{};
+                    reassembled_cluster.reserve(last_cluster.length() + utf8.length());
+                    reassembled_cluster += last_cluster;
+                    reassembled_cluster += utf8;
+                    ansi::parse(reassembled_cluster, this);
+                    if constexpr (debugmode) log("\treassembled_cluster=", utf::buffer_to_hex(reassembled_cluster, true));
+                    return *this;
+                }
+            }
+            ansi::parse(utf8, this);
+            return *this;
+        }
 
         operator writ const& () const { return locus; }
 
@@ -1460,7 +1523,7 @@ namespace netxs::ui
         void   ease()        { lyric->each([&](auto& c){ c.clr({});  });  } // para: Reset color for all text.
         void   link(id_t id) { lyric->each([&](auto& c){ c.link(id); });  } // para: Set object ID for each cell.
         template<bool ResetStyle = faux>
-        void   wipe(cell c = cell{}) // para: Clear the text and locus, and reset SGR attributes.
+        void wipe(cell c = cell{}) // para: Clear the text and locus, and reset SGR attributes.
         {
             parser::reset<ResetStyle>(c);
             caret = 0;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -389,16 +389,26 @@ R"==(
         <gui key*>  <!-- Native GUI window layer key bindings. key* here is to clear all previous bindings and start a new list. -->
             <key="CapsLock+UpArrow"      action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
             <key="CapsLock+DownArrow"    action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->
-            <key="Ctrl+0"                action=DropAutoRepeat/>          <!-- Don't repeat the Reset text cell height. -->
-            <key="Ctrl+0"                action=ResetCellHeight/>         <!-- Reset text cell height. -->
-            <key="Alt+Enter"             action=DropAutoRepeat/>          <!-- Don't repeat the Toggle fullscreen mode. -->
-            <key="Alt+Enter"             action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
-            <key="Ctrl+CapsLock"         action=DropAutoRepeat/>          <!-- Don't repeat the Toggle text antialiasing mode. -->
-            <key="Ctrl+CapsLock"         action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
-            <key="Ctrl+Shift+F11"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list backward. -->
-            <key="Ctrl+Shift+F11"        action=RollFontsBackward/>       <!-- Roll font list backward. -->
-            <key="Ctrl+Shift+F12"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list forward. -->
-            <key="Ctrl+Shift+F12"        action=RollFontsForward/>        <!-- Roll font list forward. -->
+            <key="Ctrl+0">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Reset text cell height. -->
+                <action=ResetCellHeight/>         <!-- Reset text cell height. -->
+            </key>
+            <key="Alt+Enter">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Toggle fullscreen mode. -->
+                <action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
+            </key>
+            <key="Ctrl+CapsLock">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Toggle text antialiasing mode. -->
+                <action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
+            </key>
+            <key="Ctrl+Shift+F11">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Roll font list backward. -->
+                <action=RollFontsBackward/>       <!-- Roll font list backward. -->
+            </key>
+            <key="Ctrl+Shift+F12">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Roll font list forward. -->
+                <action=RollFontsForward/>        <!-- Roll font list forward. -->
+            </key>
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
             <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
@@ -428,10 +438,14 @@ R"==(
             <key="Shift+Ctrl+DownArrow"   action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
             <key="Shift+Ctrl+LeftArrow"   action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
             <key="Shift+Ctrl+RightArrow"  action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
-            <key="Shift+Ctrl+Home"        action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+Home"        action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+End"         action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
-            <key="Shift+Ctrl+End"         action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
+            <key="Shift+Ctrl+Home">
+                <action=DropAutoRepeat/>       <!-- Don't autorepeat the Scroll to the scrollback top. -->
+                <action=TerminalViewportTop/>  <!-- Scroll to the scrollback top. -->
+            </key>
+            <key="Shift+Ctrl+End">
+                <action=DropAutoRepeat/>       <!-- Don't autorepeat the Scroll to the scrollback bottom (reset viewport position). -->
+                <action=TerminalViewportEnd/>  <!-- Scroll to the scrollback bottom (reset viewport position). -->
+            </key>
             <key=""                       action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
             <key=""                       action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
             <key=""                       action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->


### PR DESCRIPTION

### Changes

- Allow keybinding to multiple actions.
  ```xml
  <config>
    <hotkeys>  <!-- The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop. -->
      <gui key*>  <!-- Native GUI window layer key bindings. key* here is to clear all previous bindings and start a new list. -->
        <key="CapsLock+UpArrow"      action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
        <key="CapsLock+DownArrow"    action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->
        <key="Ctrl+0">
          <action=DropAutoRepeat/>          <!-- Don't autorepeat the Reset text cell height. -->
          <action=ResetCellHeight/>         <!-- Reset text cell height. -->
        </key>
        <key="Alt+Enter">
          <action=DropAutoRepeat/>          <!-- Don't autorepeat the Toggle fullscreen mode. -->
          <action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
        </key>
      </gui>
    </hotkeys>
  </config>
  ```
- Support for lazy grapheme clustering.
  ![image](https://github.com/user-attachments/assets/7c0a818e-f92b-4c37-9195-70af1f72ac54)
