### PR TITLE
Implement RunApplication action

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -116,6 +116,7 @@ TerminalQuit                 |                               | Terminate runnnin
 TerminalRestart              |                               | Terminate runnning console apps and restart current session.
 TerminalFullscreen           |                               | Toggle fullscreen mode.
 TerminalMaximize             |                               | Toggle between maximized and normal window size.
+TerminalMinimize             |                               | Minimize window.
 TerminalUndo                 |                               | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
 TerminalRedo                 |                               | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
 TerminalClipboardCopy        |                               | Сopy selection to clipboard.
@@ -268,6 +269,7 @@ Hotkey                       | Description
             <item label="Quit" type="Command" action=TerminalQuit/>
             <item label="Fullscreen" type="Command" action=TerminalFullscreen/>
             <item label="Maximize" type="Command" action=TerminalMaximize/>
+            <item label="Minimize" type="Command" action=TerminalMinimize/>
             <item label="Noop" type="Command" action=Noop/>
 
             <item label="Sync" tooltip=" CWD sync is off " type="Option" action=TerminalCwdSync data="off">
@@ -341,6 +343,7 @@ Hotkey                       | Description
             <key=""                          action=TerminalWrapMode/>                  <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. The argument is boolean. -->
             <key=""                          action=TerminalFullscreen/>                <!-- Toggle fullscreen mode. -->
             <key=""                          action=TerminalMaximize/>                  <!-- Toggle between maximized and normal window size. -->
+            <key=""                          action=TerminalMinimize/>                  <!-- Minimize window. -->
             <key=""                          action=TerminalStdioLog/>                  <!-- Toggle stdin/stdout logging. -->
             <key=""                          action=TerminalQuit/>                      <!-- Terminate runnning console apps and close terminal. -->
             <key=""                          action=TerminalRestart/>                   <!-- Terminate runnning console apps and restart current session. -->

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -104,14 +104,14 @@ Value                        | Arguments (`data=`)           | Description
 -----------------------------|-------------------------------|------------
 Noop                         |                               | Ignore all events for the specified key combination. No further processing.
 DropAutoRepeat               |                               | Ignore `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
-SwitchHotkeyScheme           | _Scheme name_                 | Switch the hotkey scheme to the specified one.
+SwitchHotkeyScheme           | _`Scheme name`_               | Switch the hotkey scheme to the specified one.
 TerminalCwdSync              |                               | Current working directory sync toggle. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. <br>To enable OSC9;9 shell notifications:<br>- Windows Command Prompt:<br>  `setx PROMPT $e]9;9;$P$e\$P$G`<br>- PowerShell:<br>  `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }`<br>- Bash:<br>  `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '`
 TerminalWrapMode             | `on` \| `off`                 | Set terminal scrollback lines wrapping mode. Applied to the active selection if it is.
 TerminalAlignMode            | `left` \| `right` \| `center` | Set terminal scrollback lines aligning mode. Applied to the active selection if it is.
 TerminalFindNext             |                               | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
 TerminalFindPrev             |                               | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
-TerminalOutput               | _Text string_                 | Direct output the string to the terminal scrollback.
-TerminalSendKey              | _Text string_                 | Simulating keypresses using the specified string.
+TerminalOutput               | _`Text string`_               | Direct output the string to the terminal scrollback.
+TerminalSendKey              | _`Text string`_               | Simulating keypresses using the specified string.
 TerminalQuit                 |                               | Terminate runnning console apps and close terminal.
 TerminalRestart              |                               | Terminate runnning console apps and restart current session.
 TerminalFullscreen           |                               | Toggle fullscreen mode.

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -124,7 +124,7 @@ TerminalClipboardWipe        |                               | Reset clipboard.
 TerminalClipboardFormat      | `none` \| `text` \| `ansi` \|<br>`rich` \| `html` \| `protected` | Set terminal text selection copy format.
 TerminalSelectionRect        | `on` \| `off`                 | Set linear(off) or rectangular(on) selection form using boolean value.
 TerminalSelectionCancel      |                               | Deselect a selection.
