### PR TITLE
Allow hotkey scheme to be an arbitrary string

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -160,7 +160,7 @@ Value                        | Unique for hotkeys | Default Hotkey              
 -----------------------------|--------------------|------------------------------|------------
 Drop                         | x                  |                              | Drop all events for the specified key combination. No further processing.
 DropAutoRepeat               | x                  |                              | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
-ToggleHotkeyScheme           | x                  | `Ctrl-Alt`, `Alt-Ctrl`       | Toggle hotkey scheme between `0` (default) `1`.
+ToggleHotkeyScheme           | x                  | `Ctrl-Alt`, `Alt-Ctrl`       | Toggle hotkey scheme between default and `"1"`.
 TerminalFindNext             |                    | `Alt+RightArrow`             | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
 TerminalFindPrev             |                    | `Alt+LeftArrow`              | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
 TerminalViewportOnePageUp    | x                  | `Shift+Ctrl+PageUp`          | Scroll one page up.
@@ -316,43 +316,43 @@ TerminalSelectionOneShot     |                    |                             
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
             <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
             <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (reversed release order). -->
-            <key="Ctrl-Alt"              action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to 1 by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl"              action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to 1 by pressing and releasing Alt-Ctrl (reversed releasing). -->
-            <key="Ctrl-Alt" scheme=1     action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to 0 (default) by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl" scheme=1     action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to 0 (default) by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Ctrl-Alt"              action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl"              action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to "1" by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Ctrl-Alt" scheme="1"   action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl" scheme="1"   action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to default by pressing and releasing Alt-Ctrl (reversed releasing). -->
         </tui>
         <term key*>
-            <key="Alt+RightArrow"         action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Alt+LeftArrow"          action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Shift+Ctrl+PageUp"      action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Shift+Ctrl+PageDown"    action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Ctrl+PageUp"   scheme=1 action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Ctrl+PageDown" scheme=1 action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Shift+Alt+LeftArrow"    action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
-            <key="Shift+Alt+RightArrow"   action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
-            <key="Shift+Ctrl+UpArrow"     action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
-            <key="Shift+Ctrl+DownArrow"   action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
-            <key="Shift+Ctrl+LeftArrow"   action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
-            <key="Shift+Ctrl+RightArrow"  action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
-            <key="Shift+Ctrl+Home"        action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+End"         action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
-            <key=""                       action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
-            <key=""                       action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
-            <key=""                       action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->
-            <key=""                       action=TerminalUndo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input. -->
-            <key=""                       action=TerminalRedo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command. -->
-            <key=""                       action=TerminalToggleCwdSync/>             <!-- Toggle the current working directory sync mode. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. To enable OSC9;9 shell notifications: - Windows Command Prompt: `setx PROMPT $e]9;9;$P$e\$P$G` - PowerShell: `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }` - Bash: `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '` -->
-            <key=""                       action=TerminalToggleWrapMode/>            <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. The argument is boolean. -->
-            <key=""                       action=TerminalToggleSelectionMode/>       <!-- Toggle between linear(0) and rectangular(1) selection form. -->
-            <key=""                       action=TerminalToggleFullscreen/>          <!-- Toggle fullscreen mode. -->
-            <key=""                       action=TerminalToggleMaximize/>            <!-- Toggle between maximized and normal window size. -->
-            <key=""                       action=TerminalToggleStdioLog/>            <!-- Stdin/stdout log toggle. -->
-            <key=""                       action=TerminalQuit/>                      <!-- Terminate runnning console apps and close terminal. -->
-            <key=""                       action=TerminalRestart/>                   <!-- Terminate runnning console apps and restart current session. -->
-            <key=""                       action=TerminalSwitchCopyMode/>            <!-- Set terminal text selection mode. The argument can be the one of the following values 0:'none', 1:'text', 2:'ansi', 3:'rich', 4:'html', 5:'protected'. -->
-            <key=""                       action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
-            <key="Esc"                    action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
-            <key=""                       action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. The argument can be the one of the following values 0:'none', 1:'text', 2:'ansi', 3:'rich', 4:'html', 5:'protected'. -->
+            <key="Alt+RightArrow"           action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Alt+LeftArrow"            action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Shift+Ctrl+PageUp"        action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
+            <key="Shift+Ctrl+PageDown"      action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
+            <key="Ctrl+PageUp"   scheme="1" action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
+            <key="Ctrl+PageDown" scheme="1" action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
+            <key="Shift+Alt+LeftArrow"      action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
+            <key="Shift+Alt+RightArrow"     action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
+            <key="Shift+Ctrl+UpArrow"       action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
+            <key="Shift+Ctrl+DownArrow"     action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
+            <key="Shift+Ctrl+LeftArrow"     action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
+            <key="Shift+Ctrl+RightArrow"    action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
+            <key="Shift+Ctrl+Home"          action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
+            <key="Shift+Ctrl+End"           action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
+            <key=""                         action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
+            <key=""                         action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
+            <key=""                         action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->
+            <key=""                         action=TerminalUndo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input. -->
+            <key=""                         action=TerminalRedo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command. -->
+            <key=""                         action=TerminalToggleCwdSync/>             <!-- Toggle the current working directory sync mode. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. To enable OSC9;9 shell notifications: - Windows Command Prompt: `setx PROMPT $e]9;9;$P$e\$P$G` - PowerShell: `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }` - Bash: `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '` -->
+            <key=""                         action=TerminalToggleWrapMode/>            <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. The argument is boolean. -->
+            <key=""                         action=TerminalToggleSelectionMode/>       <!-- Toggle between linear(0) and rectangular(1) selection form. -->
+            <key=""                         action=TerminalToggleFullscreen/>          <!-- Toggle fullscreen mode. -->
+            <key=""                         action=TerminalToggleMaximize/>            <!-- Toggle between maximized and normal window size. -->
+            <key=""                         action=TerminalToggleStdioLog/>            <!-- Stdin/stdout log toggle. -->
+            <key=""                         action=TerminalQuit/>                      <!-- Terminate runnning console apps and close terminal. -->
+            <key=""                         action=TerminalRestart/>                   <!-- Terminate runnning console apps and restart current session. -->
+            <key=""                         action=TerminalSwitchCopyMode/>            <!-- Set terminal text selection mode. The argument can be the one of the following values 0:'none', 1:'text', 2:'ansi', 3:'rich', 4:'html', 5:'protected'. -->
+            <key=""                         action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
+            <key="Esc"                      action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
+            <key=""                         action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. The argument can be the one of the following values 0:'none', 1:'text', 2:'ansi', 3:'rich', 4:'html', 5:'protected'. -->
         </term>
     </hotkeys>
 </config>

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -160,7 +160,7 @@ Value                        | Unique for hotkeys | Default Hotkey              
 -----------------------------|--------------------|------------------------------|------------
 Drop                         | x                  |                              | Drop all events for the specified key combination. No further processing.
 DropAutoRepeat               | x                  |                              | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
-ToggleHotkeyScheme           | x                  | `Ctrl-Alt`, `Alt-Ctrl`       | Toggle hotkey scheme between default and `"1"`.
+ToggleHotkeyScheme           | x                  | `Ctrl-Alt | Alt-Ctrl`        | Toggle hotkey scheme between default and `"1"`.
 TerminalFindNext             |                    | `Alt+RightArrow`             | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
 TerminalFindPrev             |                    | `Alt+LeftArrow`              | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
 TerminalViewportOnePageUp    | x                  | `Shift+Ctrl+PageUp`          | Scroll one page up.
@@ -314,12 +314,13 @@ TerminalSelectionOneShot     |                    |                             
     </term>
     <hotkeys>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.   -->
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
-            <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (reversed release order). -->
-            <key="Ctrl-Alt"              action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl"              action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to "1" by pressing and releasing Alt-Ctrl (reversed releasing). -->
-            <key="Ctrl-Alt" scheme="1"   action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl" scheme="1"   action=ToggleHotkeyScheme/>    <!-- Toggle hotkey scheme to default by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
+            <key="Ctrl-Alt | Alt-Ctrl" scheme="">
+                <action=ToggleHotkeyScheme arg="1"/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            </key>
+            <key="Ctrl-Alt | Alt-Ctrl" scheme="1">
+                <action=ToggleHotkeyScheme arg=""/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            </key>
         </tui>
         <term key*>
             <key="Alt+RightArrow"           action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -96,100 +96,79 @@ Option    | Cyclically selects the next label in the list and exec the function 
 Command   | Exec the function specified by the `action=` with `data=` as its parameter.
 Repeat    | Selects the next label and exec the function specified by the `action=` with `data=` as its parameter repeatedly from the time it is pressed until it is released.
 
-#### Attribute `action=`
+#### Actions `action=`
 
 `*` - Not implemented.
 
-Value                        | Unique for menu | Description
------------------------------|-----------------|------------
-TerminalCwdSync              |                 | Current working directory sync toggle. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. <br>To enable OSC9;9 shell notifications:<br>- Windows Command Prompt:<br>  `setx PROMPT $e]9;9;$P$e\$P$G`<br>- PowerShell:<br>  `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }`<br>- Bash:<br>  `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '`
-TerminalWrapMode             | x               | Set terminal scrollback lines wrapping mode. Applied to the active selection if it is. The `data=` attribute can have the following values `on`, `off`.
-TerminalAlignMode            | x               | Set terminal scrollback lines aligning mode. Applied to the active selection if it is. The `data=` attribute can have the following values `left`, `right`, `center`.
-TerminalFindNext             |                 | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
-TerminalFindPrev             |                 | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
-TerminalOutput               | x               | Direct output the `data=` value to the terminal scrollback.
-TerminalSendKey              | x               | Simulating keypresses using the `data=` string.
-TerminalQuit                 |                 | Terminate runnning console apps and close terminal.
-TerminalRestart              |                 | Terminate runnning console apps and restart current session.
-TerminalToggleFullscreen     |                 | Toggle fullscreen mode.
-TerminalToggleMaximize       |                 | Toggle between maximized and normal window size.
-TerminalUndo                 |                 | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
-TerminalRedo                 |                 | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
-TerminalClipboardPaste       |                 | Paste from clipboard.
-TerminalClipboardWipe        |                 | Reset clipboard.
-TerminalSelectionMode        | x               | Set terminal text selection mode.<br>The `data=` attribute can have the following values `none`, `text`, `ansi`, `rich`, `html`, `protected`.
-TerminalSelectionCopy        |                 | Сopy selection to clipboard.
-TerminalSelectionRect        | x               | Set linear(false) or rectangular(true) selection form using boolean value.
-TerminalSelectionCancel      |                 | Deselect a selection.
-TerminalSelectionOneShot     |                 | One-shot toggle to copy text while mouse tracking is active. Keep selection if `Ctrl` key is pressed.<br>The `data=` attribute can have the following values `none`, `text`, `ansi`, `rich`, `html`, `protected`.
-TerminalViewportCopy         |                 | Сopy viewport to clipboard.
-TerminalViewportPageUp       | x               | Scroll one page up.
-TerminalViewportPageDown     | x               | Scroll one page down.
-TerminalViewportLineUp       | x               | Scroll N lines up.
-TerminalViewportLineDown     | x               | Scroll N lines down.
-TerminalViewportPageLeft     | x               | Scroll one page to the left.
-TerminalViewportPageRight    | x               | Scroll one page to the right.
-TerminalViewportColumnLeft   | x               | Scroll N cells to the left.
-TerminalViewportColumnRight  | x               | Scroll N cells to the right.
-TerminalViewportTop          |                 | Scroll to the scrollback top.
-TerminalViewportEnd          |                 | Scroll to the scrollback bottom (reset viewport position).
-TerminalStdioLog             |                 | Stdin/stdout log toggle.
-*TerminalLogStart            |                 | Start logging to file.
-*TerminalLogPause            |                 | Pause logging.
-*TerminalLogStop             |                 | Stop logging.
-*TerminalLogAbort            |                 | Abort logging.
-*TerminalLogRestart          |                 | Restart logging to file.
-*TerminalVideoRecStart       |                 | Start DirectVT(dtvt) video recording to file.
-*TerminalVideoRecStop        |                 | Stop dtvt-video recording.
-*TerminalVideoRecPause       |                 | Pause dtvt-video recording.
-*TerminalVideoRecAbort       |                 | Abort dtvt-video recording.
-*TerminalVideoRecRestart     |                 | Restart dtvt-video recording to file.
-*TerminalVideoPlay           |                 | Play dtvt-video from file.
-*TerminalVideoPause          |                 | Pause dtvt-video.
-*TerminalVideoStop           |                 | Stop dtvt-video.
-*TerminalVideoForward        |                 | Fast forward dtvt-video by N ms.
-*TerminalVideoBackward       |                 | Rewind dtvt-video by N ms.
-*TerminalVideoHome           |                 | Rewind dtvt-video to the beginning.
-*TerminalVideoEnd            |                 | Rewind dtvt-video to the end.
+Value                        | Arguments (`data=`)           | Description
+-----------------------------|-------------------------------|------------
+Drop                         |                               | Drop all events for the specified key combination. No further processing.
+DropAutoRepeat               |                               | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
+SwitchHotkeyScheme           | _Scheme name_                 | Switch the hotkey scheme to the specified one.
+TerminalCwdSync              |                               | Current working directory sync toggle. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. <br>To enable OSC9;9 shell notifications:<br>- Windows Command Prompt:<br>  `setx PROMPT $e]9;9;$P$e\$P$G`<br>- PowerShell:<br>  `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }`<br>- Bash:<br>  `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '`
+TerminalWrapMode             | `on` \| `off`                 | Set terminal scrollback lines wrapping mode. Applied to the active selection if it is.
+TerminalAlignMode            | `left` \| `right` \| `center` | Set terminal scrollback lines aligning mode. Applied to the active selection if it is.
+TerminalFindNext             |                               | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
+TerminalFindPrev             |                               | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
+TerminalOutput               | _Text string_                 | Direct output the string to the terminal scrollback.
+TerminalSendKey              | _Text string_                 | Simulating keypresses using the specified string.
+TerminalQuit                 |                               | Terminate runnning console apps and close terminal.
+TerminalRestart              |                               | Terminate runnning console apps and restart current session.
+TerminalToggleFullscreen     |                               | Toggle fullscreen mode.
+TerminalToggleMaximize       |                               | Toggle between maximized and normal window size.
+TerminalUndo                 |                               | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
+TerminalRedo                 |                               | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
+TerminalClipboardPaste       |                               | Paste from clipboard.
+TerminalClipboardWipe        |                               | Reset clipboard.
+TerminalSelectionMode        | `none` \| `text` \| `ansi` \|<br>`rich` \| `html` \| `protected` | Set terminal text selection mode.
+TerminalSelectionCopy        |                               | Сopy selection to clipboard.
+TerminalSelectionRect        | `on` \| `off`                 | Set linear(off) or rectangular(on) selection form using boolean value.
+TerminalSelectionCancel      |                               | Deselect a selection.
+TerminalSelectionOneShot     | `none` \| `text` \| `ansi` \|<br>`rich` \| `html` \| `protected` | One-shot toggle to copy text while mouse tracking is active. Keep selection if `Ctrl` key is pressed..
+TerminalViewportCopy         |                               | Сopy viewport to clipboard.
+TerminalScrollViewportByPage | _`IntX, IntY`_                | Scroll viewport by _`IntX, IntY`_ pages.
+TerminalScrollViewportByCell | _`IntX, IntY`_                | Scroll viewport by _`IntX, IntY`_ cells.
+TerminalScrollViewportToTop  |                               | Scroll viewport to the scrollback top.
+TerminalScrollViewportToEnd  |                               | Scroll viewport to the scrollback bottom (reset viewport position).
+TerminalStdioLog             |                               | Stdin/stdout log toggle.
+*TerminalLogStart            |                               | Start logging to file.
+*TerminalLogPause            |                               | Pause logging.
+*TerminalLogStop             |                               | Stop logging.
+*TerminalLogAbort            |                               | Abort logging.
+*TerminalLogRestart          |                               | Restart logging to file.
+*TerminalVideoRecStart       |                               | Start DirectVT(dtvt) video recording to file.
+*TerminalVideoRecStop        |                               | Stop dtvt-video recording.
+*TerminalVideoRecPause       |                               | Pause dtvt-video recording.
+*TerminalVideoRecAbort       |                               | Abort dtvt-video recording.
+*TerminalVideoRecRestart     |                               | Restart dtvt-video recording to file.
+*TerminalVideoPlay           |                               | Play dtvt-video from file.
+*TerminalVideoPause          |                               | Pause dtvt-video.
+*TerminalVideoStop           |                               | Stop dtvt-video.
+*TerminalVideoForward        |                               | Fast forward dtvt-video by N ms.
+*TerminalVideoBackward       |                               | Rewind dtvt-video by N ms.
+*TerminalVideoHome           |                               | Rewind dtvt-video to the beginning.
+*TerminalVideoEnd            |                               | Rewind dtvt-video to the end.
 
