### PR TITLE
Fix some multithreaded deadlocks

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -67,9 +67,9 @@ Note: It is possible to combine multiple command into a single sequence using a 
 
 ### Custom menu configuration
       
-Terminal window menu can be composed from scratch by specifying a list of menu items in the `<config/term/menu/>` configuration file section.
+Terminal window menu can be composed from scratch by specifying a list of menu items in the `<config/terminal/menu/>` configuration file section.
 
-### Attributes for the `<config/term/menu/item>` object
+### Attributes for the `<config/terminal/menu/item>` object
 
 Attribute  | Description
 -----------|------------
@@ -79,7 +79,7 @@ tooltip    | Tooltip text.
 action     | The function name which called on item activation. Inherited by the label attribute.
 data       | Textual parameter for function call. Inherited by the label attribute.
 
-### Attributes for the `<config/term/menu/item/label>` sub-object
+### Attributes for the `<config/terminal/menu/item/label>` sub-object
 
 Attribute        | Description
 -----------------|------------
@@ -105,7 +105,7 @@ Value                        | Arguments (`data=`)           | Description
 Noop                         |                               | Ignore all events for the specified key combination. No further processing.
 DropAutoRepeat               |                               | Ignore `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
 SwitchHotkeyScheme           | _`Scheme name`_               | Switch the hotkey scheme to the specified one.
-TerminalCwdSync              |                               | Current working directory sync toggle. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. <br>To enable OSC9;9 shell notifications:<br>- Windows Command Prompt:<br>  `setx PROMPT $e]9;9;$P$e\$P$G`<br>- PowerShell:<br>  `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }`<br>- Bash:<br>  `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '`
+TerminalCwdSync              |                               | Current working directory sync toggle. The command to send for synchronization is configurable via the `<config><terminal cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. <br>To enable OSC9;9 shell notifications:<br>- Windows Command Prompt:<br>  `setx PROMPT $e]9;9;$P$e\$P$G`<br>- PowerShell:<br>  `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }`<br>- Bash:<br>  `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '`
 TerminalWrapMode             | `on` \| `off`                 | Set terminal scrollback lines wrapping mode. Applied to the active selection if it is.
 TerminalAlignMode            | `left` \| `right` \| `center` | Set terminal scrollback lines aligning mode. Applied to the active selection if it is.
 TerminalFindNext             |                               | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
@@ -174,7 +174,7 @@ Hotkey                       | Description
 #### Terminal configuration example
 ```xml
 <config>
-    <term>
+    <terminal>
         <menu item*>
             <item label="<" action=TerminalFindPrev>  <!-- type=Command is a default item's attribute. -->
                 <label="\e[38:2:0:255:0m<\e[m"/>
@@ -304,14 +304,14 @@ Hotkey                       | Description
                 </tooltip>
             </item>
         </menu>
-    </term>
+    </terminal>
     <hotkeys>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.   -->
         <tui key*>  <!-- TUI matrix layer key bindings. -->
             <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
             <key="Ctrl-Alt | Alt-Ctrl" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
             <key="Ctrl-Alt | Alt-Ctrl" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
         </tui>
-        <term key*>
+        <terminal key*>
             <key="Alt+RightArrow"            action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Alt+LeftArrow"             action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"       ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
@@ -339,7 +339,7 @@ Hotkey                       | Description
             <key=""                          action=TerminalClipboardFormat/>           <!-- Switch terminal text selection copy format. -->
             <key=""                          action=TerminalUndo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input. -->
             <key=""                          action=TerminalRedo/>                      <!-- (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command. -->
-            <key=""                          action=TerminalCwdSync/>                   <!-- Toggle the current working directory sync mode. The command to send for synchronization is configurable via the `<config><term cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. To enable OSC9;9 shell notifications: - Windows Command Prompt: `setx PROMPT $e]9;9;$P$e\$P$G` - PowerShell: `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }` - Bash: `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '` -->
+            <key=""                          action=TerminalCwdSync/>                   <!-- Toggle the current working directory sync mode. The command to send for synchronization is configurable via the `<config><terminal cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. To enable OSC9;9 shell notifications: - Windows Command Prompt: `setx PROMPT $e]9;9;$P$e\$P$G` - PowerShell: `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }` - Bash: `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '` -->
             <key=""                          action=TerminalWrapMode/>                  <!-- Toggle terminal scrollback lines wrapping mode. Applied to the active selection if it is. The argument is boolean. -->
             <key=""                          action=TerminalFullscreen/>                <!-- Toggle fullscreen mode. -->
             <key=""                          action=TerminalMaximize/>                  <!-- Toggle between maximized and normal window size. -->