-TerminalSelectionOneShot     | `none` \| `text` \| `ansi` \|<br>`rich` \| `html` \| `protected` | One-shot toggle to copy text while mouse tracking is active. Keep selection if `Ctrl` key is pressed..
+TerminalSelectionOneShot     | `none` \| `text` \| `ansi` \|<br>`rich` \| `html` \| `protected` | One-shot toggle to copy text while mouse tracking is active. Keep selection if `Ctrl` key is pressed.
 TerminalViewportCopy         |                               | Сopy viewport to clipboard.
 TerminalScrollViewportByPage | _`IntX, IntY`_                | Scroll viewport by _`IntX, IntY`_ pages.
 TerminalScrollViewportByCell | _`IntX, IntY`_                | Scroll viewport by _`IntX, IntY`_ cells.

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -408,7 +408,7 @@ Action                         | Arguments (`data=`)                            
 `TerminalClipboardWipe`        |                                                        | Application         | Reset clipboard.
 `TerminalClipboardFormat`      | `none` \| `text` \| `ansi` \|<br>`rich` \| `html` \| `protected` | Application | Switch terminal text selection copy format.
 `TerminalOutput`               | _Text string_                                          | Application         | Direct output the string to the terminal scrollback.
-`TerminalSendKey`              | _Text string_                                          | Application         | Simulating keypresses using the specified string.
+`TerminalSendKey`              | _Text string_                                          | Application         | Simulating key presses using the specified string.
 `TerminalUndo`                 |                                                        | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
 `TerminalRedo`                 |                                                        | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
 `TerminalCwdSync`              |                                                        | Application         | Toggle the current working directory sync mode.
@@ -419,7 +419,7 @@ Action                         | Arguments (`data=`)                            
 `TerminalStdioLog`             | `on` \| `off`                                          | Application         | Toggle stdin/stdout logging to the specified state, or just toggle to another state if no arguments are specified.
 `TerminalSelectionRect`        | `on` \| `off`                                          | Application         | Toggle between linear and rectangular selection form.
 `TerminalSelectionCancel`      |                                                        | Application         | Deselect a selection.
-`TerminalSelectionOneShot`     | `text` \| `ansi` \|<br>`rich` \| `html` \| `protected` | Application         | One-shot toggle to copy text while mouse tracking is active. Keep selection if `Ctrl` key is pressed..
+`TerminalSelectionOneShot`     | `text` \| `ansi` \|<br>`rich` \| `html` \| `protected` | Application         | One-shot toggle to copy text while mouse tracking is active. Keep selection if `Ctrl` key is pressed.
 `TerminalRestart`              |                                                        | Application         | Terminate runnning console apps and restart current session.
 `TerminalQuit`                 |                                                        | Application         | Terminate runnning console apps and close terminal.
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -391,10 +391,11 @@ Action                         | Arguments (`data=`)                            
 `RollFontsBackward`            |                                                        | Native GUI window   | Roll font list backward.
 `RollFontsForward`             |                                                        | Native GUI window   | Roll font list forward.
 `ToggleDebugOverlay`           |                                                        | TUI matrix          | Toggle debug overlay.
-`SwitchHotkeyScheme`           | _Scheme name_                                          | TUI matrix,<br>Window menu | Switch the hotkey scheme to the specified one.
+`SwitchHotkeyScheme`           | _`Scheme name`_                                        | TUI matrix,<br>Window menu | Switch the hotkey scheme to the specified one.
 `FocusPrevWindow`              |                                                        | Desktop             | Switch focus to the next desktop window.
 `FocusNextWindow`              |                                                        | Desktop             | Switch focus to the previous desktop window.
 `Disconnect`                   |                                                        | Desktop             | Disconnect from the desktop.
+`RunApplication`               | _`Taskbar item id`_                                    | Desktop             | Run application. Run the default application if no arguments are specified.
 `TryToQuit`                    |                                                        | Desktop             | Shut down the desktop server if no applications are running.
 `TerminalFindNext`             |                                                        | Application         | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
 `TerminalFindPrev`             |                                                        | Application         | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
@@ -407,8 +408,8 @@ Action                         | Arguments (`data=`)                            
 `TerminalClipboardPaste`       |                                                        | Application         | Paste from clipboard.
 `TerminalClipboardWipe`        |                                                        | Application         | Reset clipboard.
 `TerminalClipboardFormat`      | `none` \| `text` \| `ansi` \|<br>`rich` \| `html` \| `protected` | Application | Switch terminal text selection copy format.