-### Hotkeys
+### Default Hotkeys
 
-The list of hotkey actions is slightly different from the list of window menu actions.
+List of hotkeys defined in the default configuration.
 
-Value                        | Unique for hotkeys | Default Hotkey               | Description
------------------------------|--------------------|------------------------------|------------
-Drop                         | x                  |                              | Drop all events for the specified key combination. No further processing.
-DropAutoRepeat               | x                  |                              | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
-ToggleHotkeyScheme           | x                  | `Ctrl-Alt | Alt-Ctrl`        | Toggle hotkey scheme between default and `"1"`.
-TerminalFindNext             |                    | `Alt+RightArrow`             | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
-TerminalFindPrev             |                    | `Alt+LeftArrow`              | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
-TerminalViewportOnePageUp    | x                  | `Shift+Ctrl+PageUp`          | Scroll one page up.
-TerminalViewportOnePageDown  | x                  | `Shift+Ctrl+PageDown`        | Scroll one page down.
-TerminalViewportOnePageLeft  | x                  | `Shift+Alt+LeftArrow`        | Scroll one page to the left.
-TerminalViewportOnePageRight | x                  | `Shift+Alt+RightArrow`       | Scroll one page to the right.
-TerminalViewportOneCharUp    | x                  | `Shift+Ctrl+UpArrow`         | Scroll one line up.
-TerminalViewportOneCharDown  | x                  | `Shift+Ctrl+DownArrow`       | Scroll one line down.
-TerminalViewportOneCharLeft  | x                  | `Shift+Ctrl+LeftArrow`       | Scroll one cell to the left.
-TerminalViewportOneCharRight | x                  | `Shift+Ctrl+RightArrow`      | Scroll one cell to the right.
-TerminalViewportTop          |                    | `Shift+Ctrl+Home`            | Scroll to the scrollback top.
-TerminalViewportEnd          |                    | `Shift+Ctrl+End`             | Scroll to the scrollback bottom (reset viewport position).
-TerminalViewportCopy         |                    |                              | Сopy viewport to clipboard.
-TerminalClipboardPaste       |                    |                              | Paste from clipboard.
-TerminalClipboardWipe        |                    |                              | Reset clipboard.
-TerminalUndo                 |                    |                              | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
-TerminalRedo                 |                    |                              | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
-TerminalToggleCwdSync        | x                  |                              | Toggle the current working directory sync mode.
-TerminalToggleWrapMode       | x                  |                              | Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is.
-TerminalToggleSelectionMode  | x                  |                              | Toggle between linear and rectangular selection form.
-TerminalToggleFullscreen     | x                  |                              | Toggle fullscreen mode.
-TerminalToggleMaximize       | x                  |                              | Toggle between maximized and normal window size.
-TerminalToggleStdioLog       | x                  |                              | Stdin/stdout log toggle.
-TerminalQuit                 |                    |                              | Terminate runnning console apps and close terminal.
-TerminalRestart              |                    |                              | Terminate runnning console apps and restart current session.
-TerminalSwitchCopyMode       | x                  |                              | Switch terminal text selection mode.
-TerminalSelectionCopy        |                    |                              | Сopy selection to clipboard.
-TerminalSelectionCancel      |                    | `Esc`                        | Deselect a selection.
-TerminalSelectionOneShot     |                    |                              | One-shot toggle to copy text while mouse tracking is active. Keep selection if `Ctrl` key is pressed.
+Hotkey                       | Description
+-----------------------------|------------
+`Ctrl-Alt | Alt-Ctrl`        | Toggle hotkey scheme between `Keys0` and `Keys1`.
+`Alt+RightArrow`             | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
+`Alt+LeftArrow`              | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
+`Shift+Ctrl+PageUp`          | Scroll one page up.
+`Shift+Ctrl+PageDown`        | Scroll one page down.
+`Shift+Alt+LeftArrow`        | Scroll one page to the left.
+`Shift+Alt+RightArrow`       | Scroll one page to the right.
+`Shift+Ctrl+UpArrow`         | Scroll one line up.
+`Shift+Ctrl+DownArrow`       | Scroll one line down.
+`Shift+Ctrl+LeftArrow`       | Scroll one cell to the left.
+`Shift+Ctrl+RightArrow`      | Scroll one cell to the right.
+`Shift+Ctrl+Home`            | Scroll to the scrollback top.
+`Shift+Ctrl+End`             | Scroll to the scrollback bottom (reset viewport position).
+`Esc`                        | Deselect a selection.
 
 #### Terminal configuration example
 ```xml
@@ -216,10 +195,8 @@ TerminalSelectionOneShot     |                    |                             
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Command" action=ToggleHotkeyScheme>
-                <label=" Undef " data="undef"/>
-                <label=" Keys0 " data="off"/>
-                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="on"/>
+            <item type="Option" action=SwitchHotkeyScheme label=" Keys0 " data="">
+                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="1"/>
                 <tooltip>
                     " Toggle hotkey scheme                          \n"
                     "   Alternative hotkey scheme allows keystrokes \n"
@@ -257,18 +234,17 @@ TerminalSelectionOneShot     |                    |                             
             <item label="Clear" tooltip=" Clear TTY viewport "                  action=TerminalOutput data="\e[2J"/>
             <item label="Reset" tooltip=" Clear scrollback and SGR-attributes " action=TerminalOutput data="\e[!p"/>
             <item label="Restart" type="Command" action=TerminalRestart/>
-            <item label="Top" action=TerminalViewportTop/>
-            <item label="End" action=TerminalViewportEnd/>
+            <item label="Top" action=TerminalScrollViewportToTop/>
+            <item label="End" action=TerminalScrollViewportToEnd/>
 
-            <item label="PgLeft"    type="Repeat" action=TerminalViewportPageLeft/>
-            <item label="PgRight"   type="Repeat" action=TerminalViewportPageRight/>
-            <item label="CharLeft"  type="Repeat" action=TerminalViewportCharLeft/>
-            <item label="CharRight" type="Repeat" action=TerminalViewportCharRight/>
-
-            <item label="PgUp"   type="Repeat" action=TerminalViewportPageUp/>
-            <item label="PgDn"   type="Repeat" action=TerminalViewportPageDown/>
-            <item label="LineUp" type="Repeat" action=TerminalViewportLineUp/>
-            <item label="LineDn" type="Repeat" action=TerminalViewportLineDown/>
+            <item label="PgLeft"    type="Repeat" action=TerminalScrollViewportByPage data=" 1, 0"/>
+            <item label="PgRight"   type="Repeat" action=TerminalScrollViewportByPage data="-1, 0"/>
+            <item label="PgUp"      type="Repeat" action=TerminalScrollViewportByPage data=" 0, 1"/>
+            <item label="PgDn"      type="Repeat" action=TerminalScrollViewportByPage data=" 0,-1"/>
+            <item label="CharLeft"  type="Repeat" action=TerminalScrollViewportByCell data=" 1, 0"/>
+            <item label="CharRight" type="Repeat" action=TerminalScrollViewportByCell data="-1, 0"/>
+            <item label="LineUp"    type="Repeat" action=TerminalScrollViewportByCell data=" 0, 1"/>
+            <item label="LineDn"    type="Repeat" action=TerminalScrollViewportByCell data=" 0,-1"/>
 
             <item label="PrnScr" action=TerminalViewportCopy/>
             <item label="Deselect" action=TerminalSelectionCancel/>
@@ -315,45 +291,47 @@ TerminalSelectionOneShot     |                    |                             
     <hotkeys>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.   -->
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
             <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Ctrl-Alt | Alt-Ctrl" scheme="">
-                <action=ToggleHotkeyScheme arg="1"/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            </key>
-            <key="Ctrl-Alt | Alt-Ctrl" scheme="1">
-                <action=ToggleHotkeyScheme arg=""/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            </key>
+            <key="Ctrl-Alt | Alt-Ctrl" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            <key="Ctrl-Alt | Alt-Ctrl" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
         </tui>
         <term key*>
-            <key="Alt+RightArrow"           action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Alt+LeftArrow"            action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Shift+Ctrl+PageUp"        action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Shift+Ctrl+PageDown"      action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Ctrl+PageUp"   scheme="1" action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Ctrl+PageDown" scheme="1" action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Shift+Alt+LeftArrow"      action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
-            <key="Shift+Alt+RightArrow"     action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
-            <key="Shift+Ctrl+UpArrow"       action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
-            <key="Shift+Ctrl+DownArrow"     action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
-            <key="Shift+Ctrl+LeftArrow"     action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
-            <key="Shift+Ctrl+RightArrow"    action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
-            <key="Shift+Ctrl+Home"          action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+End"           action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
-            <key=""                         action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
-            <key=""                         action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
-            <key=""                         action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->
-            <key=""                         action=TerminalUndo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input. -->
-            <key=""                         action=TerminalRedo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command. -->
-            <key=""                         action=TerminalToggleCwdSync/>             <!-- Toggle the current working directory sync mode. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. To enable OSC9;9 shell notifications: - Windows Command Prompt: `setx PROMPT $e]9;9;$P$e\$P$G` - PowerShell: `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }` - Bash: `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '` -->
-            <key=""                         action=TerminalToggleWrapMode/>            <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. The argument is boolean. -->
-            <key=""                         action=TerminalToggleSelectionMode/>       <!-- Toggle between linear(0) and rectangular(1) selection form. -->
-            <key=""                         action=TerminalToggleFullscreen/>          <!-- Toggle fullscreen mode. -->
-            <key=""                         action=TerminalToggleMaximize/>            <!-- Toggle between maximized and normal window size. -->
-            <key=""                         action=TerminalToggleStdioLog/>            <!-- Stdin/stdout log toggle. -->
-            <key=""                         action=TerminalQuit/>                      <!-- Terminate runnning console apps and close terminal. -->
-            <key=""                         action=TerminalRestart/>                   <!-- Terminate runnning console apps and restart current session. -->
-            <key=""                         action=TerminalSwitchCopyMode/>            <!-- Set terminal text selection mode. The argument can be the one of the following values 0:'none', 1:'text', 2:'ansi', 3:'rich', 4:'html', 5:'protected'. -->
-            <key=""                         action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
-            <key="Esc"                      action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
-            <key=""                         action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. The argument can be the one of the following values 0:'none', 1:'text', 2:'ansi', 3:'rich', 4:'html', 5:'protected'. -->
+            <key="Alt+RightArrow"            action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Alt+LeftArrow"             action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Shift+Ctrl+PageUp"       ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
+            <key="Shift+Ctrl+PageDown"     ><action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
+            <key="Ctrl+PageUp"   scheme="1"><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
+            <key="Ctrl+PageDown" scheme="1"><action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
+            <key="Shift+Alt+LeftArrow"     ><action=TerminalScrollViewportByPage data=" 1, 0"/></key>  <!-- Scroll viewport one page to the left. -->
+            <key="Shift+Alt+RightArrow"    ><action=TerminalScrollViewportByPage data="-1, 0"/></key>  <!-- Scroll viewport one page to the right. -->
+            <key="Shift+Ctrl+UpArrow"      ><action=TerminalScrollViewportByCell data=" 0, 1"/></key>  <!-- Scroll viewport one line up. -->
+            <key="Shift+Ctrl+DownArrow"    ><action=TerminalScrollViewportByCell data=" 0,-1"/></key>  <!-- Scroll viewport one line down. -->
+            <key="Shift+Ctrl+LeftArrow"    ><action=TerminalScrollViewportByCell data=" 1, 0"/></key>  <!-- Scroll viewport one cell to the left. -->
+            <key="Shift+Ctrl+RightArrow"   ><action=TerminalScrollViewportByCell data="-1, 0"/></key>  <!-- Scroll viewport one cell to the right. -->
+            <key="Shift+Ctrl+Home">
+                <action=DropAutoRepeat/>               <!-- Don't autorepeat the Scroll to the scrollback top. -->
+                <action=TerminalScrollViewportToTop/>  <!-- Scroll to the scrollback top. -->
+            </key>
+            <key="Shift+Ctrl+End">
+                <action=DropAutoRepeat/>               <!-- Don't autorepeat the Scroll to the scrollback bottom (reset viewport position). -->
+                <action=TerminalScrollViewportToEnd/>  <!-- Scroll to the scrollback bottom (reset viewport position). -->
+            </key>
+            <key=""                          action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
+            <key=""                          action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
+            <key=""                          action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->
+            <key=""                          action=TerminalUndo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input. -->
+            <key=""                          action=TerminalRedo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command. -->
+            <key=""                          action=TerminalToggleCwdSync/>             <!-- Toggle the current working directory sync mode. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. To enable OSC9;9 shell notifications: - Windows Command Prompt: `setx PROMPT $e]9;9;$P$e\$P$G` - PowerShell: `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }` - Bash: `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '` -->
+            <key=""                          action=TerminalToggleWrapMode/>            <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. The argument is boolean. -->
+            <key=""                          action=TerminalToggleSelectionMode/>       <!-- Toggle between linear(0) and rectangular(1) selection form. -->
+            <key=""                          action=TerminalToggleFullscreen/>          <!-- Toggle fullscreen mode. -->
+            <key=""                          action=TerminalToggleMaximize/>            <!-- Toggle between maximized and normal window size. -->
+            <key=""                          action=TerminalToggleStdioLog/>            <!-- Stdin/stdout log toggle. -->
+            <key=""                          action=TerminalQuit/>                      <!-- Terminate runnning console apps and close terminal. -->
+            <key=""                          action=TerminalRestart/>                   <!-- Terminate runnning console apps and restart current session. -->
+            <key=""                          action=TerminalSwitchCopyMode/>            <!-- Switch terminal text selection mode. -->
+            <key=""                          action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
+            <key="Esc"                       action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
+            <key=""                          action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. -->
         </term>
     </hotkeys>
 </config>

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -305,9 +305,9 @@ The syntax for defining key combination bindings is:
 
 ```xml
 <key="Key+Chord | ... | Another+Key+Chord" scheme="scheme_name"> <!-- scheme="" can be omitted.  -->
-    <action="NameOfAction1" arg="argument" ... arg="argument"/>
+    <action="NameOfAction1" data="argument" ... data="argument"/>
     ...
-    <action="NameOfActionN" arg="argument" ... arg="argument"/>
+    <action="NameOfActionN" data="argument" ... data="argument"/>
 </key>
 ```
 