@@ -350,7 +350,7 @@ Hotkey                       | Description
             <key=""                          action=TerminalSelectionRect/>             <!-- Toggle between linear(0) and rectangular(1) selection form. -->
             <key="Esc"                       action=TerminalSelectionCancel/>           <!-- Deselect a selection. -->
             <key=""                          action=TerminalSelectionOneShot/>          <!-- One-shot toggle to copy text while mouse tracking is active. Keep selection if 'Ctrl' key is pressed. -->
-        </term>
+        </terminal>
     </hotkeys>
 </config>
 ```

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -512,8 +512,8 @@ echo "vtm.del()" | vtm
 ```
 # Add new menu items
 echo "vtm.set(id=Term label='Terminal' type=dtvt cmd='vtm -r term')" | vtm
-echo "vtm.set(id=White label='White Terminal' type=dtvt cmd='vtm -r term' cfg='<config><term><colors><default fgc=0xFF000000 bgc=0xFFffffff/></colors></term></config>')" | vtm
-echo "vtm.set(id=Huge label='Huge Terminal' type=dtvt cmd='vtm -r term' cfg='<config><term><scrollback size=500000/></term></config>')" | vtm
+echo "vtm.set(id=White label='White Terminal' type=dtvt cmd='vtm -r term' cfg='<config><terminal><colors><default fgc=0xFF000000 bgc=0xFFffffff/></colors></terminal></config>')" | vtm
+echo "vtm.set(id=Huge label='Huge Terminal' type=dtvt cmd='vtm -r term' cfg='<config><terminal><scrollback size=500000/></terminal></config>')" | vtm
 echo "vtm.set(id=Tile label='Three Terminals' type=tile cmd='v(h(Term, White), Huge)')" | vtm
 echo "vtm.set(id=cmd label='Remote cmd over SSH' type=dtty cmd='ssh user@server vtm cmd')" | vtm
 ```

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -41,12 +41,12 @@ Option                  | Description
 The plain xml-data could be specified in place of `<file>` in `--config <file>` option:
 - `command-line`:
   ```cmd
-  vtm -c "<config><term><scrollback size=1000000/></term></config>" -r term
+  vtm -c "<config><terminal><scrollback size=1000000/></terminal></config>" -r term
   ```
   or (using compact syntax)
 - `command-line`:
   ```cmd
-  vtm -c "<config/term/scrollback size=1000000/>" -r term
+  vtm -c "<config/terminal/scrollback size=1000000/>" -r term
   ```
 
 ### Desktop Applets

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -774,8 +774,7 @@ Notes
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Command" action=SwitchHotkeyScheme>
-                <label=" Keys0 " data=""/>
+            <item type="Option" action=SwitchHotkeyScheme label=" Keys0 " data="">
                 <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="1"/>
                 <tooltip>
                     " Toggle hotkey scheme                          \n"

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -229,9 +229,9 @@ The following declarations have the same meaning:
         </taskbar>
         ...  <!-- Set of additional desktop settings. -->
     </desktop>
-    <term ... >  <!-- Built-in terminal configuration section. -->
+    <terminal ... >  <!-- Built-in terminal configuration section. -->
         ...
-    </term>
+    </terminal>
     <hotkeys>  <!-- The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop. -->
         <gui>  <!-- Native GUI window layer key bindings. -->
             <key="Key+Chord">
@@ -251,12 +251,12 @@ The following declarations have the same meaning:
             </key>
             ...
         </desktop>
-        <term>  <!-- Application specific layer key bindings. -->
+        <terminal>  <!-- Application specific layer key bindings. -->
             <key="Key+Chord">
                 <action="ActionName" data="parameter"/>
             </key>
             ...
-        </term>
+        </terminal>
     </hotkeys>
 </config>
 ```
@@ -599,7 +599,7 @@ Notes
                     "   RightClick to set as default "
                 </tooltip>
                 <config>  <!-- The following config partially overrides the base configuration. It is valid for DirectVT apps only. -->
-                    <term>
+                    <terminal>
                         <scrollback>
                             <size=40000/>  <!-- Scrollback buffer length. -->
                             <wrap=on/>     <!-- Lines wrapping mode. -->