-`TerminalOutput`               | _Text string_                                          | Application         | Direct output the string to the terminal scrollback.
-`TerminalSendKey`              | _Text string_                                          | Application         | Simulating key presses using the specified string.
+`TerminalOutput`               | _`Text string`_                                        | Application         | Direct output the string to the terminal scrollback.
+`TerminalSendKey`              | _`Text string`_                                        | Application         | Simulating key presses using the specified string.
 `TerminalUndo`                 |                                                        | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
 `TerminalRedo`                 |                                                        | Application         | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
 `TerminalCwdSync`              |                                                        | Application         | Toggle the current working directory sync mode.
@@ -868,6 +869,7 @@ Notes
             <key="Ctrl+PageDown" action=FocusNextWindow/>  <!-- Switch focus to the previous desktop window. -->
             <key="Shift+F7"      action=Disconnect/>       <!-- Disconnect from the desktop. -->
             <key="F10"           action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
+            <key="Ctrl+Shift+N"  action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <term key*>  <!-- Application specific layer key bindings. -->
             <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -869,7 +869,7 @@ Notes
             <key="Ctrl+PageDown" action=FocusNextWindow/>  <!-- Switch focus to the previous desktop window. -->
             <key="Shift+F7"      action=Disconnect/>       <!-- Disconnect from the desktop. -->
             <key="F10"           action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
-            <key="Ctrl+Shift+N"  action=RunApplication/>   <!-- Run default application. -->
+            <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <term key*>  <!-- Application specific layer key bindings. -->
             <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -416,6 +416,7 @@ Action                         | Arguments (`data=`)                            
 `TerminalAlignMode`            | `left` \| `right` \| `center`                          | Application         | Set terminal scrollback lines aligning mode. Applied to the active selection if it is.
 `TerminalFullscreen`           |                                                        | Application         | Toggle fullscreen mode.
 `TerminalMaximize`             |                                                        | Application         | Toggle between maximized and normal window size.
+`TerminalMinimize`             |                                                        | Application         | Minimize window.
 `TerminalStdioLog`             | `on` \| `off`                                          | Application         | Toggle stdin/stdout logging to the specified state, or just toggle to another state if no arguments are specified.
 `TerminalSelectionRect`        | `on` \| `off`                                          | Application         | Toggle between linear and rectangular selection form.
 `TerminalSelectionCancel`      |                                                        | Application         | Deselect a selection.
@@ -904,6 +905,7 @@ Notes
             <key=""         action=TerminalAlignMode/>                     <!-- Toggle terminal scrollback lines aligning mode. Applied to the active selection if it is. -->
             <key=""         action=TerminalFullscreen/>                    <!-- Toggle fullscreen mode. -->
             <key=""         action=TerminalMaximize/>                      <!-- Toggle between maximized and normal window size. -->
+            <key=""         action=TerminalMinimize/>                      <!-- Minimize window. -->
             <key=""         action=TerminalStdioLog/>                      <!-- Toggle stdin/stdout logging. -->
             <key=""         action=TerminalRestart/>                       <!-- Terminate runnning console apps and restart current session. -->
             <key=""         action=TerminalQuit/>                          <!-- Terminate runnning console apps and close terminal. -->

--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -24,11 +24,11 @@
 </thead>
 <tbody>
   <tr>
-    <th>Ctrl-Alt ¹</th>
+    <th>Ctrl-Alt ¹ (Alt+Shift+B on non-Windows platforms)</th>
     <td colspan="9">Toggle alternate keyboard mode</td>
   </tr>
   <tr>
-    <th>Ctrl+Shift+N ¹</th>
+    <th>Alt+Shift+N ¹</th>
     <td colspan="9">Run app</td>
   </tr>
   <tr>

--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -28,6 +28,10 @@
     <td colspan="9">Toggle alternate keyboard mode</td>
   </tr>
   <tr>
+    <th>Ctrl+Shift+N ¹</th>
+    <td colspan="9">Run app</td>
+  </tr>
+  <tr>
     <th>F10 ¹</th>
     <td colspan="9">Disconnect all users and shutdown if there are no apps running</td>
   </tr>

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -387,7 +387,7 @@ namespace netxs::app::shared
             auto window_clr = skin::color(tone::window_clr);
             auto window = ui::veer::ctor()
                 ->limits(dot_11)
-                ->plugin<pro::focus>(pro::focus::mode::active); // Required for standalone mode.
+                ->plugin<pro::focus>();
             auto term = ui::cake::ctor()
                 ->active(window_clr);
             auto dtvt = ui::dtvt::ctor();
