### PR TITLE
Fix issue with double keyboard focus when using `vtm ssh ...`

### DIFF
--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -767,7 +767,7 @@ namespace netxs::app::terminal
         auto scroll = layers->attach(ui::rail::ctor())
                             ->limits({ 10,1 }); // mc crashes when window is too small
         if (appcfg.cmd.empty()) appcfg.cmd = os::env::shell();//todo revise + " -i";
-        auto inst = scroll->attach(ui::term::ctor(config))
+        auto term = scroll->attach(ui::term::ctor(config))
             ->plugin<pro::focus>(pro::focus::mode::focused)
             ->colors(defclr.fgc(), defclr.bgc())
             ->invoke([&](auto& boss)
@@ -892,7 +892,7 @@ namespace netxs::app::terminal
             });
 
         if (appcfg.cmd.empty()) appcfg.cmd = os::env::shell();//todo revise + " -i";
-        auto inst = scroll->attach(ui::term::ctor(config))
+        auto term = scroll->attach(ui::term::ctor(config))
             ->plugin<pro::focus>(pro::focus::mode::focused)
             ->invoke([&](auto& boss)
             {
@@ -970,8 +970,8 @@ namespace netxs::app::terminal
             ->limits({ -1,1 }, { -1,1 })
             ->invoke([&](auto& boss)
             {
-                boss.color(boss.color().bgc(inst->color().bgc()));
-                inst->LISTEN(tier::release, e2::form::prop::filler, brush, -)
+                boss.color(boss.color().bgc(term->color().bgc()));
+                term->LISTEN(tier::release, e2::form::prop::filler, brush, -)
                 {
                     boss.color(boss.color().bgc(brush.bgc()));
                 };
@@ -990,7 +990,7 @@ namespace netxs::app::terminal
         cover->invoke([&, &slot1 = slot1](auto& boss) //todo clang 15.0.0 still disallows capturing structured bindings (wait for clang 16.0.0)
         {
             auto bar = cell{ "▀"sv }.link(slot1->id);
-            auto term_bgc_ptr = ptr::shared(inst->color().bgc());
+            auto term_bgc_ptr = ptr::shared(term->color().bgc());
             auto& term_bgc = *term_bgc_ptr;
             auto winsz = ptr::shared(dot_00);
             auto visible = ptr::shared(slot1->back() != boss.This());
@@ -1011,7 +1011,7 @@ namespace netxs::app::terminal
                 *winsz = new_area.size;
                 (*check_state)(boss);
             };
-            inst->LISTEN(tier::release, e2::form::prop::filler, clr, -, (term_bgc_ptr))
+            term->LISTEN(tier::release, e2::form::prop::filler, clr, -, (term_bgc_ptr))
             {
                 term_bgc = clr.bgc();
             };
@@ -1028,7 +1028,7 @@ namespace netxs::app::terminal
             };
         });
 
-        inst->attach_property(ui::term::events::colors::bg,      terminal::events::release::colors::bg)
+        term->attach_property(ui::term::events::colors::bg,      terminal::events::release::colors::bg)
             ->attach_property(ui::term::events::colors::fg,      terminal::events::release::colors::fg)
             ->attach_property(ui::term::events::selmod,          terminal::events::release::selection::mode)
             ->attach_property(ui::term::events::onesht,          terminal::events::release::selection::shot)

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.52";
+    static const auto version = "v0.9.99.53";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2765,9 +2765,8 @@ namespace netxs::gui
             {
                 if (changed)
                 {
-                    auto timecode = datetime::now();
                     stream.m.changed++;
-                    stream.m.timecod = timecode;
+                    stream.m.timecod = datetime::now();
                     stream.m.ctlstat = get_mods_state();
                     stream.mouse(stream.m);
                 }

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1177,9 +1177,6 @@ namespace netxs::input
         si32 virtcod{};
         si32 scancod{};
         si32 keycode{};
-        ui64 vk_hash{};
-        ui64 sc_hash{};
-        ui64 ch_hash{};
         text vkchord{};
         text scchord{};
         text chchord{};
@@ -1664,7 +1661,16 @@ namespace netxs::input
         }
         void set_handled(bool b = true)
         {
-            handled = b;
+            if (keybd::keystat == input::key::released) // Don't stop the key release event, just break the chord processing.
+            {
+                keybd::vkchord.clear();
+                keybd::scchord.clear();
+                keybd::chchord.clear();
+            }
+            else
+            {
+                handled = b;
+            }
         }
         void set_hotkey_scheme(qiew scheme)
         {

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -161,6 +161,7 @@ namespace netxs::events::userland
                 EVENT_XS( off, input::foci ), // release: Reset focus toward inside; preview: reset focus toward outside.
                 EVENT_XS( get, input::foci ), // request: Unfocus and delete focus route.
                 EVENT_XS( dry, input::foci ), // request: Remove the reference to the specified applet.
+                EVENT_XS( hop, input::foci ), // request: Switch focus branch to seed.item.
             };
             SUBSET_XS( device )
             {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -8431,7 +8431,6 @@ namespace netxs::ui
                 gear.m_sys.enabled = hids::stat::halt;
                 stream.sysmouse.send(*this, gear.m_sys);
             };
-            //todo replace it with tier::release hids::events::focus::any (set/off)
             LISTEN(tier::release, hids::events::focus::any, seed)
             {
                 auto deed = this->bell::protos(tier::release);


### PR DESCRIPTION
### Changes

- Fix issue with double keyboard focus when using `vtm ssh user@host vtm`.
- Don't stop processing the key release event, just break processing the chords.