@@ -607,14 +607,14 @@ Notes
                         <selection>
                             <mode=/config/set/selection/mode/>  <!-- Clipboard copy format: "text" | "ansi" | "rich" | "html" | "protected" | "none" . -->
                         </selection>
-                    </term>
+                    </terminal>
                 </config>
             </item>
             <item id="Tile" label="Tile" type="tile" title="Tiling Window Manager" cmd="h1:1(Term, Term)"      tooltip=" Tiling Window Manager           \n   LeftClick to launch instance  \n   RightClick to set as default "/>
             <item id="Site" label="Site" type="site" title="\e[11:3pSite "         cmd="@" winform="maximized" tooltip=" Desktop Region Marker           \n   LeftClick to launch instance  \n   RightClick to set as default "/>  <!-- "\e[11:3p" for center alignment, cmd="@" for instance numbering -->
             <item id="Logs" label="Logs" type="dtvt" title="Logs"                  cmd="$0 -q -r term $0 -m"   tooltip=" Log Monitor                     \n   LeftClick to launch instance  \n   RightClick to set as default ">
                 <config>
-                    <term>
+                    <terminal>
                         <scrollback>
                             <size=5000/>
                             <wrap="off"/>
@@ -668,7 +668,7 @@ Notes
                             </item>
                             <item label="Reset" tooltip=" Clear scrollback and SGR-attributes " action=TerminalOutput data="\e[!p"/>
                         </menu>
-                    </term>
+                    </terminal>
                 </config>
             </item>
             <autorun item*>  <!-- Autorun specified menu items:     -->
@@ -707,7 +707,7 @@ Notes
             <offset=2,1/>     <!-- 2D offset relative to the window (in cells). Default is "2,1". -->
         </shadow>
     </desktop>
-    <term>  <!-- Base settings for the Term app. It can be partially overridden by the menu item's config subarg. -->
+    <terminal>  <!-- Base settings for the built-in terminal. It can be partially overridden by the menu item's config subarg. -->
         <sendinput=""/>  <!-- Send input on startup. E.g. sendinput="echo \"test\"\n" -->
         <cwdsync=" cd $P\n"/>  <!-- Command to sync the current working directory. When 'Sync' is active, $P (case sensitive) will be replaced with the current path received via OSC9;9 notification. Prefixed with a space to avoid touching command history. -->
         <scrollback>
@@ -827,7 +827,7 @@ Notes
                                 close:   Always close.
                                 restart: Restart session.
                                 retry:   Restart session if exit code != 0. -->
-    </term>
+    </terminal>
     <defapp>
         <menu>
             <autohide=menu/autohide/>  <!-- Link to global <config/set/menu/autohide>. -->
@@ -871,7 +871,7 @@ Notes
             <key="F10"           action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
             <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
-        <term key*>  <!-- Application specific layer key bindings. -->
+        <terminal key*>  <!-- Application specific layer key bindings. -->
             <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Alt+LeftArrow"  action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"       ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
@@ -911,7 +911,7 @@ Notes
             <key=""         action=TerminalStdioLog/>                      <!-- Toggle stdin/stdout logging. -->
             <key=""         action=TerminalRestart/>                       <!-- Terminate runnning console apps and restart current session. -->
             <key=""         action=TerminalQuit/>                          <!-- Terminate runnning console apps and close terminal. -->