@@ -775,7 +775,6 @@ namespace netxs::app::shared
         app::shared::initialize info_builder{ app::info::id, build_info };
         //todo UD
         app::shared::initialize noui_builder{ "noui", build_vtty };
-        app::shared::initialize xlvt_builder{ "xlvt", build_dtty };
         app::shared::initialize shell_builder{ "shell", build_vtty };
         app::shared::initialize ansivt_builder{ "ansivt", build_vtty };
         app::shared::initialize headless_builder{ "headless", build_vtty };

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -319,7 +319,6 @@ namespace netxs::app::desk
                         };
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear, -, (inst_id, group_focus = faux))
                         {
-                            static auto offset = dot_00; // static: Share initial offset between all instances.
                             if (gear.meta(hids::anyCtrl | hids::anyAlt | hids::anyShift | hids::anyWin)) // Not supported with any modifier but Ctrl.
                             {
                                 if (gear.meta(hids::anyCtrl)) // Toggle group focus.
@@ -332,13 +331,7 @@ namespace netxs::app::desk
                                 return;
                             }
                             boss.bell::signal(tier::anycast, events::ui::selected, inst_id);
-                            auto viewport = gear.owner.bell::signal(tier::request, e2::form::prop::viewport);
-                            offset = (offset + dot_21 * 2) % std::max(dot_11, viewport.size * 7 / 32);
-                            gear.slot.coor = viewport.coor + offset + viewport.size * 1 / 32 + dot_11;
-                            gear.slot.size = viewport.size * 3 / 4;
-                            gear.slot_forced = faux;
-                            boss.base::riseup(tier::request, e2::form::proceed::createby, gear);
-                            gear.dismiss(true);
+                            gear.owner.bell::signal(tier::preview, e2::form::proceed::createby, gear);
                         };
                     });
                 auto head = head_fork->attach(slot::_1, ui::item::ctor(obj_desc)

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -213,6 +213,7 @@ namespace netxs::app::terminal
                 X(TerminalCwdSync             ) /* */ \
                 X(TerminalFullscreen          ) /* */ \
                 X(TerminalMaximize            ) /* */ \
+                X(TerminalMinimize            ) /* */ \
                 X(TerminalRestart             ) /* */ \
                 X(TerminalSendKey             ) /* */ \
                 X(TerminalWrapMode            ) /* */ \
@@ -373,6 +374,13 @@ namespace netxs::app::terminal
                     _submit<true>(boss, item, [](auto& boss, auto& /*item*/, auto& gear)
                     {
                         boss.base::riseup(tier::preview, e2::form::size::enlarge::maximize, gear);
+                    });
+                }
+                static void TerminalMinimize(ui::item& boss, menu::item& item)
+                {
+                    _submit<true>(boss, item, [](auto& boss, auto& /*item*/, auto& gear)
+                    {
+                        boss.base::riseup(tier::release, e2::form::size::minimize, gear);
                     });
                 }
                 static void TerminalRestart(ui::item& boss, menu::item& item)

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.50";
+    static const auto version = "v0.9.99.51";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1368,7 +1368,6 @@ namespace netxs::ui
                 auto lock = src_ptr->bell::sync();
                 if (auto parent = src_ptr->parent())
                 {
-                    parent->base::riseup(tier::request, hids::events::focus::hop, { .what = src_ptr, .item = dst_ptr });
                     auto gear_id_list = pro::focus::off(src_ptr);
                     pro::focus::set(dst_ptr, gear_id_list, solo::off);
                 }
@@ -1493,20 +1492,6 @@ namespace netxs::ui
                     }
                     auto& route = iter->second;
                     notify_set_focus(route, seed);
-                };
-                // pro::focus: Replace next hop object "seed.what" with "seed.item".
-                boss.LISTEN(tier::request, hids::events::focus::hop, seed, memo)
-                {
-                    for (auto& [gear_id, route] : gears)
-                    {
-                        for (auto& next_wptr : route.next)
-                        {
-                            if (next_wptr.lock() == seed.what)
-                            {
-                                next_wptr = seed.item;
-                            }
-                        }
-                    }
                 };
                 // all tier::previews going to outside (upstream)
                 // all tier::releases going to inside (downstream)

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -161,7 +161,6 @@ namespace netxs::events::userland
                 EVENT_XS( off, input::foci ), // release: Reset focus toward inside; preview: reset focus toward outside.
                 EVENT_XS( get, input::foci ), // request: Unfocus and delete focus route.
                 EVENT_XS( dry, input::foci ), // request: Remove the reference to the specified applet.