@@ -351,52 +351,46 @@ Configuration record                                  | Interpretation
 
 #### Available actions
 
-Action                         | Default key combination  | Available at layer  | Description
--------------------------------|--------------------------|---------------------|------------
-`Drop`                         |                          | All layers          | Drop all events for the specified key combination. No further processing.
-`DropAutoRepeat`               |                          | All layers          | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
-`ToggleDebugOverlay`           |                          | TUI matrix          | Toggle debug overlay.
-`ToggleHotkeyScheme`           | `Ctrl-Alt | Alt-Ctrl`    | TUI matrix          | Toggle hotkey scheme between default and `"1"`.
-`IncreaseCellHeight`           | `CapsLock+UpArrow`       | Native GUI window   | Increase the text cell height by one pixel.
-`DecreaseCellHeight`           | `CapsLock+DownArrow`     | Native GUI window   | Decrease the text cell height by one pixel.
-`ResetCellHeight`              | `Ctrl+Key0`              | Native GUI window   | Reset text cell height.
-`ToggleFullscreenMode`         | `Alt+Enter`              | Native GUI window   | Toggle fullscreen mode.
-`ToggleAntialiasingMode`       | `Ctrl+CapsLock`          | Native GUI window   | Toggle text antialiasing mode.
-`RollFontsBackward`            | `Ctrl+Shift+F11`         | Native GUI window   | Roll font list backward.
-`RollFontsForward`             | `Ctrl+Shift+F12`         | Native GUI window   | Roll font list forward.
-`FocusPrevWindow`              | `Ctrl+PageUp`            | Desktop             | Switch focus to the next desktop window.
-`FocusNextWindow`              | `Ctrl+PageDown`          | Desktop             | Switch focus to the previous desktop window.
-`Disconnect`                   | `Shift+F7`               | Desktop             | Disconnect from the desktop.
-`TryToQuit`                    | `F10`                    | Desktop             | Shut down the desktop server if no applications are running.
-`TerminalFindNext`             | `Alt+RightArrow`         | Application         | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
-`TerminalFindPrev`             | `Alt+LeftArrow`          | Application         | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
-`TerminalViewportOnePageUp`    | `Shift+Ctrl+PageUp`      | Application         | Scroll one page up.
-`TerminalViewportOnePageDown`  | `Shift+Ctrl+PageDown`    | Application         | Scroll one page down.
-`TerminalViewportOnePageLeft`  | `Shift+Alt+LeftArrow`    | Application         | Scroll one page to the left.
-`TerminalViewportOnePageRight` | `Shift+Alt+RightArrow`   | Application         | Scroll one page to the right.
-`TerminalViewportOneCharUp`    | `Shift+Ctrl+UpArrow`     | Application         | Scroll one line up.
-`TerminalViewportOneCharDown`  | `Shift+Ctrl+DownArrow`   | Application         | Scroll one line down.
-`TerminalViewportOneCharLeft`  | `Shift+Ctrl+LeftArrow`   | Application         | Scroll one cell to the left.
-`TerminalViewportOneCharRight` | `Shift+Ctrl+RightArrow`  | Application         | Scroll one cell to the right.
-`TerminalViewportTop`          | `Shift+Ctrl+Home`        | Application         | Scroll to the scrollback top.
-`TerminalViewportEnd`          | `Shift+Ctrl+End`         | Application         | Scroll to the scrollback bottom (reset viewport position).
-`TerminalViewportCopy`         |                          | Application         | Сopy viewport to clipboard.
-`TerminalClipboardPaste`       |                          | Application         | Paste from clipboard.
-`TerminalClipboardWipe`        |                          | Application         | Reset clipboard.
-`TerminalUndo`                 |                          | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
-`TerminalRedo`                 |                          | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
-`TerminalToggleCwdSync`        |                          | Application         | Toggle the current working directory sync mode.
-`TerminalToggleWrapMode`       |                          | Application         | Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is.
-`TerminalToggleSelectionMode`  |                          | Application         | Toggle between linear and rectangular selection form.
-`TerminalToggleFullscreen`     |                          | Application         | Toggle fullscreen mode.
-`TerminalToggleMaximize`       |                          | Application         | Toggle between maximized and normal window size.
-`TerminalToggleStdioLog`       |                          | Application         | Stdin/stdout log toggle.
-`TerminalQuit`                 |                          | Application         | Terminate runnning console apps and close terminal.
-`TerminalRestart`              |                          | Application         | Terminate runnning console apps and restart current session.
-`TerminalSwitchCopyMode`       |                          | Application         | Switch terminal text selection copy mode.
-`TerminalSelectionCopy`        |                          | Application         | Сopy selection to clipboard.
-`TerminalSelectionCancel`      | `Esc`                    | Application         | Deselect a selection.
-`TerminalSelectionOneShot`     |                          | Application         | One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed.
+Action                         | Arguments (`data=`) | Available at layer  | Description
+-------------------------------|---------------------|---------------------|------------
+`Drop`                         |                     | All layers          | Drop all events for the specified key combination. No further processing.
+`DropAutoRepeat`               |                     | All layers          | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
+`ToggleDebugOverlay`           |                     | TUI matrix          | Toggle debug overlay.
+`SwitchHotkeyScheme`           | _Scheme name_       | TUI matrix          | Switch the hotkey scheme to the specified one.
+`IncreaseCellHeight`           |                     | Native GUI window   | Increase the text cell height by one pixel.
+`DecreaseCellHeight`           |                     | Native GUI window   | Decrease the text cell height by one pixel.
+`ResetCellHeight`              |                     | Native GUI window   | Reset text cell height.
+`ToggleFullscreenMode`         |                     | Native GUI window   | Toggle fullscreen mode.
+`ToggleAntialiasingMode`       |                     | Native GUI window   | Toggle text antialiasing mode.
+`RollFontsBackward`            |                     | Native GUI window   | Roll font list backward.
+`RollFontsForward`             |                     | Native GUI window   | Roll font list forward.
+`FocusPrevWindow`              |                     | Desktop             | Switch focus to the next desktop window.
+`FocusNextWindow`              |                     | Desktop             | Switch focus to the previous desktop window.
+`Disconnect`                   |                     | Desktop             | Disconnect from the desktop.
+`TryToQuit`                    |                     | Desktop             | Shut down the desktop server if no applications are running.
+`TerminalFindNext`             |                     | Application         | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
+`TerminalFindPrev`             |                     | Application         | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
+`TerminalScrollViewportByPage` | _`IntX, IntY`_      | Application         | Scroll viewport by _`IntX, IntY`_ pages.
+`TerminalScrollViewportByCell` | _`IntX, IntY`_      | Application         | Scroll viewport by _`IntX, IntY`_ cells.
+`TerminalScrollViewportToTop`  |                     | Application         | Scroll viewport to the scrollback top.
+`TerminalScrollViewportToEnd`  |                     | Application         | Scroll viewport to the scrollback bottom (reset viewport position).
+`TerminalViewportCopy`         |                     | Application         | Сopy viewport to clipboard.
+`TerminalClipboardPaste`       |                     | Application         | Paste from clipboard.
+`TerminalClipboardWipe`        |                     | Application         | Reset clipboard.
+`TerminalUndo`                 |                     | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
+`TerminalRedo`                 |                     | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
+`TerminalToggleCwdSync`        |                     | Application         | Toggle the current working directory sync mode.
+`TerminalToggleWrapMode`       |                     | Application         | Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is.
+`TerminalToggleSelectionMode`  |                     | Application         | Toggle between linear and rectangular selection form.
+`TerminalToggleFullscreen`     |                     | Application         | Toggle fullscreen mode.
+`TerminalToggleMaximize`       |                     | Application         | Toggle between maximized and normal window size.
+`TerminalToggleStdioLog`       |                     | Application         | Stdin/stdout log toggle.
+`TerminalQuit`                 |                     | Application         | Terminate runnning console apps and close terminal.
+`TerminalRestart`              |                     | Application         | Terminate runnning console apps and restart current session.
+`TerminalSwitchCopyMode`       |                     | Application         | Switch terminal text selection copy mode.
+`TerminalSelectionCopy`        |                     | Application         | Сopy selection to clipboard.
+`TerminalSelectionCancel`      |                     | Application         | Deselect a selection.
+`TerminalSelectionOneShot`     |                     | Application         | One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed.
 
 ### DirectVT configuration payload received from the parent process
 
@@ -747,10 +741,9 @@ Notes
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Command" action=ToggleHotkeyScheme>
-                <label=" Undef " data="undef"/>
-                <label=" Keys0 " data="off"/>
-                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="on"/>
+            <item type="Command" action=SwitchHotkeyScheme>
+                <label=" Keys0 " data=""/>
+                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="1"/>
                 <tooltip>
                     " Toggle hotkey scheme                          \n"
                     "   Alternative hotkey scheme allows keystrokes \n"
@@ -812,25 +805,31 @@ Notes
         <gui key*>  <!-- Native GUI window layer key bindings. key* here is to clear all previous bindings and start a new list. -->
             <key="CapsLock+UpArrow"      action=IncreaseCellHeight/>      <!-- Increase the text cell height by one pixel. -->
             <key="CapsLock+DownArrow"    action=DecreaseCellHeight/>      <!-- Decrease the text cell height by one pixel. -->
-            <key="Ctrl+0"                action=DropAutoRepeat/>          <!-- Don't repeat the Reset text cell height. -->
-            <key="Ctrl+0"                action=ResetCellHeight/>         <!-- Reset text cell height. -->
-            <key="Alt+Enter"             action=DropAutoRepeat/>          <!-- Don't repeat the Toggle fullscreen mode. -->
-            <key="Alt+Enter"             action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
-            <key="Ctrl+CapsLock"         action=DropAutoRepeat/>          <!-- Don't repeat the Toggle text antialiasing mode. -->
-            <key="Ctrl+CapsLock"         action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
-            <key="Ctrl+Shift+F11"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list backward. -->
-            <key="Ctrl+Shift+F11"        action=RollFontsBackward/>       <!-- Roll font list backward. -->
-            <key="Ctrl+Shift+F12"        action=DropAutoRepeat/>          <!-- Don't repeat the Roll font list forward. -->
-            <key="Ctrl+Shift+F12"        action=RollFontsForward/>        <!-- Roll font list forward. -->
+            <key="Ctrl+0">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Reset text cell height. -->
+                <action=ResetCellHeight/>         <!-- Reset text cell height. -->
+            </key>
+            <key="Alt+Enter">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Toggle fullscreen mode. -->
+                <action=ToggleFullscreenMode/>    <!-- Toggle fullscreen mode. -->
+            </key>
+            <key="Ctrl+CapsLock">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Toggle text antialiasing mode. -->
+                <action=ToggleAntialiasingMode/>  <!-- Toggle text antialiasing mode. -->
+            </key>
+            <key="Ctrl+Shift+F11">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Roll font list backward. -->
+                <action=RollFontsBackward/>       <!-- Roll font list backward. -->
+            </key>
+            <key="Ctrl+Shift+F12">
+                <action=DropAutoRepeat/>          <!-- Don't autorepeat the Roll font list forward. -->
+                <action=RollFontsForward/>        <!-- Roll font list forward. -->
+            </key>
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
             <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Ctrl-Alt | Alt-Ctrl" scheme="">
-                <action=ToggleHotkeyScheme arg="1"/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            </key>
-            <key="Ctrl-Alt | Alt-Ctrl" scheme="1">
-                <action=ToggleHotkeyScheme arg=""/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            </key>
+            <key="Ctrl-Alt | Alt-Ctrl" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            <key="Ctrl-Alt | Alt-Ctrl" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"           action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
@@ -840,22 +839,26 @@ Notes
             <!-- <key="Ctrl+N"    action="Start(\"Term\")"/> -->
         </desktop>
         <term key*>  <!-- Application specific layer key bindings. -->
-            <key="Alt+RightArrow"           action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Alt+LeftArrow"            action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Shift+Ctrl+PageUp"        action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Shift+Ctrl+PageDown"      action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Ctrl+PageUp"   scheme="1" action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Ctrl+PageDown" scheme="1" action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Shift+Alt+LeftArrow"      action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
-            <key="Shift+Alt+RightArrow"     action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
-            <key="Shift+Ctrl+UpArrow"       action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
-            <key="Shift+Ctrl+DownArrow"     action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
-            <key="Shift+Ctrl+LeftArrow"     action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
-            <key="Shift+Ctrl+RightArrow"    action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
-            <key="Shift+Ctrl+Home"          action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+Home"          action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+End"           action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
-            <key="Shift+Ctrl+End"           action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
+            <key="Alt+RightArrow"           action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Alt+LeftArrow"            action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Shift+Ctrl+PageUp"       ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
+            <key="Shift+Ctrl+PageDown"     ><action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
+            <key="Ctrl+PageUp"   scheme="1"><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
+            <key="Ctrl+PageDown" scheme="1"><action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
+            <key="Shift+Alt+LeftArrow"     ><action=TerminalScrollViewportByPage data=" 1, 0"/></key>  <!-- Scroll viewport one page to the left. -->
+            <key="Shift+Alt+RightArrow"    ><action=TerminalScrollViewportByPage data="-1, 0"/></key>  <!-- Scroll viewport one page to the right. -->
+            <key="Shift+Ctrl+UpArrow"      ><action=TerminalScrollViewportByCell data=" 0, 1"/></key>  <!-- Scroll viewport one line up. -->
+            <key="Shift+Ctrl+DownArrow"    ><action=TerminalScrollViewportByCell data=" 0,-1"/></key>  <!-- Scroll viewport one line down. -->
+            <key="Shift+Ctrl+LeftArrow"    ><action=TerminalScrollViewportByCell data=" 1, 0"/></key>  <!-- Scroll viewport one cell to the left. -->
+            <key="Shift+Ctrl+RightArrow"   ><action=TerminalScrollViewportByCell data="-1, 0"/></key>  <!-- Scroll viewport one cell to the right. -->
+            <key="Shift+Ctrl+Home">
+                <action=DropAutoRepeat/>               <!-- Don't autorepeat the Scroll to the scrollback top. -->
+                <action=TerminalScrollViewportToTop/>  <!-- Scroll to the scrollback top. -->
+            </key>
+            <key="Shift+Ctrl+End">
+                <action=DropAutoRepeat/>               <!-- Don't autorepeat the Scroll to the scrollback bottom (reset viewport position). -->
+                <action=TerminalScrollViewportToEnd/>  <!-- Scroll to the scrollback bottom (reset viewport position). -->
+            </key>
             <key=""                         action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
             <key=""                         action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
             <key=""                         action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -350,7 +350,7 @@ Action                         | Default key combination  | Available at layer  
 `Drop`                         |                          | All layers          | Drop all events for the specified key combination. No further processing.
 `DropAutoRepeat`               |                          | All layers          | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
 `ToggleDebugOverlay`           |                          | TUI matrix          | Toggle debug overlay.