-        </term>
+        </terminal>
     </hotkeys>
 </config>
 ```

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -392,7 +392,7 @@ namespace netxs::app::shared
                 ->active(window_clr);
             auto dtvt = ui::dtvt::ctor();
             auto scrl = term->attach(ui::rail::ctor());
-            auto defclr = config.take("/config/term/colors/default", cell{}.fgc(whitelt).bgc(blackdk));
+            auto defclr = config.take("/config/terminal/colors/default", cell{}.fgc(whitelt).bgc(blackdk));
             auto inst = scrl->attach(ui::term::ctor(config))
                 ->plugin<pro::focus>(pro::focus::mode::focused)
                 ->colors(defclr.fgc(), defclr.bgc())

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -92,9 +92,9 @@ namespace netxs::app::terminal
 
     namespace attr
     {
-        static constexpr auto cwdsync   = "/config/term/cwdsync";
-        static constexpr auto borders   = "/config/term/border";
-        static constexpr auto menuitems = "/config/term/menu/item";
+        static constexpr auto cwdsync   = "/config/terminal/cwdsync";
+        static constexpr auto borders   = "/config/terminal/border";
+        static constexpr auto menuitems = "/config/terminal/menu/item";
     }
 
     using events = netxs::events::userland::terminal;
@@ -642,7 +642,7 @@ namespace netxs::app::terminal
                 };
                 list.push_back({ item, setup });
             }
-            config.cd("/config/term", "/config/defapp");
+            config.cd("/config/terminal", "/config/defapp");
             return menu::create(config, list);
         }
     }
@@ -760,7 +760,7 @@ namespace netxs::app::terminal
         window//->plugin<pro::track>()
             //->plugin<pro::acryl>()
             ->plugin<pro::cache>();
-        auto defclr = config.take("/config/term/colors/default", cell{}.fgc(whitelt).bgc(blackdk));
+        auto defclr = config.take("/config/terminal/colors/default", cell{}.fgc(whitelt).bgc(blackdk));
         auto layers = window->attach(ui::cake::ctor())
                             ->colors(window_clr)
                             ->limits(dot_11);

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.51";
+    static const auto version = "v0.9.99.52";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1761,7 +1761,7 @@ namespace netxs::gui
             {
                 auto copy = lock.thing;
                 //todo implement
-                //owner.bell::enqueue(owner.This(), [tooltips = std::move(copy)](auto& boss) mutable
+                //owner.bell::enqueue(owner_wptr, [tooltips = std::move(copy)](auto& boss) mutable
                 //{
                 //    for (auto& tooltip : tooltips)
                 //    {
@@ -1792,16 +1792,17 @@ namespace netxs::gui
             void handle(s11n::xs::expose         /*lock*/)
             {
                 owner.window_post_command(ipc::expose_win);
-                //owner.bell::enqueue(owner.This(), [&](auto& /*boss*/)
+                //owner.bell::enqueue(owner_wptr, [&](auto& /*boss*/)
                 //{
                 //    owner.base::riseup(tier::preview, e2::form::layout::expose);
                 //});
             }
             void handle(s11n::xs::sysfocus         lock)
             {
+                auto f = lock.thing;
+                lock.unlock();
                 auto guard = owner.sync(); // Guard the owner.This() call.
                 auto owner_ptr = owner.This();
-                auto& f = lock.thing;
                 if (f.state)
                 {
                     if (owner.mfocus.focused()) // We are the focus tree endpoint.
@@ -1821,7 +1822,8 @@ namespace netxs::gui
             }
             void handle(s11n::xs::hotkey_scheme    lock)
             {
-                auto& k = lock.thing;
+                auto k = lock.thing;
+                lock.unlock();
                 auto guard = owner.sync();
                 if (auto gear_ptr = owner.bell::getref<hids>(k.gear_id))
                 {
@@ -1831,16 +1833,20 @@ namespace netxs::gui
             }
             void handle(s11n::xs::syskeybd         lock)
             {
+                auto keybd = lock.thing;
+                lock.unlock();
+                auto guard = owner.sync();
                 auto& gear = *gears;
-                auto& keybd = lock.thing;
                 gear.alive = true;
                 keybd.syncto(gear);
                 owner.bell::signal(tier::release, hids::events::keybd::key::post, gear);
             };
             void handle(s11n::xs::mouse_event      lock)
             {
+                auto mouse = lock.thing;
+                lock.unlock();
+                auto guard = owner.sync();
                 auto& gear = *gears;
-                auto& mouse = lock.thing;
                 auto basis = gear.owner.base::coor();
                 owner.global(basis);
                 gear.replay(mouse.cause, mouse.coord - basis, mouse.click - basis, mouse.delta, mouse.buttons, mouse.ctlstat, mouse.whlfp, mouse.whlsi, mouse.hzwhl);
@@ -1848,13 +1854,15 @@ namespace netxs::gui
             }
             void handle(s11n::xs::warping          lock)
             {
-                auto& warp = lock.thing;
+                auto warp = lock.thing;
+                lock.unlock();
+                auto guard = owner.sync();
                 owner.warp_window(warp.warpdata);
             }
             void handle(s11n::xs::fps            /*lock*/)
             {
                 //todo revise
-                //owner.bell::enqueue(owner.This(), [&, fps = lock.thing.frame_rate](auto& /*boss*/) mutable
+                //owner.bell::enqueue(owner_wptr, [&, fps = lock.thing.frame_rate](auto& /*boss*/) mutable
                 //{
                 //    owner.bell::signal(tier::general, e2::config::fps, fps);
                 //});
@@ -1866,7 +1874,7 @@ namespace netxs::gui
             void handle(s11n::xs::fatal          /*lock*/)
             {
                 //todo revise
-                //owner.bell::enqueue(owner.This(), [&, utf8 = lock.thing.err_msg](auto& /*boss*/)
+                //owner.bell::enqueue(owner_wptr, [&, utf8 = lock.thing.err_msg](auto& /*boss*/)
                 //{
                 //    owner.errmsg = owner.genmsg(utf8);
                 //    owner.deface();
@@ -1882,7 +1890,7 @@ namespace netxs::gui
             void handle(s11n::xs::sysstart       /*lock*/)
             {
                 //todo revise
-                //owner.bell::enqueue(owner.This(), [&](auto& /*boss*/)
+                //owner.bell::enqueue(owner_wptr, [&](auto& /*boss*/)
                 //{
                 //    owner.base::riseup(tier::release, e2::form::global::sysstart, 1);
                 //});
@@ -1890,7 +1898,7 @@ namespace netxs::gui
             void handle(s11n::xs::cwd            /*lock*/)
             {
                 //todo revise
-                //owner.bell::enqueue(owner.This(), [&, path = lock.thing.path](auto& /*boss*/)
+                //owner.bell::enqueue(owner_wptr, [&, path = lock.thing.path](auto& /*boss*/)
                 //{
                 //    owner.base::riseup(tier::preview, e2::form::prop::cwd, path);
                 //});

--- a/src/netxs/desktopio/scripting.hpp
+++ b/src/netxs/desktopio/scripting.hpp
@@ -121,7 +121,7 @@ namespace netxs::scripting
         {
             //todo initiate global shutdown
 
-            //owner.bell::enqueue(owner.This(), [&, code](auto& boss) mutable
+            //owner.bell::enqueue(owner_wptr, [&, code](auto& boss) mutable
             //{
             //    if (code) log(ansi::bgc(reddk).fgc(whitelt).add('\n', prompt::repl, "Exit code ", utf::to_hex_0x(code), ' ').nil());
             //    else      log(prompt::repl, "Exit code 0");

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -205,53 +205,53 @@ namespace netxs::ui
                      { "invert",  commands::fx::invert  },
                      { "reverse", commands::fx::reverse }};
 
-                send_input =             config.take("/config/term/sendinput",                 text{});
-                def_mxline = std::max(1, config.take("/config/term/scrollback/maxline",        si32{ 65535 }));
-                def_length = std::max(1, config.take("/config/term/scrollback/size",           si32{ 40000 }));
-                def_growdt = std::max(0, config.take("/config/term/scrollback/growstep",       si32{ 0 }    ));
-                def_growmx = std::max(0, config.take("/config/term/scrollback/growlimit",      si32{ 0 }    ));
+                send_input =             config.take("/config/terminal/sendinput",                 text{});
+                def_mxline = std::max(1, config.take("/config/terminal/scrollback/maxline",        si32{ 65535 }));
+                def_length = std::max(1, config.take("/config/terminal/scrollback/size",           si32{ 40000 }));
+                def_growdt = std::max(0, config.take("/config/terminal/scrollback/growstep",       si32{ 0 }    ));
+                def_growmx = std::max(0, config.take("/config/terminal/scrollback/growlimit",      si32{ 0 }    ));
                 recalc_buffer_metrics(def_length, def_growdt, def_growmx);
-                def_wrpmod =             config.take("/config/term/scrollback/wrap",            deco::defwrp == wrap::on) ? wrap::on : wrap::off;
-                resetonkey =             config.take("/config/term/scrollback/reset/onkey",     true);
-                resetonout =             config.take("/config/term/scrollback/reset/onoutput",  faux);
-                def_alt_on =             config.take("/config/term/scrollback/altscroll",       true);
-                def_lucent = std::max(0, config.take("/config/term/scrollback/oversize/opacity",si32{ 0xC0 } ));
-                def_margin = std::max(0, config.take("/config/term/scrollback/oversize",        si32{ 0 }    ));
-                def_tablen = std::max(1, config.take("/config/term/tablen",                     si32{ 8 }    ));
-                def_border = std::max(0, config.take("/config/term/border",                     si32{ 0 }    ));
-                def_selmod =             config.take("/config/term/selection/mode",             mime::textonly, xml::options::format);
-                def_selalt =             config.take("/config/term/selection/rect",             faux);
+                def_wrpmod =             config.take("/config/terminal/scrollback/wrap",            deco::defwrp == wrap::on) ? wrap::on : wrap::off;
+                resetonkey =             config.take("/config/terminal/scrollback/reset/onkey",     true);
+                resetonout =             config.take("/config/terminal/scrollback/reset/onoutput",  faux);
+                def_alt_on =             config.take("/config/terminal/scrollback/altscroll",       true);
+                def_lucent = std::max(0, config.take("/config/terminal/scrollback/oversize/opacity",si32{ 0xC0 } ));
+                def_margin = std::max(0, config.take("/config/terminal/scrollback/oversize",        si32{ 0 }    ));
+                def_tablen = std::max(1, config.take("/config/terminal/tablen",                     si32{ 8 }    ));
+                def_border = std::max(0, config.take("/config/terminal/border",                     si32{ 0 }    ));
+                def_selmod =             config.take("/config/terminal/selection/mode",             mime::textonly, xml::options::format);
+                def_selalt =             config.take("/config/terminal/selection/rect",             faux);
                 def_cur_on =             config.take("/config/cursor/show",                     true);
                 def_cursor =             config.take("/config/cursor/style",                    text_cursor::I_bar, xml::options::cursor);
                 def_curclr =             config.take("/config/cursor/color",                    cell{});
                 def_period =             config.take("/config/cursor/blink",                    span{ skin::globals().blink_period });
                 def_io_log =             config.take("/config/debug/logs",        faux);
                 allow_logs =             true; // Disallowed for dtty.
-                def_atexit =             config.take("/config/term/atexit",                     commands::atexit::smart, atexit_options);
-                def_fcolor =             config.take("/config/term/colors/default/fgc",         argb{ whitelt });
-                def_bcolor =             config.take("/config/term/colors/default/bgc",         argb{ blackdk });
-                def_filler =             config.take("/config/term/colors/bground",             argb{ argb::default_color });
+                def_atexit =             config.take("/config/terminal/atexit",                     commands::atexit::smart, atexit_options);
+                def_fcolor =             config.take("/config/terminal/colors/default/fgc",         argb{ whitelt });
+                def_bcolor =             config.take("/config/terminal/colors/default/bgc",         argb{ blackdk });
+                def_filler =             config.take("/config/terminal/colors/bground",             argb{ argb::default_color });
 
-                def_safe_c =             config.take("/config/term/colors/selection/protected", cell{}.bgc(bluelt)    .fgc(whitelt));
-                def_ansi_c =             config.take("/config/term/colors/selection/ansi",      cell{}.bgc(bluelt)    .fgc(whitelt));
-                def_rich_c =             config.take("/config/term/colors/selection/rich",      cell{}.bgc(bluelt)    .fgc(whitelt));
-                def_html_c =             config.take("/config/term/colors/selection/html",      cell{}.bgc(bluelt)    .fgc(whitelt));
-                def_text_c =             config.take("/config/term/colors/selection/text",      cell{}.bgc(bluelt)    .fgc(whitelt));
-                def_none_c =             config.take("/config/term/colors/selection/none",      cell{}.bgc(blacklt)   .fgc(whitedk));
-                def_find_c =             config.take("/config/term/colors/match",               cell{}.bgc(0xFF007F00).fgc(whitelt));
+                def_safe_c =             config.take("/config/terminal/colors/selection/protected", cell{}.bgc(bluelt)    .fgc(whitelt));
+                def_ansi_c =             config.take("/config/terminal/colors/selection/ansi",      cell{}.bgc(bluelt)    .fgc(whitelt));
+                def_rich_c =             config.take("/config/terminal/colors/selection/rich",      cell{}.bgc(bluelt)    .fgc(whitelt));
+                def_html_c =             config.take("/config/terminal/colors/selection/html",      cell{}.bgc(bluelt)    .fgc(whitelt));
+                def_text_c =             config.take("/config/terminal/colors/selection/text",      cell{}.bgc(bluelt)    .fgc(whitelt));
+                def_none_c =             config.take("/config/terminal/colors/selection/none",      cell{}.bgc(blacklt)   .fgc(whitedk));
+                def_find_c =             config.take("/config/terminal/colors/match",               cell{}.bgc(0xFF007F00).fgc(whitelt));
 
-                def_safe_f =             config.take("/config/term/colors/selection/protected/fx", commands::fx::color,  fx_options);
-                def_ansi_f =             config.take("/config/term/colors/selection/ansi/fx",      commands::fx::xlight, fx_options);
-                def_rich_f =             config.take("/config/term/colors/selection/rich/fx",      commands::fx::xlight, fx_options);
-                def_html_f =             config.take("/config/term/colors/selection/html/fx",      commands::fx::xlight, fx_options);
-                def_text_f =             config.take("/config/term/colors/selection/text/fx",      commands::fx::color,  fx_options);
-                def_none_f =             config.take("/config/term/colors/selection/none/fx",      commands::fx::color,  fx_options);
-                def_find_f =             config.take("/config/term/colors/match/fx",               commands::fx::color,  fx_options);
+                def_safe_f =             config.take("/config/terminal/colors/selection/protected/fx", commands::fx::color,  fx_options);
+                def_ansi_f =             config.take("/config/terminal/colors/selection/ansi/fx",      commands::fx::xlight, fx_options);
+                def_rich_f =             config.take("/config/terminal/colors/selection/rich/fx",      commands::fx::xlight, fx_options);
+                def_html_f =             config.take("/config/terminal/colors/selection/html/fx",      commands::fx::xlight, fx_options);
+                def_text_f =             config.take("/config/terminal/colors/selection/text/fx",      commands::fx::color,  fx_options);
+                def_none_f =             config.take("/config/terminal/colors/selection/none/fx",      commands::fx::color,  fx_options);
+                def_find_f =             config.take("/config/terminal/colors/match/fx",               commands::fx::color,  fx_options);
 
                 std::copy(std::begin(argb::vt256), std::end(argb::vt256), std::begin(def_colors));
                 for (auto i = 0; i < 16; i++)
                 {
-                    def_colors[i] = config.take("/config/term/colors/color" + std::to_string(i), def_colors[i]);
+                    def_colors[i] = config.take("/config/terminal/colors/color" + std::to_string(i), def_colors[i]);
                 }
             }
         };
@@ -7760,7 +7760,7 @@ namespace netxs::ui
             chords.proc("TerminalOutput",               [&](hids& gear, txts& args){ gear.set_handled(); if (args.size()) data_in(args.front()); });
             chords.proc("TerminalAlignMode",            [&](hids& gear, txts& args){ gear.set_handled(); if (args.empty()) exec_cmd(commands::ui::togglejet); else set_align((si32)netxs::get_or(xml::options::align, args.front(), bias::none)); });
             chords.proc("TerminalWrapMode",             [&](hids& gear, txts& args){ gear.set_handled(); if (args.empty()) exec_cmd(commands::ui::togglewrp); else set_wrapln(1 + (si32)!xml::take_or<bool>(args.front(), true)); });
-            auto bindings = chords.load(xml_config, "term");
+            auto bindings = chords.load(xml_config, "terminal");
             for (auto& r : bindings)
             {
                 chords.bind<tier::release>(r.chord, r.scheme, r.actions);

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -187,9 +187,9 @@ int main(int argc, char* argv[])
                 "\n    Plain xml-data can be specified in place of <file> in the '--config <file>' option,"
                 "\n    as well as in the $VTM_CONFIG environment variable:"
                 "\n"
-                "\n      vtm -c \"<config><term><scrollback size=1000000/></term></config>\" -r term"
+                "\n      vtm -c \"<config><terminal><scrollback size=1000000/></terminal></config>\" -r term"
                 "\n      or (using compact syntax)"
-                "\n      vtm -c \"<config/term/scrollback size=1000000/>\" -r term"
+                "\n      vtm -c \"<config/terminal/scrollback size=1000000/>\" -r term"
                 "\n");
             return 0;
         }

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -141,7 +141,7 @@ R"==(<!-- Ordered list of paths to settings files. -->
                     "   RightClick to set as default "
                 </tooltip>
                 <config>  <!-- The following config partially overrides the base configuration. It is valid for DirectVT apps only. -->
-                    <term>
+                    <terminal>
                         <scrollback>
                             <size=40000/>  <!-- Scrollback buffer length. -->
                             <wrap=on/>     <!-- Lines wrapping mode. -->
@@ -149,14 +149,14 @@ R"==(<!-- Ordered list of paths to settings files. -->
                         <selection>
                             <mode=/config/set/selection/mode/>  <!-- Clipboard copy format: "text" | "ansi" | "rich" | "html" | "protected" | "none" . -->
                         </selection>
-                    </term>
+                    </terminal>
                 </config>
             </item>
             <item id="Tile" label="Tile" type="tile" title="Tiling Window Manager" cmd="h1:1(Term, Term)"      tooltip=" Tiling Window Manager           \n   LeftClick to launch instance  \n   RightClick to set as default "/>
             <item id="Site" label="Site" type="site" title="\e[11:3pSite "         cmd="@" winform="maximized" tooltip=" Desktop Region Marker           \n   LeftClick to launch instance  \n   RightClick to set as default "/>  <!-- "\e[11:3p" for center alignment, cmd="@" for instance numbering -->
             <item id="Logs" label="Logs" type="dtvt" title="Logs"                  cmd="$0 -q -r term $0 -m"   tooltip=" Log Monitor                     \n   LeftClick to launch instance  \n   RightClick to set as default ">
                 <config>
-                    <term>
+                    <terminal>
                         <scrollback>
                             <size=5000/>
                             <wrap="off"/>
@@ -214,7 +214,7 @@ R"==(
                         </menu>
 )=="
 R"==(
-                    </term>
+                    </terminal>
                 </config>
             </item>
             <autorun item*>  <!-- Autorun specified menu items:     -->
@@ -255,7 +255,7 @@ R"==(
     </desktop>
 )==" // MSVC2022: C2026 String too big, trailing characters truncated.
 R"==(
-    <term>  <!-- Base settings for the Term app. It can be partially overridden by the menu item's config subarg. -->
+    <terminal>  <!-- Base settings for the built-in terminal. It can be partially overridden by the menu item's config subarg. -->
         <sendinput=""/>  <!-- Send input on startup. E.g. sendinput="echo \"test\"\n" -->
         <cwdsync=" cd $P\n"/>  <!-- Command to sync the current working directory. When 'Sync' is active, $P (case sensitive) will be replaced with the current path received via OSC9;9 notification. Prefixed with a space to avoid touching command history. -->
         <scrollback>
@@ -376,7 +376,7 @@ R"==(
                                 retry:   Restart session if exit code != 0. -->
 )==" // MSVC2022: C2026 String too big, trailing characters truncated.
 R"==(
-    </term>
+    </terminal>
     <defapp>
         <menu>
             <autohide=menu/autohide/>  <!-- Link to global <config/set/menu/autohide>. -->
@@ -431,7 +431,7 @@ R"==(
             <key="F10"           action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
             <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
-        <term key*>  <!-- Application specific layer key bindings. -->
+        <terminal key*>  <!-- Application specific layer key bindings. -->
             <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Alt+LeftArrow"  action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"    ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
@@ -471,6 +471,6 @@ R"==(
             <key=""         action=TerminalStdioLog/>                      <!-- Toggle stdin/stdout logging. -->
             <key=""         action=TerminalRestart/>                       <!-- Terminate runnning console apps and restart current session. -->
             <key=""         action=TerminalQuit/>                          <!-- Terminate runnning console apps and close terminal. -->
-        </term>
+        </terminal>
     </hotkeys>
 </config>)=="

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -354,9 +354,9 @@ R"==(
                 <label="\e[38:2:0:255:255mHTML-code\e[m" data="html"/>
                 <label="\e[38:2:0:255:255mProtected\e[m" data="protected"/>
             </item>
-            <item label="Sync" tooltip=" CWD sync is off " type="Option" action=TerminalCwdSync data="off">
-                <label="\e[38:2:0:255:0mSync\e[m" tooltip=" CWD sync is on                          \n Make sure your shell has OSC9;9 enabled " data="on"/>
-            </item>
+            <!-- <item label="Sync" tooltip=" CWD sync is off " type="Option" action=TerminalCwdSync data="off"> -->
+            <!--     <label="\e[38:2:0:255:0mSync\e[m" tooltip=" CWD sync is on                          \n Make sure your shell has OSC9;9 enabled " data="on"/> -->
+            <!-- </item> -->
             <item label="Log" tooltip=" Console logging is off " type="Option" action=TerminalStdioLog data="off">
                 <label="\e[38:2:0:255:0mLog\e[m" tooltip=" Console logging is on   \n Run Logs to see output  " data="on"/>
             </item>


### PR DESCRIPTION
### Breaking changes

- Rename `<term/>` to `<terminal/>` in settings.xml. See [`/src/vtm.xml`](https://github.com/directvt/vtm/blob/master/src/vtm.xml) for reference.

### Changes

- Fix some multithreaded deadlocks.
- Remove `TerminalCwdSync` menu item from default configuration.