-                EVENT_XS( hop, input::foci ), // request: Change next hop destination. args: seed.what => seed.item.
             };
             SUBSET_XS( device )
             {
@@ -742,7 +741,6 @@ namespace netxs::input
         id_t gear_id{}; // foci: Gear id.
         si32 focus_type{}; // foci: Exclusive focus request.
         bool just_activate_only{}; // foci: Ignore focusable object, just activate it.
-        sptr what{}; // foci: Replacement item.
         sptr item{}; // foci: Next focused item.
 
         auto nondefault_gear() const

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1418,7 +1418,7 @@ namespace netxs::ui
             {
                 auto& back = canvas.back();
                 auto [w, h, x, y] = back.whxy();
-                if constexpr (debugmode) log("\tw=%%, h=%%, x=%%, y=%%", w, h, x, y);
+                //if constexpr (debugmode) log("\tw=%%, h=%%, x=%%, y=%%", w, h, x, y);
                 if (w && x == w && size >= w)
                 {
                     auto current_x = w - 1;
@@ -1432,7 +1432,7 @@ namespace netxs::ui
                             break;
                         }
                         auto [cw, ch, cx, cy] = c.whxy();
-                        if constexpr (debugmode) log("\t\tcurrent_x=%%, cw=%%, ch=%%, cx=%%, cy=%%", current_x, cw, ch, cx, cy);
+                        //if constexpr (debugmode) log("\t\tcurrent_x=%%, cw=%%, ch=%%, cx=%%, cy=%%", current_x, cw, ch, cx, cy);
                         if (cw != w || ch != h || cy != y || cx != current_x)
                         {
                             break;

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7744,6 +7744,7 @@ namespace netxs::ui
             //todo use wptr for gear when enqueueing
             chords.proc("TerminalFullscreen",           [&](hids& gear, txts&){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); }); // Refocus-related operations require execution outside of keyboard events.
             chords.proc("TerminalMaximize",             [&](hids& gear, txts&){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); });
+            chords.proc("TerminalMinimize",             [&](hids& gear, txts&){ gear.set_handled(); bell::enqueue(This(), [&](auto& /*boss*/){ base::riseup(tier::release, e2::form::size::minimize, gear); }); });
             chords.proc("TerminalUndo",                 [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::undo);      });
             chords.proc("TerminalRedo",                 [&](hids& gear, txts&){ gear.set_handled(); exec_cmd(commands::ui::redo);      });
             chords.proc("TerminalClipboardCopy",        [&](hids& gear, txts&){ gear.set_handled(); copy(gear);                        });

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -340,7 +340,6 @@ int main(int argc, char* argv[])
         else if (shadow.starts_with(app::dtvt::id))      { aptype = app::dtvt::id;      apname = app::dtvt::name;      }
         else if (shadow.starts_with(app::dtty::id))      { aptype = app::dtty::id;      apname = app::dtty::name;      }
         //todo undocumented
-        else if (shadow.starts_with(/*UD*/"xlvt"))       { aptype = app::dtty::id;     apname = app::dtty::name;       }
         else if (shadow.starts_with(/*UD*/"headless"))   { aptype = app::teletype::id; apname = app::teletype::name;   }
         else if (shadow.starts_with(/*UD*/"noui"))       { aptype = app::teletype::id; apname = app::teletype::name;   }
         //#if defined(DEBUG)

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -505,7 +505,15 @@ namespace netxs::app::vtm
                         gear.slot = data.slot;
                         gear.slot.coor += boss.base::coor();
                         gear.slot_forced = true;
-                        boss.base::riseup(tier::request, e2::form::proceed::createby, gear);
+                        if (gear.meta(hids::anyCtrl))
+                        {
+                            log(prompt::hall, "Area copied to clipboard ", gear.slot);
+                            gear.owner.bell::signal(tier::release, e2::command::printscreen, gear);
+                        }
+                        else
+                        {
+                            boss.base::riseup(tier::request, e2::form::proceed::createby, gear);
+                        }
                     }
                     slots.erase(gear.id);
                     if (slots.empty()) cache = {};