-`ToggleHotkeyScheme`           | `Ctrl-Alt`, `Alt-Ctrl`   | TUI matrix          | Toggle hotkey scheme between scheme=0 (default) and scheme=1.
+`ToggleHotkeyScheme`           | `Ctrl-Alt`, `Alt-Ctrl`   | TUI matrix          | Toggle hotkey scheme between default and `"1"`.
 `IncreaseCellHeight`           | `CapsLock+UpArrow`       | Native GUI window   | Increase the text cell height by one pixel.
 `DecreaseCellHeight`           | `CapsLock+DownArrow`     | Native GUI window   | Decrease the text cell height by one pixel.
 `ResetCellHeight`              | `Ctrl+Key0`              | Native GUI window   | Reset text cell height.
@@ -820,10 +820,10 @@ Notes
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
             <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
             <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (reversed release order). -->
-            <key="Ctrl-Alt"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to 1 by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to 1 by pressing and releasing Alt-Ctrl (reversed releasing). -->
-            <key="Ctrl-Alt" scheme=1     action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to 0 (default) by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl" scheme=1     action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to 0 (default) by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Ctrl-Alt"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Ctrl-Alt" scheme="1"   action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl" scheme="1"   action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to default by pressing and releasing Alt-Ctrl (reversed releasing). -->
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"           action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
@@ -833,39 +833,39 @@ Notes
             <!-- <key="Ctrl+N"    action="Start(\"Term\")"/> -->
         </desktop>
         <term key*>  <!-- Application specific layer key bindings. -->
-            <key="Alt+RightArrow"         action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Alt+LeftArrow"          action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Shift+Ctrl+PageUp"      action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Shift+Ctrl+PageDown"    action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Ctrl+PageUp"   scheme=1 action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Ctrl+PageDown" scheme=1 action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Shift+Alt+LeftArrow"    action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
-            <key="Shift+Alt+RightArrow"   action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
-            <key="Shift+Ctrl+UpArrow"     action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
-            <key="Shift+Ctrl+DownArrow"   action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
-            <key="Shift+Ctrl+LeftArrow"   action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
-            <key="Shift+Ctrl+RightArrow"  action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
-            <key="Shift+Ctrl+Home"        action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+Home"        action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
-            <key="Shift+Ctrl+End"         action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
-            <key="Shift+Ctrl+End"         action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
-            <key=""                       action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
-            <key=""                       action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
-            <key=""                       action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->
-            <key=""                       action=TerminalUndo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input. -->
-            <key=""                       action=TerminalRedo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command. -->
-            <key=""                       action=TerminalToggleCwdSync/>             <!-- Toggle the current working directory sync mode. -->
-            <key=""                       action=TerminalToggleWrapMode/>            <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. -->
-            <key=""                       action=TerminalToggleSelectionMode/>       <!-- Toggle between linear and rectangular selection form. -->
-            <key=""                       action=TerminalToggleFullscreen/>          <!-- Toggle fullscreen mode. -->
-            <key=""                       action=TerminalToggleMaximize/>            <!-- Toggle between maximized and normal window size. -->
-            <key=""                       action=TerminalToggleStdioLog/>            <!-- Stdin/stdout log toggle. -->
-            <key=""                       action=TerminalQuit/>                      <!-- Terminate runnning console apps and close terminal. -->
-            <key=""                       action=TerminalRestart/>                   <!-- Terminate runnning console apps and restart current session. -->
-            <key=""                       action=TerminalSwitchCopyMode/>            <!-- Switch terminal text selection copy mode. -->
-            <key=""                       action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
-            <key="Esc"                    action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
-            <key=""                       action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. -->
+            <key="Alt+RightArrow"           action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Alt+LeftArrow"            action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Shift+Ctrl+PageUp"        action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
+            <key="Shift+Ctrl+PageDown"      action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
+            <key="Ctrl+PageUp"   scheme="1" action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
+            <key="Ctrl+PageDown" scheme="1" action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
+            <key="Shift+Alt+LeftArrow"      action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
+            <key="Shift+Alt+RightArrow"     action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
+            <key="Shift+Ctrl+UpArrow"       action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
+            <key="Shift+Ctrl+DownArrow"     action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
+            <key="Shift+Ctrl+LeftArrow"     action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
+            <key="Shift+Ctrl+RightArrow"    action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
+            <key="Shift+Ctrl+Home"          action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback top. -->
+            <key="Shift+Ctrl+Home"          action=TerminalViewportTop/>               <!-- Scroll to the scrollback top. -->
+            <key="Shift+Ctrl+End"           action=DropAutoRepeat/>                    <!-- Don't repeat the Scroll to the scrollback bottom (reset viewport position). -->
+            <key="Shift+Ctrl+End"           action=TerminalViewportEnd/>               <!-- Scroll to the scrollback bottom (reset viewport position). -->
+            <key=""                         action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
+            <key=""                         action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
+            <key=""                         action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->
+            <key=""                         action=TerminalUndo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input. -->
+            <key=""                         action=TerminalRedo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command. -->
+            <key=""                         action=TerminalToggleCwdSync/>             <!-- Toggle the current working directory sync mode. -->
+            <key=""                         action=TerminalToggleWrapMode/>            <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. -->
+            <key=""                         action=TerminalToggleSelectionMode/>       <!-- Toggle between linear and rectangular selection form. -->
+            <key=""                         action=TerminalToggleFullscreen/>          <!-- Toggle fullscreen mode. -->
+            <key=""                         action=TerminalToggleMaximize/>            <!-- Toggle between maximized and normal window size. -->
+            <key=""                         action=TerminalToggleStdioLog/>            <!-- Stdin/stdout log toggle. -->
+            <key=""                         action=TerminalQuit/>                      <!-- Terminate runnning console apps and close terminal. -->
+            <key=""                         action=TerminalRestart/>                   <!-- Terminate runnning console apps and restart current session. -->
+            <key=""                         action=TerminalSwitchCopyMode/>            <!-- Switch terminal text selection copy mode. -->
+            <key=""                         action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
+            <key="Esc"                      action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
+            <key=""                         action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. -->
         </term>
     </hotkeys>
 </config>

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -304,14 +304,19 @@ Application `app_name` | `<config/hotkeys/app_name/>` | Application layer key bi
 The syntax for defining key combination bindings is:
 
 ```xml
-<key="Key+Chord" action="NameOfAction" scheme=N/> <!-- scheme=0 can be omitted.  -->
+<key="Key+Chord | ... | Another+Key+Chord" scheme="scheme_name"> <!-- scheme="" can be omitted.  -->
+    <action="NameOfAction1" arg="argument" ... arg="argument"/>
+    ...
+    <action="NameOfActionN" arg="argument" ... arg="argument"/>
+</key>
 ```
 
 Tag      | Value
 ---------|--------
-`key`    | The text string containing the key combination.
+`key`    | The text string containing the key combinations.
+`scheme` | Hotkey scheme name for which mapping is being done (empty string by default).
 `action` | The action name.
-`scheme` | Hotkey scheme for which mapping is being done (0 by default). Either `0` or `1` are allowed.
+`arg`    | The arguments passed to the action.
 
 The following joiners are allowed for combining keys:
 
@@ -319,6 +324,7 @@ Joiner | Meaning
 -------|--------
 `+`    | The subsequent key is in pressed state.
 `-`    | The subsequent key is in released state. This joiner is allowed for the last key only.
+` | `  | The separator for key combinations in a list (vertical bar surrounded by spaces).
 
 Key combinations can be of the following types:
 
@@ -335,13 +341,13 @@ The required key combination sequence can be generated on the Info page, accessi
 
 #### Interpretation
 
-Configuration record                                | Interpretation
-----------------------------------------------------|-----------------
-`<key="Key+Chord" action=NameOfAction/>`            | Append existing bindings using an indirect reference (the `NameOfAction` variable without quotes).
-`<key="Key+Chord" action="NameOfAction"/>`          | Append existing bindings with the directly specified command "NameOfAction".
-`<key="Key+Chord" action="NameOfAction" scheme=1/>` | Append existing bindings for scheme=1.
-`<key="Key+Chord" action=""/>`                      | Remove all existing bindings for the specified key combination "Key+Chord".
-`<key=""          action="NameOfAction"/>`          | Do nothing.
+Configuration record                                  | Interpretation
+------------------------------------------------------|-----------------
+`<key="Key+Chord" action=NameOfAction/>`              | Append existing bindings using an indirect reference (the `NameOfAction` variable without quotes).
+`<key="Key+Chord" action="NameOfAction"/>`            | Append existing bindings with the directly specified command "NameOfAction".
+`<key="Key+Chord" action="NameOfAction" scheme="1"/>` | Append existing bindings for scheme="1".
+`<key="Key+Chord" action=""/>`                        | Remove all existing bindings for the specified key combination "Key+Chord".
+`<key=""          action="NameOfAction"/>`            | Do nothing.
 
 #### Available actions
 