@@ -738,12 +746,17 @@ namespace netxs::app::vtm
             keybd.proc("FocusNextWindow", [&](hids& gear, txts&){ focus_next_window(gear, feed::fwd); });
             keybd.proc("Disconnect",      [&](hids& gear, txts&){ disconnect(gear); });
             keybd.proc("TryToQuit",       [&](hids& gear, txts&){ try_quit(gear); });
+            keybd.proc("RunApplication",  [&](hids& gear, txts& args){ create_app(gear, args.empty() ? "" : args.front()); });
             auto bindings = keybd.load(config, "desktop");
             for (auto& r : bindings)
             {
                 keybd.bind<tier::preview>(r.chord, r.scheme, r.actions);
             }
 
+            LISTEN(tier::preview, e2::form::proceed::createby, gear, tokens)
+            {
+                create_app(gear);
+            };
             LISTEN(tier::release, e2::form::upon::vtree::attached, world_ptr, tokens)
             {
                 nexthop = world_ptr;
@@ -830,6 +843,24 @@ namespace netxs::app::vtm
             };
         }
 
+        void create_app(hids& gear, qiew inst_id = {})
+        {
+            static auto offset = dot_00; // static: Share initial offset between all instances.
+            if (auto world_ptr = nexthop.lock())
+            {
+                if (inst_id)
+                {
+                    bell::signal(tier::release, e2::data::changed, inst_id); // Inform ui::desk about default has been changed.
+                }
+                auto current_viewport = gear.owner.bell::signal(tier::request, e2::form::prop::viewport);
+                offset = (offset + dot_21 * 2) % std::max(dot_11, current_viewport.size * 7 / 32);
+                gear.slot.coor = current_viewport.coor + offset + current_viewport.size * 1 / 32 + dot_11;
+                gear.slot.size = current_viewport.size * 3 / 4;
+                gear.slot_forced = faux;
+                world_ptr->base::riseup(tier::request, e2::form::proceed::createby, gear);
+            }
+            gear.dismiss(true);
+        }
         void try_quit(hids& gear)
         {
             auto window_ptr = e2::form::layout::go::item.param();
@@ -1920,27 +1951,19 @@ namespace netxs::app::vtm
             {
                 auto& gate = gear.owner;
                 auto location = gear.slot;
-                if (gear.meta(hids::anyCtrl))
+                auto what = link{ .square = gear.slot, .forced = gear.slot_forced };
+                gate.bell::signal(tier::request, e2::data::changed, what.menuid);
+                if (auto window = create(what))
                 {
-                    log(prompt::hall, "Area copied to clipboard ", location);
-                    gate.bell::signal(tier::release, e2::command::printscreen, gear);
-                }
-                else
-                {
-                    auto what = link{ .square = gear.slot, .forced = gear.slot_forced };
-                    gate.bell::signal(tier::request, e2::data::changed, what.menuid);
-                    if (auto window = create(what))
-                    {
-                        //window->LISTEN(tier::release, e2::form::upon::vtree::detached, master)
-                        //{
-                        //    log(prompt::hall, "Objects count: ", items.size());
-                        //};
-                        pro::focus::set(window, gear.id, solo::on);
-                        window->bell::signal(tier::anycast, e2::form::upon::created, gear); // Tile should change the menu item.
-                        auto& cfg = dbase.menu[what.menuid];
-                             if (cfg.winform == shared::win::state::maximized) window->bell::signal(tier::preview, e2::form::size::enlarge::maximize, gear);
-                        else if (cfg.winform == shared::win::state::minimized) window->bell::signal(tier::release, e2::form::size::minimize, gear);
-                    }
+                    //window->LISTEN(tier::release, e2::form::upon::vtree::detached, master)
+                    //{
+                    //    log(prompt::hall, "Objects count: ", items.size());
+                    //};
+                    pro::focus::set(window, gear.id, solo::on);
+                    window->bell::signal(tier::anycast, e2::form::upon::created, gear); // Tile should change the menu item.
+                    auto& cfg = dbase.menu[what.menuid];
+                         if (cfg.winform == shared::win::state::maximized) window->bell::signal(tier::preview, e2::form::size::enlarge::maximize, gear);
+                    else if (cfg.winform == shared::win::state::minimized) window->bell::signal(tier::release, e2::form::size::minimize, gear);
                 }
             };
             LISTEN(tier::request, vtm::events::handoff, what)

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1898,7 +1898,7 @@ namespace netxs::app::vtm
                         pro::focus::set(window, gear.id, solo::on); // Notify pro::focus owners.
                         window->bell::signal(tier::anycast, e2::form::upon::created, gear); // Tile should change the menu item.
                              if (appbase.winform == shared::win::state::maximized) window->bell::signal(tier::preview, e2::form::size::enlarge::maximize, gear);
-                        else if (appbase.winform == shared::win::state::minimized) window->bell::signal(tier::preview, e2::form::size::minimize, gear);
+                        else if (appbase.winform == shared::win::state::minimized) window->bell::signal(tier::release, e2::form::size::minimize, gear);
                         yield = utf::concat(window->id);
                     }
                 }
@@ -1939,7 +1939,7 @@ namespace netxs::app::vtm
                         window->bell::signal(tier::anycast, e2::form::upon::created, gear); // Tile should change the menu item.
                         auto& cfg = dbase.menu[what.menuid];
                              if (cfg.winform == shared::win::state::maximized) window->bell::signal(tier::preview, e2::form::size::enlarge::maximize, gear);
-                        else if (cfg.winform == shared::win::state::minimized) window->bell::signal(tier::preview, e2::form::size::minimize, gear);
+                        else if (cfg.winform == shared::win::state::minimized) window->bell::signal(tier::release, e2::form::size::minimize, gear);
                     }
                 }
             };

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1950,7 +1950,6 @@ namespace netxs::app::vtm
             LISTEN(tier::request, e2::form::proceed::createby, gear)
             {
                 auto& gate = gear.owner;
-                auto location = gear.slot;
                 auto what = link{ .square = gear.slot, .forced = gear.slot_forced };
                 gate.bell::signal(tier::request, e2::data::changed, what.menuid);
                 if (auto window = create(what))

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -455,6 +455,7 @@ R"==(
             <key=""         action=TerminalAlignMode/>                     <!-- Toggle terminal scrollback lines aligning mode. Applied to the active selection if it is. -->
             <key=""         action=TerminalFullscreen/>                    <!-- Toggle fullscreen mode. -->
             <key=""         action=TerminalMaximize/>                      <!-- Toggle between maximized and normal window size. -->
+            <key=""         action=TerminalMinimize/>                      <!-- Minimize window. -->
             <key=""         action=TerminalStdioLog/>                      <!-- Toggle stdin/stdout logging. -->
             <key=""         action=TerminalRestart/>                       <!-- Terminate runnning console apps and restart current session. -->
             <key=""         action=TerminalQuit/>                          <!-- Terminate runnning console apps and close terminal. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -410,15 +410,26 @@ R"==(
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. -->
             <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
+)=="
+#if defined (WIN32)
+R"==(
             <key="Ctrl-Alt | Alt-Ctrl" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
             <key="Ctrl-Alt | Alt-Ctrl" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+)=="
+#else
+R"==(
+            <key="Alt+Shift+B" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            <key="Alt+Shift+B" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+)=="
+#endif
+R"==(
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"   action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
             <key="Ctrl+PageDown" action=FocusNextWindow/>  <!-- Switch focus to the previous desktop window. -->
             <key="Shift+F7"      action=Disconnect/>       <!-- Disconnect from the desktop. -->
             <key="F10"           action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
-            <key="Ctrl+Shift+N"  action=RunApplication/>   <!-- Run default application. -->
+            <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <term key*>  <!-- Application specific layer key bindings. -->
             <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -418,6 +418,7 @@ R"==(
             <key="Ctrl+PageDown" action=FocusNextWindow/>  <!-- Switch focus to the previous desktop window. -->
             <key="Shift+F7"      action=Disconnect/>       <!-- Disconnect from the desktop. -->
             <key="F10"           action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
+            <key="Ctrl+Shift+N"  action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <term key*>  <!-- Application specific layer key bindings. -->
             <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->


### PR DESCRIPTION
### Changes

- Fix keystroke doubles in dtty ssh sessions (e.g. in `vtm ssh user@host vtm -r term`).
- Implement `TerminalMinimize` action.
- Implement `RunApplication` action.
- Make switching the hotkey scheme via `Alt+Shift+B` on non-Windows platforms.