@@ -350,7 +356,7 @@ Action                         | Default key combination  | Available at layer  
 `Drop`                         |                          | All layers          | Drop all events for the specified key combination. No further processing.
 `DropAutoRepeat`               |                          | All layers          | Drop `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
 `ToggleDebugOverlay`           |                          | TUI matrix          | Toggle debug overlay.
-`ToggleHotkeyScheme`           | `Ctrl-Alt`, `Alt-Ctrl`   | TUI matrix          | Toggle hotkey scheme between default and `"1"`.
+`ToggleHotkeyScheme`           | `Ctrl-Alt | Alt-Ctrl`    | TUI matrix          | Toggle hotkey scheme between default and `"1"`.
 `IncreaseCellHeight`           | `CapsLock+UpArrow`       | Native GUI window   | Increase the text cell height by one pixel.
 `DecreaseCellHeight`           | `CapsLock+DownArrow`     | Native GUI window   | Decrease the text cell height by one pixel.
 `ResetCellHeight`              | `Ctrl+Key0`              | Native GUI window   | Reset text cell height.
@@ -818,12 +824,13 @@ Notes
             <key="Ctrl+Shift+F12"        action=RollFontsForward/>        <!-- Roll font list forward. -->
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
-            <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (reversed release order). -->
-            <key="Ctrl-Alt"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Alt-Ctrl (reversed releasing). -->
-            <key="Ctrl-Alt" scheme="1"   action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl" scheme="1"   action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to default by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
+            <key="Ctrl-Alt | Alt-Ctrl" scheme="">
+                <action=ToggleHotkeyScheme arg="1"/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            </key>
+            <key="Ctrl-Alt | Alt-Ctrl" scheme="1">
+                <action=ToggleHotkeyScheme arg=""/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            </key>
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"           action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -753,7 +753,7 @@ namespace netxs::app::shared
                 auto& items_inst = *items;
                 auto& keybd = boss.template plugins<pro::keybd>();
                 app::shared::base_kb_navigation(keybd, scroll, boss);
-                keybd.proc("UpdateChordPreview", [&, update_ptr](hids& gear)
+                keybd.proc("UpdateChordPreview", [&, update_ptr](hids& gear, txts&)
                 {
                     if (gear.keystat != input::key::repeated) (*update_ptr)(items_inst, gear, true);
                 });

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -757,8 +757,8 @@ namespace netxs::app::shared
                 {
                     if (gear.keystat != input::key::repeated) (*update_ptr)(items_inst, gear, true);
                 });
-                keybd.template bind<tier::release>( "Any", "UpdateChordPreview", "");
-                keybd.template bind<tier::release>( "Any", "UpdateChordPreview", "1");
+                keybd.template bind<tier::release>( "Any", "",  "UpdateChordPreview");
+                keybd.template bind<tier::release>( "Any", "1", "UpdateChordPreview");
             });
             inside->attach(slot::_2, ui::post::ctor())
                 ->limits({ -1, 1 })

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -617,17 +617,26 @@ namespace netxs::app::shared
                         subs_ptr->clear();
                         if (auto focusable_parent = boss.base::riseup(tier::request, e2::config::plugins::focus::owner))
                         {
-                            focusable_parent->LISTEN(tier::release, e2::form::state::keybd::hotkey, state, (*subs_ptr))
+                            focusable_parent->LISTEN(tier::release, e2::form::state::keybd::scheme, hscheme, (*subs_ptr))
                             {
-                                boss.set(state ? ansi::bgc(greendk).fgc(whitelt).add(" on █")
-                                               : ansi::bgc(reddk).fgx(0)        .add("█off "));
+                                //todo unify
+                                boss.set(hscheme.size() ? ansi::bgc(greendk).fgc(whitelt).add(" on █")
+                                                        : ansi::bgc(reddk).fgx(0)        .add("█off "));
                                 boss.base::reflow();
                             };
                         }
                     };
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                     {
-                        gear.set_hotkey_scheme(gear.meta(hids::HotkeyScheme) ? 0 : hids::HotkeyScheme);
+                        //todo unify
+                        if (gear.hscheme != ""sv)
+                        {
+                            gear.set_hotkey_scheme("");
+                        }
+                        else
+                        {
+                            gear.set_hotkey_scheme("1");
+                        }
                         gear.dismiss_dblclick();
                     };
                 });
@@ -748,8 +757,8 @@ namespace netxs::app::shared
                 {
                     if (gear.keystat != input::key::repeated) (*update_ptr)(items_inst, gear, true);
                 });
-                keybd.template bind<tier::release>( "Any", "UpdateChordPreview", 0);
-                keybd.template bind<tier::release>( "Any", "UpdateChordPreview", 1);
+                keybd.template bind<tier::release>( "Any", "UpdateChordPreview", "");
+                keybd.template bind<tier::release>( "Any", "UpdateChordPreview", "1");
             });
             inside->attach(slot::_2, ui::post::ctor())
                 ->limits({ -1, 1 })

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -281,15 +281,25 @@ namespace netxs::app::terminal
                     _submit<true>(boss, item, [](auto& /*boss*/, auto& /*item*/, auto& gear)
                     {
                         gear.set_handled();
-                        gear.set_hotkey_scheme(gear.meta(hids::HotkeyScheme) ? 0 : hids::HotkeyScheme);
+                        //todo unify
+                        if (gear.hscheme != ""sv)
+                        {
+                            gear.set_hotkey_scheme("");
+                        }
+                        else
+                        {
+                            gear.set_hotkey_scheme("1");
+                        }
                     });
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (hook_ptr = ptr::shared<hook>()))
                     {
                         if (auto focusable_parent = boss.base::riseup(tier::request, e2::config::plugins::focus::owner))
                         {
-                            focusable_parent->LISTEN(tier::release, e2::form::state::keybd::hotkey, state, (*hook_ptr))
+                            focusable_parent->LISTEN(tier::release, e2::form::state::keybd::scheme, hscheme, (*hook_ptr))
                             {
-                                _update_to(boss, item, state + 1);
+                                //todo unify
+                                auto s = hscheme.empty() ? 1 : 2;
+                                _update_to(boss, item, s);
                             };
                         }
                     };

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -115,10 +115,14 @@ namespace netxs::app::terminal
             gear.set_tooltip(look.tooltip, true);
             _update(boss, item);
         }
-        auto _update_to(ui::item& boss, menu::item& item, si32 i)
+        auto _update_to(ui::item& boss, menu::item& item, ui64 i)
         {
             item.select(i);
             _update(boss, item);
+        }
+        auto _update_to(ui::item& boss, menu::item& item, text utf8)
+        {
+            _update_to(boss, item, qiew::hash{}(utf8));
         }
         template<bool AutoUpdate = faux, class P>
         auto _submit(ui::item& boss, menu::item& item, P proc)
@@ -203,57 +207,51 @@ namespace netxs::app::terminal
                 { menu::type::Repeat,   menu::item::Repeat   }};
 
             #define proc_list \
-                X(Noop                      ) /* */ \
-                X(ToggleHotkeyScheme        ) /* */ \
-                X(TerminalQuit              ) /* */ \
-                X(TerminalCwdSync           ) /* */ \
-                X(TerminalToggleFullscreen  ) /* */ \
-                X(TerminalToggleMaximize    ) /* */ \
-                X(TerminalRestart           ) /* */ \
-                X(TerminalSendKey           ) /* */ \
-                X(TerminalWrapMode          ) /* */ \
-                X(TerminalAlignMode         ) /* */ \
-                X(TerminalOutput            ) /* */ \
-                X(TerminalFindNext          ) /* */ \
-                X(TerminalFindPrev          ) /* */ \
-                X(TerminalUndo              ) /* Undo/Redo for cooked read on win32 */ \
-                X(TerminalRedo              ) /* */ \
-                X(TerminalClipboardPaste    ) /* */ \
-                X(TerminalClipboardWipe     ) /* */ \
-                X(TerminalSelectionCopy     ) /* */ \
-                X(TerminalSelectionMode     ) /* */ \
-                X(TerminalSelectionRect     ) /* Linear/Rectangular */ \
-                X(TerminalSelectionCancel   ) /* */ \
-                X(TerminalSelectionOneShot  ) /* One-shot toggle to copy text while mouse tracking is active */ \
-                X(TerminalViewportPageUp    ) /* */ \
-                X(TerminalViewportPageDown  ) /* */ \
-                X(TerminalViewportLineUp    ) /* */ \
-                X(TerminalViewportLineDown  ) /* */ \
-                X(TerminalViewportPageLeft  ) /* */ \
-                X(TerminalViewportPageRight ) /* */ \
-                X(TerminalViewportCharLeft  ) /* */ \
-                X(TerminalViewportCharRight ) /* */ \
-                X(TerminalViewportTop       ) /* */ \
-                X(TerminalViewportEnd       ) /* */ \
-                X(TerminalViewportCopy      ) /* */ \
-                X(TerminalStdioLog          ) /* */ \
-                X(TerminalLogStart          ) /* */ \
-                X(TerminalLogPause          ) /* */ \
-                X(TerminalLogStop           ) /* */ \
-                X(TerminalLogAbort          ) /* */ \
-                X(TerminalLogRestart        ) /* */ \
-                X(TerminalVideoRecStart     ) /* */ \
-                X(TerminalVideoRecStop      ) /* */ \
-                X(TerminalVideoRecPause     ) /* */ \
-                X(TerminalVideoRecAbort     ) /* */ \
-                X(TerminalVideoRecRestart   ) /* */ \
-                X(TerminalVideoPlay         ) /* */ \
-                X(TerminalVideoPause        ) /* */ \
-                X(TerminalVideoStop         ) /* */ \
-                X(TerminalVideoForward      ) /* */ \
-                X(TerminalVideoBackward     ) /* */ \
-                X(TerminalVideoHome         ) /* */ \
-                X(TerminalVideoEnd          ) /* */
+                X(Noop                        ) /* */ \
+                X(SwitchHotkeyScheme          ) /* */ \
+                X(TerminalQuit                ) /* */ \
+                X(TerminalCwdSync             ) /* */ \
+                X(TerminalToggleFullscreen    ) /* */ \
+                X(TerminalToggleMaximize      ) /* */ \
+                X(TerminalRestart             ) /* */ \
+                X(TerminalSendKey             ) /* */ \
+                X(TerminalWrapMode            ) /* */ \
+                X(TerminalAlignMode           ) /* */ \
+                X(TerminalOutput              ) /* */ \
+                X(TerminalFindNext            ) /* */ \
+                X(TerminalFindPrev            ) /* */ \
+                X(TerminalUndo                ) /* Undo/Redo for cooked read on win32 */ \
+                X(TerminalRedo                ) /* */ \
+                X(TerminalClipboardPaste      ) /* */ \
+                X(TerminalClipboardWipe       ) /* */ \
+                X(TerminalSelectionCopy       ) /* */ \
+                X(TerminalSelectionMode       ) /* */ \
+                X(TerminalSelectionRect       ) /* Linear/Rectangular */ \
+                X(TerminalSelectionCancel     ) /* */ \
+                X(TerminalSelectionOneShot    ) /* One-shot toggle to copy text while mouse tracking is active */ \
+                X(TerminalScrollViewportByPage) /* */ \
+                X(TerminalScrollViewportByCell) /* */ \
+                X(TerminalScrollViewportToTop ) /* */ \
+                X(TerminalScrollViewportToEnd ) /* */ \
+                X(TerminalViewportCopy        ) /* */ \
+                X(TerminalStdioLog            ) /* */ \
+                X(TerminalLogStart            ) /* */ \
+                X(TerminalLogPause            ) /* */ \
+                X(TerminalLogStop             ) /* */ \
+                X(TerminalLogAbort            ) /* */ \
+                X(TerminalLogRestart          ) /* */ \
+                X(TerminalVideoRecStart       ) /* */ \
+                X(TerminalVideoRecStop        ) /* */ \
+                X(TerminalVideoRecPause       ) /* */ \
+                X(TerminalVideoRecAbort       ) /* */ \
+                X(TerminalVideoRecRestart     ) /* */ \
+                X(TerminalVideoPlay           ) /* */ \
+                X(TerminalVideoPause          ) /* */ \
+                X(TerminalVideoStop           ) /* */ \
+                X(TerminalVideoForward        ) /* */ \
+                X(TerminalVideoBackward       ) /* */ \
+                X(TerminalVideoHome           ) /* */ \
+                X(TerminalVideoEnd            ) /* */
 
             enum func
             {
@@ -275,21 +273,13 @@ namespace netxs::app::terminal
                 using release = terminal::events::release;
 
                 static void Noop(ui::item& /*boss*/, menu::item& /*item*/) { }
-                static void ToggleHotkeyScheme(ui::item& boss, menu::item& item)
+                static void SwitchHotkeyScheme(ui::item& boss, menu::item& item)
                 {
-                    item.reindex([](auto& utf8){ auto v = xml::take<bool>(utf8); return v ? v.value() + 1 : 0; });
-                    _submit<true>(boss, item, [](auto& /*boss*/, auto& /*item*/, auto& gear)
+                    item.reindex<text>([](auto& utf8){ return xml::take_or<text>(utf8, ""s); });
+                    _submit<true>(boss, item, [](auto& /*boss*/, auto& item, auto& gear)
                     {
                         gear.set_handled();
-                        //todo unify
-                        if (gear.hscheme != ""sv)
-                        {
-                            gear.set_hotkey_scheme("");
-                        }
-                        else
-                        {
-                            gear.set_hotkey_scheme("1");
-                        }
+                        gear.set_hotkey_scheme(item.views[item.taken].data);
                     });
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (hook_ptr = ptr::shared<hook>()))
                     {
@@ -297,9 +287,7 @@ namespace netxs::app::terminal
                         {
                             focusable_parent->LISTEN(tier::release, e2::form::state::keybd::scheme, hscheme, (*hook_ptr))
                             {
-                                //todo unify
-                                auto s = hscheme.empty() ? 1 : 2;
-                                _update_to(boss, item, s);
+                                _update_to(boss, item, hscheme);
                             };
                         }
                     };
@@ -356,14 +344,14 @@ namespace netxs::app::terminal
                 {
                     _submit<true>(boss, item, [](auto& boss, auto& item, auto& /*gear*/)
                     {
-                        boss.bell::signal(tier::anycast, terminal::events::data::in, view{ item.views[item.taken].param });
+                        boss.bell::signal(tier::anycast, terminal::events::data::in, view{ item.views[item.taken].data });
                     });
                 }
                 static void TerminalSendKey(ui::item& boss, menu::item& item)
                 {
                     _submit<true>(boss, item, [](auto& boss, auto& item, auto& /*gear*/)
                     {
-                        boss.bell::signal(tier::anycast, terminal::events::data::out, view{ item.views[item.taken].param });
+                        boss.bell::signal(tier::anycast, terminal::events::data::out, view{ item.views[item.taken].data });
                     });
                 }
                 static void TerminalQuit(ui::item& boss, menu::item& item)
@@ -479,78 +467,34 @@ namespace netxs::app::terminal
                         boss.bell::signal(tier::anycast, terminal::events::data::prnscrn, gear);
                     });
                 }
-                static void TerminalViewportPageUp(ui::item& boss, menu::item& item)
+                static void TerminalScrollViewportByPage(ui::item& boss, menu::item& item)
                 {
-                    _submit<true>(boss, item, [](auto& boss, auto& /*item*/, auto& /*gear*/)
-                    {
-                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bypage::y, { .vector = dot_01 });
-                    });
-                }
-                static void TerminalViewportPageDown(ui::item& boss, menu::item& item)
-                {
-                    _submit<true>(boss, item, [](auto& boss, auto& /*item*/, auto& /*gear*/)
-                    {
-                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bypage::y, { .vector = -dot_01 });
-                    });
-                }
-                static void TerminalViewportLineUp(ui::item& boss, menu::item& item)
-                {
-                    item.reindex([](auto& utf8){ auto v = xml::take<si32>(utf8); return v ? v.value() : 1; });
                     _submit<true>(boss, item, [](auto& boss, auto& item, auto& /*gear*/)
                     {
-                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bystep::y, { .vector = { 0, std::abs(item.views[item.taken].value) }});
+                        auto delta = xml::take_or<twod>(item.views[item.taken].data, dot_00);
+                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bypage::v, { .vector = delta });
                     });
                 }
-                static void TerminalViewportLineDown(ui::item& boss, menu::item& item)
+                static void TerminalScrollViewportByCell(ui::item& boss, menu::item& item)
                 {
-                    item.reindex([](auto& utf8){ auto v = xml::take<si32>(utf8); return v ? v.value() : 1; });
                     _submit<true>(boss, item, [](auto& boss, auto& item, auto& /*gear*/)
                     {
-                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bystep::y, { .vector = { 0, -std::abs(item.views[item.taken].value) }});
+                        auto delta = xml::take_or<twod>(item.views[item.taken].data, dot_00);
+                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bystep::v, { .vector = delta });
                     });
                 }
-                static void TerminalViewportTop(ui::item& boss, menu::item& item)
+                static void TerminalScrollViewportToTop(ui::item& boss, menu::item& item)
                 {
                     _submit<true>(boss, item, [](auto& boss, auto& /*item*/, auto& /*gear*/)
                     {
                         boss.bell::signal(tier::anycast, e2::form::upon::scroll::to_top::y);
                     });
                 }
-                static void TerminalViewportEnd(ui::item& boss, menu::item& item)
+                static void TerminalScrollViewportToEnd(ui::item& boss, menu::item& item)
                 {
                     _submit<true>(boss, item, [](auto& boss, auto& /*item*/, auto& /*gear*/)
                     {
                         boss.bell::signal(tier::anycast, e2::form::upon::scroll::to_end::y);
-                    });
-                }
-                static void TerminalViewportPageLeft(ui::item& boss, menu::item& item)
-                {
-                    _submit<true>(boss, item, [](auto& boss, auto& /*item*/, auto& /*gear*/)
-                    {
-                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bypage::x, { .vector = dot_10 });
-                    });
-                }
-                static void TerminalViewportPageRight(ui::item& boss, menu::item& item)
-                {
-                    _submit<true>(boss, item, [](auto& boss, auto& /*item*/, auto& /*gear*/)
-                    {
-                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bypage::x, { .vector = -dot_10 });
-                    });
-                }
-                static void TerminalViewportCharLeft(ui::item& boss, menu::item& item)
-                {
-                    item.reindex([](auto& utf8){ auto v = xml::take<si32>(utf8); return v ? v.value() : 1; });
-                    _submit<true>(boss, item, [](auto& boss, auto& item, auto& /*gear*/)
-                    {
-                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bystep::x, { .vector = { std::abs(item.views[item.taken].value), 0 }});
-                    });
-                }
-                static void TerminalViewportCharRight(ui::item& boss, menu::item& item)
-                {
-                    item.reindex([](auto& utf8){ auto v = xml::take<si32>(utf8); return v ? v.value() : 1; });
-                    _submit<true>(boss, item, [](auto& boss, auto& item, auto& /*gear*/)
-                    {
-                        boss.bell::signal(tier::anycast, e2::form::upon::scroll::bystep::x, { .vector = { -std::abs(item.views[item.taken].value), 0 }});
                     });
                 }
                 static void TerminalStdioLog(ui::item& boss, menu::item& item)
@@ -664,7 +608,7 @@ namespace netxs::app::terminal
                 auto route = data.take(menu::attr::route, func::Noop,          route_options);
                 item.brand = data.take(menu::attr::brand, menu::item::Command, brand_options);
                 defs.tooltip = data.take(menu::attr::tooltip, ""s);
-                defs.param = data.take(menu::attr::param, ""s);
+                defs.data = data.take(menu::attr::data, ""s);
                 item.alive = route != func::Noop && item.brand != menu::item::Splitter;
                 for (auto label : data.list(menu::attr::label))
                 {
@@ -672,7 +616,7 @@ namespace netxs::app::terminal
                     {
                         .label = label->take_value(),
                         .tooltip = label->take(menu::attr::tooltip, defs.tooltip),
-                        .param = label->take(menu::attr::param, defs.param),
+                        .data = label->take(menu::attr::data, defs.data),
                     });
                 }
                 if (item.views.empty()) continue; // Menu item without label.

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -114,7 +114,7 @@ namespace netxs::app::shared
     {
         auto& scroll_inst = *scroll;
         auto esc_pressed = ptr::shared(faux);
-        keybd.proc("WindowClose", [&, esc_pressed](hids& gear)
+        keybd.proc("WindowClose", [&, esc_pressed](hids& gear, txts&)
         {
             if (*esc_pressed)
             {
@@ -122,25 +122,25 @@ namespace netxs::app::shared
                 gear.set_handled(true);
             }
         });
-        keybd.proc("WindowClosePreview", [&, esc_pressed](hids& /*gear*/)
+        keybd.proc("WindowClosePreview", [&, esc_pressed](hids& /*gear*/, txts&)
         {
             if (std::exchange(*esc_pressed, true) != *esc_pressed) boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
         });
-        keybd.proc("CancelWindowClose", [&, esc_pressed](hids& /*gear*/)
+        keybd.proc("CancelWindowClose", [&, esc_pressed](hids& /*gear*/, txts&)
         {
             if (std::exchange(*esc_pressed, faux) != *esc_pressed) boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
         });
-        keybd.proc("ScrollPageUp"    , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
-        keybd.proc("ScrollPageDown"  , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
-        keybd.proc("ScrollLineUp"    , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 3 }}); });
-        keybd.proc("ScrollLineDown"  , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-3 }}); });
-        keybd.proc("ScrollCharLeft"  , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 3, 0 }}); });
-        keybd.proc("ScrollCharRight" , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-3, 0 }}); });
-        keybd.proc("ScrollTop"       , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
-        keybd.proc("ScrollEnd"       , [&](hids& /*gear*/){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
+        keybd.proc("ScrollPageUp"    , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
+        keybd.proc("ScrollPageDown"  , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
+        keybd.proc("ScrollLineUp"    , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 3 }}); });
+        keybd.proc("ScrollLineDown"  , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-3 }}); });
+        keybd.proc("ScrollCharLeft"  , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 3, 0 }}); });
+        keybd.proc("ScrollCharRight" , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-3, 0 }}); });
+        keybd.proc("ScrollTop"       , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
+        keybd.proc("ScrollEnd"       , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
         //todo use sptr for gear when enqueueing (dangling reference)
-        keybd.proc("ToggleMaximize"  , [&](hids& gear){ scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); }); // Refocus-related operations require execution outside of keyboard eves.
-        keybd.proc("ToggleFullscreen", [&](hids& gear){ scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); });
+        keybd.proc("ToggleMaximize"  , [&](hids& gear, txts&){ scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); }); // Refocus-related operations require execution outside of keyboard eves.
+        keybd.proc("ToggleFullscreen", [&](hids& gear, txts&){ scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); });
         auto binding = [&](qiew scheme)
         {
             keybd.template bind<tier::preview>( "Esc", scheme, "DropAutoRepeat"    );

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -162,7 +162,7 @@ namespace netxs::app::shared
             keybd.bind("F12"       , "DropAutoRepeat"  , mode);
             keybd.bind("F12"       , "ToggleFullscreen", mode);
         };
-        binding(0);
+        binding(""s);
     };
 
     using builder_t = std::function<ui::sptr(eccc, xmls&)>;
@@ -662,7 +662,7 @@ namespace netxs::app::shared
         twod gridsize{};
         si32 cellsize{};
         std::list<text> fontlist;
-        std::list<std::tuple<text, std::vector<text>, si32>> hotkeys;
+        std::list<std::tuple<text, std::vector<text>, text>> hotkeys;
     };
 
     auto get_gui_config(xmls& config)
@@ -686,8 +686,7 @@ namespace netxs::app::shared
         {
             auto& keybind = *keybind_ptr;
             auto chord = keybind.take_value();
-            auto scheme = keybind.take("scheme", 0); //todo use text instead of si32 as a scheme identifier
-            auto action = keybind.take("action", ""s);
+            auto scheme = keybind.take("scheme", ""s); //todo use text instead of si32 as a scheme identifier
             auto action_list = std::vector<text>{};
             auto action_ptr_list = keybind.list("action");
             for (auto action_ptr : action_ptr_list)

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.48";
+    static const auto version = "v0.9.99.49";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -433,7 +433,7 @@ namespace netxs::events::userland
                         EVENT_XS( find    , ui::focus_test_t   ), // request: Check the focus.
                         EVENT_XS( next    , ui::focus_test_t   ), // request: Next hop count.
                         EVENT_XS( check   , bool               ), // anycast: Check any focus.
-                        EVENT_XS( hotkey  , si32               ), // release: Hotkey scheme index.
+                        EVENT_XS( scheme  , text               ), // release: Hotkey scheme id.
                         GROUP_XS( command , si32               ), // release: Hotkey command preview.
 
                         SUBSET_XS( command )

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2716,6 +2716,12 @@ namespace netxs
             canvas.resize(new_size_x, c);
             digest++;
         }
+        auto crop(si32 at, si32 length) const // core: Return 1D fragment.
+        {
+            auto fragment = core{ span{ canvas.begin() + at, canvas.begin() + at + length }, twod{ length, 1 } };
+            fragment.marker = marker;
+            return fragment;
+        }
         void push(cell const& c) // core: Push cell back.
         {
             crop(region.size.x + 1, c);

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1128,7 +1128,11 @@ namespace netxs::ui
                     gear.set_hotkey_scheme("1");
                 }
             });
-            keybd.load<tier::preview>(config, "/config/hotkeys/tui/key");
+            auto bindings = keybd.load(config, "tui");
+            for (auto& r : bindings)
+            {
+                keybd.bind<tier::preview>(r.chord, r.scheme, r.actions);
+            }
 
             base::root(true);
             base::limits(dot_11);

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1115,18 +1115,11 @@ namespace netxs::ui
               fullscreen{ faux }
         {
             keybd.proc("ToggleDebugOverlay", [&](hids& gear, txts&){ gear.set_handled(); debug ? debug.stop() : debug.start(); });
-            keybd.proc("ToggleHotkeyScheme", [&](hids& gear, txts&)
+            keybd.proc("SwitchHotkeyScheme", [&](hids& gear, txts& args)
             {
                 gear.set_handled();
-                //todo unify
-                if (gear.hscheme != ""sv)
-                {
-                    gear.set_hotkey_scheme("");
-                }
-                else
-                {
-                    gear.set_hotkey_scheme("1");
-                }
+                if (args.empty()) gear.set_hotkey_scheme("");
+                else              gear.set_hotkey_scheme(args.front());
             });
             auto bindings = keybd.load(config, "tui");
             for (auto& r : bindings)

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1114,8 +1114,8 @@ namespace netxs::ui
               yield{ faux },
               fullscreen{ faux }
         {
-            keybd.proc("ToggleDebugOverlay", [&](hids& gear){ gear.set_handled(); debug ? debug.stop() : debug.start(); });
-            keybd.proc("ToggleHotkeyScheme", [&](hids& gear)
+            keybd.proc("ToggleDebugOverlay", [&](hids& gear, txts&){ gear.set_handled(); debug ? debug.stop() : debug.start(); });
+            keybd.proc("ToggleHotkeyScheme", [&](hids& gear, txts&)
             {
                 gear.set_handled();
                 //todo unify

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1115,7 +1115,19 @@ namespace netxs::ui
               fullscreen{ faux }
         {
             keybd.proc("ToggleDebugOverlay", [&](hids& gear){ gear.set_handled(); debug ? debug.stop() : debug.start(); });
-            keybd.proc("ToggleHotkeyScheme", [&](hids& gear){ gear.set_handled(); gear.set_hotkey_scheme(gear.meta(hids::HotkeyScheme) ? 0 : hids::HotkeyScheme); });
+            keybd.proc("ToggleHotkeyScheme", [&](hids& gear)
+            {
+                gear.set_handled();
+                //todo unify
+                if (gear.hscheme != ""sv)
+                {
+                    gear.set_hotkey_scheme("");
+                }
+                else
+                {
+                    gear.set_hotkey_scheme("1");
+                }
+            });
             keybd.load<tier::preview>(config, "/config/hotkeys/tui/key");
 
             base::root(true);
@@ -1146,7 +1158,7 @@ namespace netxs::ui
             {
                 auto [ext_gear_id, gear_ptr] = input.get_foreign_gear_id(gear.id);
                 if (!gear_ptr) return;
-                conio.hotkey_scheme.send(canal, ext_gear_id, gear.meta(hids::HotkeyScheme));
+                conio.hotkey_scheme.send(canal, ext_gear_id, gear.hscheme);
             };
             //todo mimic pro::focus
             //if (standalone)
@@ -1156,15 +1168,15 @@ namespace netxs::ui
                     owner_ptr = This();
                 };
             }
-            LISTEN(tier::preview, hids::events::keybd::key::post, gear, tokens, (hotkey = 0)) // Start of kb event propagation.
+            LISTEN(tier::preview, hids::events::keybd::key::post, gear, tokens, (hscheme = text{})) // Start of kb event propagation.
             {
                 //if (standalone)
                 {
                     //todo mimic pro::focus
-                    auto m = gear.meta(hids::HotkeyScheme) >> 28; //std::countr_zero(hids::HotkeyScheme); //todo MSVC doesn't get it
-                    if (std::exchange(hotkey, m) != hotkey)
+                    if (hscheme != gear.hscheme)
                     {
-                        bell::signal(tier::release, e2::form::state::keybd::hotkey, m);
+                        hscheme = gear.hscheme;
+                        bell::signal(tier::release, e2::form::state::keybd::scheme, hscheme);
                     }
                 }
                 if (gear)

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2115,7 +2115,8 @@ namespace netxs::ui
                         auto chord = keybind_ptr->take_value();
                         auto scheme = keybind_ptr->take("scheme", ""s);
                         auto action_ptr_list = keybind_ptr->list("action");
-                        auto& rec = bindings.emplace_back(chord, scheme);
+                        bindings.push_back({ .chord = chord, .scheme = scheme });
+                        auto& rec = bindings.back();
                         if constexpr (debugmode) log("chord=%% scheme=%%", chord, scheme);
                         for (auto action_ptr : action_ptr_list)
                         {

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -861,7 +861,7 @@ namespace netxs::directvt
                                         (si32, whlsi)
                                         (bool, hzwhl)
                                         (fp2d, click))
-        STRUCT_macro(hotkey_scheme,     (id_t, gear_id) (si32, index))
+        STRUCT_macro(hotkey_scheme,     (id_t, gear_id) (text, hscheme))
         STRUCT_macro(fullscrn,          (id_t, gear_id))
         STRUCT_macro(maximize,          (id_t, gear_id))
         STRUCT_macro(header,            (id_t, window_id) (text, utf8))
@@ -894,7 +894,8 @@ namespace netxs::directvt
                                         (si32, keycode)  // syskeybd: Key id.
                                         (text, vkchord)  // sysmouse: Key virtcode-based chord.
                                         (text, scchord)  // sysmouse: Key scancode-based chord.
-                                        (text, chchord)) // sysmouse: Key virtcode+cluster-based chord.
+                                        (text, chchord)  // sysmouse: Key virtcode+cluster-based chord.
+                                        (text, hscheme)) // sysmouse: Current hotkey scheme.
         STRUCT_macro(sysmouse,          (id_t, gear_id)  // sysmouse: Devide id.
                                         (si32, ctlstat)  // sysmouse: Keybd modifiers.
                                         (si32, enabled)  // sysmouse: Mouse device health status.

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1971,7 +1971,7 @@ namespace netxs::gui
         text  scheme; // winbase: Current hotkey scheme.
         bool  drykey; // winbase: Hotkey scheme should be sent as soon as possible.
 
-        winbase(auth& indexer, std::list<text>& font_names, si32 cell_height, bool antialiasing, span blink_rate, twod grip_cell, std::list<std::tuple<text, std::vector<text>, text>>& hotkeys)
+        winbase(auth& indexer, std::list<text>& font_names, si32 cell_height, bool antialiasing, span blink_rate, twod grip_cell, input::key::keybind_list_t& hotkeys)
             : base{ indexer },
               titles{ *this, "", "", faux },
               wfocus{ *this, ui::pro::focus::mode::relay },
@@ -2011,11 +2011,12 @@ namespace netxs::gui
             wkeybd.proc("RollFontsBackward"     , [&](hids& gear){ gear.set_handled(); RollFontList(feed::rev);  });
             wkeybd.proc("RollFontsForward"      , [&](hids& gear){ gear.set_handled(); RollFontList(feed::fwd);  });
             wkeybd.proc("_ResetWheelAccumulator", [&](hids& /*gear*/){ whlacc = {}; });
-            wkeybd.bind<tier::preview>("-Ctrl", "_ResetWheelAccumulator", "");
-            wkeybd.bind<tier::preview>("-Ctrl", "_ResetWheelAccumulator", "1");
-            for (auto& [chord, action_list, hotkey_scheme] : hotkeys)
+            //todo use scheme="*"
+            wkeybd.bind<tier::preview>("-Ctrl", "" , "_ResetWheelAccumulator");
+            wkeybd.bind<tier::preview>("-Ctrl", "1", "_ResetWheelAccumulator");
+            for (auto& r : hotkeys)
             {
-                wkeybd.bind<tier::preview>(chord, action_list, hotkey_scheme);
+                wkeybd.bind<tier::preview>(r.chord, r.scheme, r.actions);
             }
         }
 

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2003,14 +2003,14 @@ namespace netxs::gui
               stream{ *this, *os::dtvt::client },
               drykey{ faux }
         {
-            wkeybd.proc("IncreaseCellHeight"    , [&](hids& gear){ gear.set_handled(); IncreaseCellHeight(1.f); });
-            wkeybd.proc("DecreaseCellHeight"    , [&](hids& gear){ gear.set_handled(); IncreaseCellHeight(-1.f);});
-            wkeybd.proc("ResetCellHeight"       , [&](hids& gear){ gear.set_handled(); ResetCellHeight();        });
-            wkeybd.proc("ToggleFullscreenMode"  , [&](hids& gear){ gear.set_handled(); ToggleFullscreenMode();   });
-            wkeybd.proc("ToggleAntialiasingMode", [&](hids& gear){ gear.set_handled(); ToggleAntialiasingMode(); });
-            wkeybd.proc("RollFontsBackward"     , [&](hids& gear){ gear.set_handled(); RollFontList(feed::rev);  });
-            wkeybd.proc("RollFontsForward"      , [&](hids& gear){ gear.set_handled(); RollFontList(feed::fwd);  });
-            wkeybd.proc("_ResetWheelAccumulator", [&](hids& /*gear*/){ whlacc = {}; });
+            wkeybd.proc("IncreaseCellHeight"    , [&](hids& gear, txts&){ gear.set_handled(); IncreaseCellHeight(1.f); });
+            wkeybd.proc("DecreaseCellHeight"    , [&](hids& gear, txts&){ gear.set_handled(); IncreaseCellHeight(-1.f);});
+            wkeybd.proc("ResetCellHeight"       , [&](hids& gear, txts&){ gear.set_handled(); ResetCellHeight();        });
+            wkeybd.proc("ToggleFullscreenMode"  , [&](hids& gear, txts&){ gear.set_handled(); ToggleFullscreenMode();   });
+            wkeybd.proc("ToggleAntialiasingMode", [&](hids& gear, txts&){ gear.set_handled(); ToggleAntialiasingMode(); });
+            wkeybd.proc("RollFontsBackward"     , [&](hids& gear, txts&){ gear.set_handled(); RollFontList(feed::rev);  });
+            wkeybd.proc("RollFontsForward"      , [&](hids& gear, txts&){ gear.set_handled(); RollFontList(feed::fwd);  });
+            wkeybd.proc("_ResetWheelAccumulator", [&](hids& /*gear*/, txts&){ whlacc = {}; });
             //todo use scheme="*"
             wkeybd.bind<tier::preview>("-Ctrl", "" , "_ResetWheelAccumulator");
             wkeybd.bind<tier::preview>("-Ctrl", "1", "_ResetWheelAccumulator");

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -703,6 +703,14 @@ namespace netxs::input
             }
         };
 
+        struct keybind_t
+        {
+            text chord;
+            text scheme;
+            std::vector<text> actions;
+        };
+        using keybind_list_t = std::vector<keybind_t>;
+
         template<class ...Args>
         auto xlat(Args&&... args)
         {

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -705,9 +705,14 @@ namespace netxs::input
 
         struct keybind_t
         {
+            struct action_t
+            {
+                text action;
+                txts args;
+            };
             text chord;
             text scheme;
-            std::vector<text> actions;
+            std::vector<action_t> actions;
         };
         using keybind_list_t = std::vector<keybind_t>;
 

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1171,6 +1171,7 @@ namespace netxs::input
         text vkchord{};
         text scchord{};
         text chchord{};
+        text hscheme{};
 
         auto doinput()
         {
@@ -1365,7 +1366,6 @@ namespace netxs::input
             NumLock      = 1 << 12, // ⇭ Num Lock
             CapsLock     = 1 << 13, // ⇪ Caps Lock
             ScrlLock     = 1 << 14, // ⇳ Scroll Lock (⤓)
-            HotkeyScheme = 1 << 28, // Hotkey scheme
             AltGr        = LAlt   | LCtrl,
             anyCtrl      = LCtrl  | RCtrl,
             anyAlt       = LAlt   | RAlt,
@@ -1654,12 +1654,10 @@ namespace netxs::input
         {
             handled = b;
         }
-        void set_hotkey_scheme(si32 s)
+        void set_hotkey_scheme(qiew scheme)
         {
-            auto temp = keybd::ctlstat;
-            netxs::set_flag<hids::HotkeyScheme>(keybd::ctlstat, s);
+            keybd::hscheme = scheme;
             owner.bell::signal(tier::preview, hids::events::keybd::scheme, *this);
-            keybd::ctlstat = temp;
         }
 
         void take(sysfocus& f)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7716,18 +7716,12 @@ namespace netxs::ui
             publish_property(ui::term::events::search::status, [&](auto& v){ v = target->selection_button(); });
             selection_selmod(config.def_selmod);
 
+            chords.proc("TerminalScrollViewportByPage", [&](hids& gear, txts& args){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::v, { .vector = args.size() ? xml::take_or<twod>(args.front(), dot_00) : dot_00 }); });
+            chords.proc("TerminalScrollViewportByCell", [&](hids& gear, txts& args){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::v, { .vector = args.size() ? xml::take_or<twod>(args.front(), dot_00) : dot_00 }); });
+            chords.proc("TerminalScrollViewportToTop",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
+            chords.proc("TerminalScrollViewportToEnd",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
             chords.proc("TerminalFindPrev",             [&](hids& gear, txts&){ gear.set_handled(); selection_search(gear, feed::rev); });
             chords.proc("TerminalFindNext",             [&](hids& gear, txts&){ gear.set_handled(); selection_search(gear, feed::fwd); });
-            chords.proc("TerminalViewportOnePageLeft",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = { 1, 0 }}); });
-            chords.proc("TerminalViewportOnePageRight", [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = {-1, 0 }}); });
-            chords.proc("TerminalViewportOneCharLeft",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 1, 0 }}); });
-            chords.proc("TerminalViewportOneCharRight", [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-1, 0 }}); });
-            chords.proc("TerminalViewportOneCharUp",    [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 1 }}); });
-            chords.proc("TerminalViewportOneCharDown",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-1 }}); });
-            chords.proc("TerminalViewportOnePageUp",    [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
-            chords.proc("TerminalViewportOnePageDown",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
-            chords.proc("TerminalViewportTop",          [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
-            chords.proc("TerminalViewportEnd",          [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
             chords.proc("TerminalSelectionCancel",      [&](hids& gear, txts&){ if (!selection_active()) return; gear.set_handled(); exec_cmd(commands::ui::deselect); });
             chords.proc("TerminalToggleCwdSync",        [&](hids& gear, txts&){ gear.set_handled(); base::riseup(tier::preview, ui::term::events::toggle::cwdsync, true); });
             chords.proc("TerminalToggleWrapMode",       [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::togglewrp); });
@@ -7803,7 +7797,7 @@ namespace netxs::ui
                     origin = new_area.coor;
                 }
             };
-            LISTEN(tier::release, hids::events::keybd::key::post, gear)
+            LISTEN(tier::release, hids::events::keybd::key::any, gear)
             {
                 switch (gear.payload)
                 {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7746,7 +7746,11 @@ namespace netxs::ui
             chords.proc("TerminalSelectionOneShot",     [&](hids& gear){ gear.set_handled(); set_oneshot(mime::textonly);       });
             chords.proc("TerminalViewportCopy",         [&](hids& gear){ gear.set_handled(); prnscrn(gear);                     });
             chords.proc("TerminalToggleStdioLog",       [&](hids& gear){ gear.set_handled(); set_log(!io_log); ondata<true>();  });
-            chords.load<tier::release>(xml_config, "/config/hotkeys/term/key");
+            auto bindings = chords.load(xml_config, "term");
+            for (auto& r : bindings)
+            {
+                chords.bind<tier::release>(r.chord, r.scheme, r.actions);
+            }
 
             LISTEN(tier::general, e2::timer::tick, timestamp) // Update before world rendering.
             {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -430,10 +430,10 @@ namespace netxs::ui
         // term: Terminal title tracking functionality.
         struct w_tracking
         {
-            term&                             owner; // w_tracking: Terminal object reference.
-            std::map<text, text>              props;
-            std::map<text, std::vector<text>> stack;
-            escx                              queue;
+            term&                owner; // w_tracking: Terminal object reference.
+            std::map<text, text> props;
+            std::map<text, txts> stack;
+            escx                 queue;
 
             w_tracking(term& owner)
                 : owner{ owner }
@@ -7716,36 +7716,36 @@ namespace netxs::ui
             publish_property(ui::term::events::search::status, [&](auto& v){ v = target->selection_button(); });
             selection_selmod(config.def_selmod);
 
-            chords.proc("TerminalFindPrev",             [&](hids& gear){ gear.set_handled(); selection_search(gear, feed::rev); });
-            chords.proc("TerminalFindNext",             [&](hids& gear){ gear.set_handled(); selection_search(gear, feed::fwd); });
-            chords.proc("TerminalViewportOnePageLeft",  [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = { 1, 0 }}); });
-            chords.proc("TerminalViewportOnePageRight", [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = {-1, 0 }}); });
-            chords.proc("TerminalViewportOneCharLeft",  [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 1, 0 }}); });
-            chords.proc("TerminalViewportOneCharRight", [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-1, 0 }}); });
-            chords.proc("TerminalViewportOneCharUp",    [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 1 }}); });
-            chords.proc("TerminalViewportOneCharDown",  [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-1 }}); });
-            chords.proc("TerminalViewportOnePageUp",    [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
-            chords.proc("TerminalViewportOnePageDown",  [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
-            chords.proc("TerminalViewportTop",          [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
-            chords.proc("TerminalViewportEnd",          [&](hids& gear){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
-            chords.proc("TerminalSelectionCancel",      [&](hids& gear){ if (!selection_active()) return; gear.set_handled(); exec_cmd(commands::ui::deselect); });
-            chords.proc("TerminalToggleCwdSync",        [&](hids& gear){ gear.set_handled(); base::riseup(tier::preview, ui::term::events::toggle::cwdsync, true); });
-            chords.proc("TerminalToggleWrapMode",       [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::togglewrp); });
-            chords.proc("TerminalQuit",                 [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::sighup);    });
-            chords.proc("TerminalRestart",              [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::restart);   });
+            chords.proc("TerminalFindPrev",             [&](hids& gear, txts&){ gear.set_handled(); selection_search(gear, feed::rev); });
+            chords.proc("TerminalFindNext",             [&](hids& gear, txts&){ gear.set_handled(); selection_search(gear, feed::fwd); });
+            chords.proc("TerminalViewportOnePageLeft",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = { 1, 0 }}); });
+            chords.proc("TerminalViewportOnePageRight", [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::x, { .vector = {-1, 0 }}); });
+            chords.proc("TerminalViewportOneCharLeft",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 1, 0 }}); });
+            chords.proc("TerminalViewportOneCharRight", [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-1, 0 }}); });
+            chords.proc("TerminalViewportOneCharUp",    [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 1 }}); });
+            chords.proc("TerminalViewportOneCharDown",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-1 }}); });
+            chords.proc("TerminalViewportOnePageUp",    [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
+            chords.proc("TerminalViewportOnePageDown",  [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
+            chords.proc("TerminalViewportTop",          [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
+            chords.proc("TerminalViewportEnd",          [&](hids& gear, txts&){ if (target != &normal) return; gear.set_handled(); base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
+            chords.proc("TerminalSelectionCancel",      [&](hids& gear, txts&){ if (!selection_active()) return; gear.set_handled(); exec_cmd(commands::ui::deselect); });
+            chords.proc("TerminalToggleCwdSync",        [&](hids& gear, txts&){ gear.set_handled(); base::riseup(tier::preview, ui::term::events::toggle::cwdsync, true); });
+            chords.proc("TerminalToggleWrapMode",       [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::togglewrp); });
+            chords.proc("TerminalQuit",                 [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::sighup);    });
+            chords.proc("TerminalRestart",              [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::restart);   });
             //todo use wptr for gear when enqueueing
-            chords.proc("TerminalToggleFullscreen",     [&](hids& gear){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); }); // Refocus-related operations require execution outside of keyboard events.
-            chords.proc("TerminalToggleMaximize",       [&](hids& gear){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); });
-            chords.proc("TerminalUndo",                 [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::undo);      });
-            chords.proc("TerminalRedo",                 [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::redo);      });
-            chords.proc("TerminalClipboardPaste",       [&](hids& gear){ gear.set_handled(); paste(gear);                       });
-            chords.proc("TerminalClipboardWipe",        [&](hids& gear){ gear.set_handled(); gear.clear_clipboard();            });
-            chords.proc("TerminalSwitchCopyMode",       [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::togglesel); });
-            chords.proc("TerminalSelectionCopy",        [&](hids& gear){ gear.set_handled(); copy(gear);                        });
-            chords.proc("TerminalToggleSelectionMode",  [&](hids& gear){ gear.set_handled(); exec_cmd(commands::ui::toggleselalt); });
-            chords.proc("TerminalSelectionOneShot",     [&](hids& gear){ gear.set_handled(); set_oneshot(mime::textonly);       });
-            chords.proc("TerminalViewportCopy",         [&](hids& gear){ gear.set_handled(); prnscrn(gear);                     });
-            chords.proc("TerminalToggleStdioLog",       [&](hids& gear){ gear.set_handled(); set_log(!io_log); ondata<true>();  });
+            chords.proc("TerminalToggleFullscreen",     [&](hids& gear, txts&){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); }); // Refocus-related operations require execution outside of keyboard events.
+            chords.proc("TerminalToggleMaximize",       [&](hids& gear, txts&){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); });
+            chords.proc("TerminalUndo",                 [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::undo);      });
+            chords.proc("TerminalRedo",                 [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::redo);      });
+            chords.proc("TerminalClipboardPaste",       [&](hids& gear, txts&){ gear.set_handled(); paste(gear);                       });
+            chords.proc("TerminalClipboardWipe",        [&](hids& gear, txts&){ gear.set_handled(); gear.clear_clipboard();            });
+            chords.proc("TerminalSwitchCopyMode",       [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::togglesel); });
+            chords.proc("TerminalSelectionCopy",        [&](hids& gear, txts&){ gear.set_handled(); copy(gear);                        });
+            chords.proc("TerminalToggleSelectionMode",  [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::toggleselalt); });
+            chords.proc("TerminalSelectionOneShot",     [&](hids& gear, txts&){ gear.set_handled(); set_oneshot(mime::textonly);       });
+            chords.proc("TerminalViewportCopy",         [&](hids& gear, txts&){ gear.set_handled(); prnscrn(gear);                     });
+            chords.proc("TerminalToggleStdioLog",       [&](hids& gear, txts&){ gear.set_handled(); set_log(!io_log); ondata<true>();  });
             auto bindings = chords.load(xml_config, "term");
             for (auto& r : bindings)
             {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -8041,7 +8041,7 @@ namespace netxs::ui
                     auto guard = owner.sync();
                     if (auto gear_ptr = owner.bell::getref<hids>(k.gear_id))
                     {
-                        gear_ptr->set_hotkey_scheme(k.index);
+                        gear_ptr->set_hotkey_scheme(k.hscheme);
                     }
                 }
             }

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -27,6 +27,7 @@ namespace netxs
     using wchr = wchar_t;
     using flux = std::stringstream;
     using utfx = uint32_t;
+    using txts = std::vector<text>;
     using namespace std::literals;
 
     static constexpr auto whitespaces = " \n\r\t"sv;

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -178,6 +178,18 @@ namespace netxs::xml
         }
         return std::nullopt;
     }
+    template<class T>
+    auto take_or(qiew utf8, T fallback)
+    {
+        if (auto v = take<T>(utf8))
+        {
+            return v.value();
+        }
+        else
+        {
+            return fallback;
+        }
+    }
 
     struct document
     {
@@ -542,8 +554,7 @@ namespace netxs::xml
                     if (item_set.size()) // Take the first item only.
                     {
                         auto crop = item_set.front()->take_value();
-                        if (auto result = xml::take<T>(crop)) return result.value();
-                        else                                  return fallback;
+                        return xml::take_or<T>(crop, fallback);
                     }
                 }
                 if (auto defs_ptr = defs.lock()) return defs_ptr->take(attr, fallback);

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -734,10 +734,10 @@ namespace netxs::app::vtm
         {
             //todo local=>nexthop
             local = faux;
-            keybd.proc("FocusPrevWindow", [&](hids& gear){ focus_next_window(gear, feed::rev); });
-            keybd.proc("FocusNextWindow", [&](hids& gear){ focus_next_window(gear, feed::fwd); });
-            keybd.proc("Disconnect",      [&](hids& gear){ disconnect(gear); });
-            keybd.proc("TryToQuit",       [&](hids& gear){ try_quit(gear); });
+            keybd.proc("FocusPrevWindow", [&](hids& gear, txts&){ focus_next_window(gear, feed::rev); });
+            keybd.proc("FocusNextWindow", [&](hids& gear, txts&){ focus_next_window(gear, feed::fwd); });
+            keybd.proc("Disconnect",      [&](hids& gear, txts&){ disconnect(gear); });
+            keybd.proc("TryToQuit",       [&](hids& gear, txts&){ try_quit(gear); });
             auto bindings = keybd.load(config, "desktop");
             for (auto& r : bindings)
             {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -738,7 +738,11 @@ namespace netxs::app::vtm
             keybd.proc("FocusNextWindow", [&](hids& gear){ focus_next_window(gear, feed::fwd); });
             keybd.proc("Disconnect",      [&](hids& gear){ disconnect(gear); });
             keybd.proc("TryToQuit",       [&](hids& gear){ try_quit(gear); });
-            keybd.load<tier::preview>(config, "/config/hotkeys/desktop/key");
+            auto bindings = keybd.load(config, "desktop");
+            for (auto& r : bindings)
+            {
+                keybd.bind<tier::preview>(r.chord, r.scheme, r.actions);
+            }
 
             LISTEN(tier::release, e2::form::upon::vtree::attached, world_ptr, tokens)
             {

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -413,10 +413,10 @@ R"==(
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
             <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
             <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (reversed release order). -->
-            <key="Ctrl-Alt"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to 1 by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to 1 by pressing and releasing Alt-Ctrl (reversed releasing). -->
-            <key="Ctrl-Alt" scheme=1     action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to 0 (default) by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl" scheme=1     action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to 0 (default) by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Ctrl-Alt"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Ctrl-Alt" scheme="1"   action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt. -->
+            <key="Alt-Ctrl" scheme="1"   action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to default by pressing and releasing Alt-Ctrl (reversed releasing). -->
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"           action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
@@ -426,18 +426,18 @@ R"==(
             <!-- <key="Ctrl+N"    action="Start(\"Term\")"/> -->
         </desktop>
         <term key*>  <!-- Application specific layer key bindings. -->
-            <key="Alt+RightArrow"         action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Alt+LeftArrow"          action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Shift+Ctrl+PageUp"      action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Shift+Ctrl+PageDown"    action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Ctrl+PageUp"   scheme=1 action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Ctrl+PageDown" scheme=1 action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Shift+Alt+LeftArrow"    action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
-            <key="Shift+Alt+RightArrow"   action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
-            <key="Shift+Ctrl+UpArrow"     action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
-            <key="Shift+Ctrl+DownArrow"   action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
-            <key="Shift+Ctrl+LeftArrow"   action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
-            <key="Shift+Ctrl+RightArrow"  action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
+            <key="Alt+RightArrow"           action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Alt+LeftArrow"            action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Shift+Ctrl+PageUp"        action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
+            <key="Shift+Ctrl+PageDown"      action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
+            <key="Ctrl+PageUp"   scheme="1" action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
+            <key="Ctrl+PageDown" scheme="1" action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
+            <key="Shift+Alt+LeftArrow"      action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
+            <key="Shift+Alt+RightArrow"     action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
+            <key="Shift+Ctrl+UpArrow"       action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
+            <key="Shift+Ctrl+DownArrow"     action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
+            <key="Shift+Ctrl+LeftArrow"     action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
+            <key="Shift+Ctrl+RightArrow"    action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
             <key="Shift+Ctrl+Home">
                 <action=DropAutoRepeat/>       <!-- Don't autorepeat the Scroll to the scrollback top. -->
                 <action=TerminalViewportTop/>  <!-- Scroll to the scrollback top. -->
@@ -446,23 +446,23 @@ R"==(
                 <action=DropAutoRepeat/>       <!-- Don't autorepeat the Scroll to the scrollback bottom (reset viewport position). -->
                 <action=TerminalViewportEnd/>  <!-- Scroll to the scrollback bottom (reset viewport position). -->
             </key>
-            <key=""                       action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
-            <key=""                       action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
-            <key=""                       action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->
-            <key=""                       action=TerminalUndo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input. -->
-            <key=""                       action=TerminalRedo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command. -->
-            <key=""                       action=TerminalToggleCwdSync/>             <!-- Toggle the current working directory sync mode. -->
-            <key=""                       action=TerminalToggleWrapMode/>            <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. -->
-            <key=""                       action=TerminalToggleSelectionMode/>       <!-- Toggle between linear and rectangular selection form. -->
-            <key=""                       action=TerminalToggleFullscreen/>          <!-- Toggle fullscreen mode. -->
-            <key=""                       action=TerminalToggleMaximize/>            <!-- Toggle between maximized and normal window size. -->
-            <key=""                       action=TerminalToggleStdioLog/>            <!-- Stdin/stdout log toggle. -->
-            <key=""                       action=TerminalQuit/>                      <!-- Terminate runnning console apps and close terminal. -->
-            <key=""                       action=TerminalRestart/>                   <!-- Terminate runnning console apps and restart current session. -->
-            <key=""                       action=TerminalSwitchCopyMode/>            <!-- Switch terminal text selection copy mode. -->
-            <key=""                       action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
-            <key="Esc"                    action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
-            <key=""                       action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. -->
+            <key=""                         action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
+            <key=""                         action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->
+            <key=""                         action=TerminalClipboardWipe/>             <!-- Reset clipboard. -->
+            <key=""                         action=TerminalUndo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input. -->
+            <key=""                         action=TerminalRedo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command. -->
+            <key=""                         action=TerminalToggleCwdSync/>             <!-- Toggle the current working directory sync mode. -->
+            <key=""                         action=TerminalToggleWrapMode/>            <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. -->
+            <key=""                         action=TerminalToggleSelectionMode/>       <!-- Toggle between linear and rectangular selection form. -->
+            <key=""                         action=TerminalToggleFullscreen/>          <!-- Toggle fullscreen mode. -->
+            <key=""                         action=TerminalToggleMaximize/>            <!-- Toggle between maximized and normal window size. -->
+            <key=""                         action=TerminalToggleStdioLog/>            <!-- Stdin/stdout log toggle. -->
+            <key=""                         action=TerminalQuit/>                      <!-- Terminate runnning console apps and close terminal. -->
+            <key=""                         action=TerminalRestart/>                   <!-- Terminate runnning console apps and restart current session. -->
+            <key=""                         action=TerminalSwitchCopyMode/>            <!-- Switch terminal text selection copy mode. -->
+            <key=""                         action=TerminalSelectionCopy/>             <!-- Сopy selection to clipboard. -->
+            <key="Esc"                      action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
+            <key=""                         action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. -->
         </term>
     </hotkeys>
 </config>)=="

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -322,10 +322,8 @@ R"==(
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Command" action=ToggleHotkeyScheme>
-                <label=" Undef " data="undef"/>
-                <label=" Keys0 " data="off"/>
-                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="on"/>
+            <item type="Option" action=SwitchHotkeyScheme label=" Keys0 " data="">
+                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="1"/>
                 <tooltip>
                     " Toggle hotkey scheme                          \n"
                     "   Alternative hotkey scheme allows keystrokes \n"
@@ -412,40 +410,35 @@ R"==(
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
             <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Ctrl-Alt | Alt-Ctrl" scheme="">
-                <action=ToggleHotkeyScheme arg="1"/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            </key>
-            <key="Ctrl-Alt | Alt-Ctrl" scheme="1">
-                <action=ToggleHotkeyScheme arg=""/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            </key>
+            <key="Ctrl-Alt | Alt-Ctrl" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            <key="Ctrl-Alt | Alt-Ctrl" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
-            <key="Ctrl+PageUp"           action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
-            <key="Ctrl+PageDown"         action=FocusNextWindow/>  <!-- Switch focus to the previous desktop window. -->
-            <key="Shift+F7"              action=Disconnect/>       <!-- Disconnect from the desktop. -->
-            <key="F10"                   action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
-            <!-- <key="Ctrl+N"    action="Start(\"Term\")"/> -->
+            <key="Ctrl+PageUp"   action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
+            <key="Ctrl+PageDown" action=FocusNextWindow/>  <!-- Switch focus to the previous desktop window. -->
+            <key="Shift+F7"      action=Disconnect/>       <!-- Disconnect from the desktop. -->
+            <key="F10"           action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
         </desktop>
         <term key*>  <!-- Application specific layer key bindings. -->
-            <key="Alt+RightArrow"           action=TerminalFindNext/>                  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Alt+LeftArrow"            action=TerminalFindPrev/>                  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
-            <key="Shift+Ctrl+PageUp"        action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Shift+Ctrl+PageDown"      action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Ctrl+PageUp"   scheme="1" action=TerminalViewportOnePageUp/>         <!-- Scroll one page up. -->
-            <key="Ctrl+PageDown" scheme="1" action=TerminalViewportOnePageDown/>       <!-- Scroll one page down. -->
-            <key="Shift+Alt+LeftArrow"      action=TerminalViewportOnePageLeft/>       <!-- Scroll one page to the left. -->
-            <key="Shift+Alt+RightArrow"     action=TerminalViewportOnePageRight/>      <!-- Scroll one page to the right. -->
-            <key="Shift+Ctrl+UpArrow"       action=TerminalViewportOneCharUp/>         <!-- Scroll one line up. -->
-            <key="Shift+Ctrl+DownArrow"     action=TerminalViewportOneCharDown/>       <!-- Scroll one line down. -->
-            <key="Shift+Ctrl+LeftArrow"     action=TerminalViewportOneCharLeft/>       <!-- Scroll one cell to the left. -->
-            <key="Shift+Ctrl+RightArrow"    action=TerminalViewportOneCharRight/>      <!-- Scroll one cell to the right. -->
+            <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Alt+LeftArrow"  action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
+            <key="Shift+Ctrl+PageUp"       ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
+            <key="Shift+Ctrl+PageDown"     ><action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
+            <key="Ctrl+PageUp"   scheme="1"><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
+            <key="Ctrl+PageDown" scheme="1"><action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
+            <key="Shift+Alt+LeftArrow"     ><action=TerminalScrollViewportByPage data=" 1, 0"/></key>  <!-- Scroll viewport one page to the left. -->
+            <key="Shift+Alt+RightArrow"    ><action=TerminalScrollViewportByPage data="-1, 0"/></key>  <!-- Scroll viewport one page to the right. -->
+            <key="Shift+Ctrl+UpArrow"      ><action=TerminalScrollViewportByCell data=" 0, 1"/></key>  <!-- Scroll viewport one line up. -->
+            <key="Shift+Ctrl+DownArrow"    ><action=TerminalScrollViewportByCell data=" 0,-1"/></key>  <!-- Scroll viewport one line down. -->
+            <key="Shift+Ctrl+LeftArrow"    ><action=TerminalScrollViewportByCell data=" 1, 0"/></key>  <!-- Scroll viewport one cell to the left. -->
+            <key="Shift+Ctrl+RightArrow"   ><action=TerminalScrollViewportByCell data="-1, 0"/></key>  <!-- Scroll viewport one cell to the right. -->
             <key="Shift+Ctrl+Home">
-                <action=DropAutoRepeat/>       <!-- Don't autorepeat the Scroll to the scrollback top. -->
-                <action=TerminalViewportTop/>  <!-- Scroll to the scrollback top. -->
+                <action=DropAutoRepeat/>               <!-- Don't autorepeat the Scroll to the scrollback top. -->
+                <action=TerminalScrollViewportToTop/>  <!-- Scroll to the scrollback top. -->
             </key>
             <key="Shift+Ctrl+End">
-                <action=DropAutoRepeat/>       <!-- Don't autorepeat the Scroll to the scrollback bottom (reset viewport position). -->
-                <action=TerminalViewportEnd/>  <!-- Scroll to the scrollback bottom (reset viewport position). -->
+                <action=DropAutoRepeat/>               <!-- Don't autorepeat the Scroll to the scrollback bottom (reset viewport position). -->
+                <action=TerminalScrollViewportToEnd/>  <!-- Scroll to the scrollback bottom (reset viewport position). -->
             </key>
             <key=""                         action=TerminalViewportCopy/>              <!-- Сopy viewport to clipboard. -->
             <key=""                         action=TerminalClipboardPaste/>            <!-- Paste from clipboard. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -411,12 +411,13 @@ R"==(
             </key>
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
-            <key="Space-Backspace"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Backspace-Space"       action=ToggleDebugOverlay/>  <!-- Toggle debug overlay (reversed release order). -->
-            <key="Ctrl-Alt"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl"              action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Alt-Ctrl (reversed releasing). -->
-            <key="Ctrl-Alt" scheme="1"   action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt. -->
-            <key="Alt-Ctrl" scheme="1"   action=ToggleHotkeyScheme/>  <!-- Toggle hotkey scheme to default by pressing and releasing Alt-Ctrl (reversed releasing). -->
+            <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
+            <key="Ctrl-Alt | Alt-Ctrl" scheme="">
+                <action=ToggleHotkeyScheme arg="1"/>  <!-- Toggle hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            </key>
+            <key="Ctrl-Alt | Alt-Ctrl" scheme="1">
+                <action=ToggleHotkeyScheme arg=""/>  <!-- Toggle hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            </key>
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"           action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->


### PR DESCRIPTION
### Changes

- Allow hotkey scheme to be an arbitrary string.
- Fix insertion for lazy grapheme clustering.
- Allow multiple key chords in one settings statement.
- Make a key combination action parameterized.
- Fix handled key combination leak.
- Replace `ToggleHotkeyScheme` with `SwitchHotkeyScheme`.
- Introduce parametrized actions `TerminalScrollViewportByPage` and `TerminalScrollViewportByCell`.

```xml
<config>
    <term>
        <menu>
            <item type="Option" action=SwitchHotkeyScheme label=" Keys0 " data="">
                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="1"/>
                <tooltip>
                    " Toggle hotkey scheme                          \n"
                    "   Alternative hotkey scheme allows keystrokes \n"
                    "   to be passed through without processing     "
                </tooltip>
            </item>
        </menu>
    </term>
    <hotkeys>  <!-- The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop. -->
        <tui key*>  <!-- TUI matrix layer key bindings. The scheme=0 is implicitly used by default. -->
            <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
            <key="Ctrl-Alt | Alt-Ctrl" scheme=""> <action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
            <key="Ctrl-Alt | Alt-Ctrl" scheme="1"><action=SwitchHotkeyScheme data=""/> </key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
        </tui>
        <term key*>  <!-- Application specific layer key bindings. -->
            <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
            <key="Alt+LeftArrow"  action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
            <key="Shift+Ctrl+PageUp">       <action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
            <key="Shift+Ctrl+PageDown">     <action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
            <key="Ctrl+PageUp"   scheme="1"><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
            <key="Ctrl+PageDown" scheme="1"><action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
            <key="Shift+Alt+LeftArrow">     <action=TerminalScrollViewportByPage data=" 1, 0"/></key>  <!-- Scroll viewport one page to the left. -->
            <key="Shift+Alt+RightArrow">    <action=TerminalScrollViewportByPage data="-1, 0"/></key>  <!-- Scroll viewport one page to the right. -->
            <key="Shift+Ctrl+UpArrow">      <action=TerminalScrollViewportByCell data=" 0, 1"/></key>  <!-- Scroll viewport one line up. -->
            <key="Shift+Ctrl+DownArrow">    <action=TerminalScrollViewportByCell data=" 0,-1"/></key>  <!-- Scroll viewport one line down. -->
            <key="Shift+Ctrl+LeftArrow">    <action=TerminalScrollViewportByCell data=" 1, 0"/></key>  <!-- Scroll viewport one cell to the left. -->
            <key="Shift+Ctrl+RightArrow">   <action=TerminalScrollViewportByCell data="-1, 0"/></key>  <!-- Scroll viewport one cell to the right. -->
        </term>
    </hotkeys>
</config>
```