### PR TITLE
Reimplement hotkey handling (drop schemes)

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -104,7 +104,7 @@ Value                        | Arguments (`data=`)           | Description
 -----------------------------|-------------------------------|------------
 Noop                         |                               | Ignore all events for the specified key combination. No further processing.
 DropAutoRepeat               |                               | Ignore `Key Repeat` events for the specified key combination. This binding should be specified before the main action for the key combination.
-SwitchHotkeyScheme           | _`Scheme name`_               | Switch the hotkey scheme to the specified one.
+ExclusiveKeyboardMode        |                               | Toggle exclusive keyboard mode.
 TerminalCwdSync              |                               | Current working directory sync toggle. The command to send for synchronization is configurable via the `<config><terminal cwdsync=" cd $P\n"/></config>` setting's option. Where `$P` is a variable containing current path received via OSC 9;9 notification. <br>To enable OSC9;9 shell notifications:<br>- Windows Command Prompt:<br>  `setx PROMPT $e]9;9;$P$e\$P$G`<br>- PowerShell:<br>  `function prompt{ $e=[char]27; "$e]9;9;$(Convert-Path $pwd)$e\PS $pwd$('>' * ($nestedPromptLevel + 1)) " }`<br>- Bash:<br>  `export PS1='\[\033]9;9;\w\033\\\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '`
 TerminalWrapMode             | `on` \| `off`                 | Set terminal scrollback lines wrapping mode. Applied to the active selection if it is.
 TerminalAlignMode            | `left` \| `right` \| `center` | Set terminal scrollback lines aligning mode. Applied to the active selection if it is.
@@ -156,7 +156,8 @@ List of hotkeys defined in the default configuration.
 
 Hotkey                       | Description
 -----------------------------|------------
-`Ctrl-Alt | Alt-Ctrl`        | Toggle hotkey scheme between `Keys0` and `Keys1`.
+`Ctrl-Alt | Alt-Ctrl`        | Win32: Toggle exclusive keyboard mode.
+`Alt=Shift+B`                | Unix: Toggle exclusive keyboard mode.
 `Alt+RightArrow`             | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
 `Alt+LeftArrow`              | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
 `Shift+Ctrl+PageUp`          | Scroll one page up.
@@ -196,12 +197,12 @@ Hotkey                       | Description
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Option" action=SwitchHotkeyScheme label=" Keys0 " data="">
-                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="1"/>
+            <item type="Option" action=ExclusiveKeyboardMode label=" Keys0 " data="off">
+                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="on"/>
                 <tooltip>
-                    " Toggle hotkey scheme                          \n"
-                    "   Alternative hotkey scheme allows keystrokes \n"
-                    "   to be passed through without processing     "
+                    " Toggle exclusive keyboard mode              \n"
+                    "   Exclusive keyboard mode allows keystrokes \n"
+                    "   to be passed through without processing   "
                 </tooltip>
             </item>
             <item label="Wrap" type="Option" action=TerminalWrapMode data="off">
@@ -308,16 +309,13 @@ Hotkey                       | Description
     <hotkeys>  <!--  The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop.   -->
         <tui key*>  <!-- TUI matrix layer key bindings. -->
             <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Ctrl-Alt | Alt-Ctrl" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            <key="Ctrl-Alt | Alt-Ctrl" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
         </tui>
         <terminal key*>
+            <key="Ctrl-Alt | Alt-Ctrl" raw="on" action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
             <key="Alt+RightArrow"            action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Alt+LeftArrow"             action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"       ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
             <key="Shift+Ctrl+PageDown"     ><action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
-            <key="Ctrl+PageUp"   scheme="1"><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->
-            <key="Ctrl+PageDown" scheme="1"><action=TerminalScrollViewportByPage data=" 0,-1"/></key>  <!-- Scroll viewport one page down. -->
             <key="Shift+Alt+LeftArrow"     ><action=TerminalScrollViewportByPage data=" 1, 0"/></key>  <!-- Scroll viewport one page to the left. -->
             <key="Shift+Alt+RightArrow"    ><action=TerminalScrollViewportByPage data="-1, 0"/></key>  <!-- Scroll viewport one page to the right. -->
             <key="Shift+Ctrl+UpArrow"      ><action=TerminalScrollViewportByCell data=" 0, 1"/></key>  <!-- Scroll viewport one line up. -->

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -156,7 +156,7 @@ List of hotkeys defined in the default configuration.
 
 Hotkey                       | Description
 -----------------------------|------------
-`Ctrl-Alt | Alt-Ctrl`        | Win32: Toggle exclusive keyboard mode.
+`Ctrl-Alt \| Alt-Ctrl`       | Win32: Toggle exclusive keyboard mode.
 `Alt=Shift+B`                | Unix: Toggle exclusive keyboard mode.
 `Alt+RightArrow`             | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
 `Alt+LeftArrow`              | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -197,8 +197,8 @@ Hotkey                       | Description
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Option" action=ExclusiveKeyboardMode label=" Keys0 " data="off">
-                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="on"/>
+            <item type="Option" action=ExclusiveKeyboardMode label=" Desktop " data="off">
+                <label="\e[48:2:0:128:128;38:2:0:255:0m Exclusive \e[m" data="on"/>
                 <tooltip>
                     " Toggle exclusive keyboard mode              \n"
                     "   Exclusive keyboard mode allows keystrokes \n"

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -311,7 +311,7 @@ Hotkey                       | Description
             <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
         </tui>
         <terminal key*>
-            <key="Ctrl-Alt | Alt-Ctrl" raw="on" action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            <key="Ctrl-Alt | Alt-Ctrl" preview action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
             <key="Alt+RightArrow"            action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Alt+LeftArrow"             action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"       ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -330,7 +330,7 @@ Application `app_name` | `<config/hotkeys/app_name/>` | Application layer key bi
 The syntax for defining key combination bindings is:
 
 ```xml
-<key="Key+Chord | ... | Another+Key+Chord" scheme="scheme_name"> <!-- scheme="" can be omitted.  -->
+<key="Key+Chord | ... | Another+Key+Chord" [ raw="on | off" ]>
     <action="NameOfAction1" data="argument"/>
     ...
     <action="NameOfActionN" data="argument"/>
@@ -340,8 +340,8 @@ The syntax for defining key combination bindings is:
 Tag      | Value
 ---------|--------
 `key`    | The text string containing the key combinations.
-`scheme` | Hotkey scheme name for which mapping is being done (empty string by default).
 `action` | The action name.
+`raw`    | Force hotkey action to be processed in exclusive keyboard mode. Default is `off`.
 `data`   | The arguments passed to the action.
 
 The following joiners are allowed for combining keys:
@@ -372,7 +372,6 @@ Configuration record                                           | Interpretation
 `<key="Key+Chord" action=NameOfAction/>`                       | Append existing bindings using an indirect reference (the `NameOfAction` variable without quotes).
 `<key="Key+Chord | Another+Chord" action=NameOfAction/>`       | Append existing bindings for `Key+Chord | Another+Chord`.
 `<key="Key+Chord" action="NameOfAction"/>`                     | Append existing bindings with the directly specified command "NameOfAction".
-`<key="Key+Chord" action="NameOfAction" scheme="1"/>`          | Append existing bindings for scheme="1".
 `<key="Key+Chord" action=""/>`                                 | Remove all existing bindings for the specified key combination "Key+Chord".
 `<key="Key+Chord"><action="NameOfAction" data="param"/></key>` | Append existing bindings with the directly specified command "NameOfAction" with arguments "param".
 `<key=""          action="NameOfAction"/>`                     | Do nothing.
@@ -391,12 +390,12 @@ Action                         | Arguments (`data=`)                            
 `RollFontsBackward`            |                                                        | Native GUI window   | Roll font list backward.
 `RollFontsForward`             |                                                        | Native GUI window   | Roll font list forward.
 `ToggleDebugOverlay`           |                                                        | TUI matrix          | Toggle debug overlay.
-`SwitchHotkeyScheme`           | _`Scheme name`_                                        | TUI matrix,<br>Window menu | Switch the hotkey scheme to the specified one.
 `FocusPrevWindow`              |                                                        | Desktop             | Switch focus to the next desktop window.
 `FocusNextWindow`              |                                                        | Desktop             | Switch focus to the previous desktop window.
 `Disconnect`                   |                                                        | Desktop             | Disconnect from the desktop.
 `RunApplication`               | _`Taskbar item id`_                                    | Desktop             | Run application. Run the default application if no arguments are specified.
 `TryToQuit`                    |                                                        | Desktop             | Shut down the desktop server if no applications are running.
+`ExclusiveKeyboardMode`        | `on` \| `off`                                          | Application         | Toggle exclusive keyboard mode.
 `TerminalFindNext`             |                                                        | Application         | Highlight next match of selected text fragment. Clipboard content is used if no active selection.
 `TerminalFindPrev`             |                                                        | Application         | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
 `TerminalScrollViewportByPage` | _`IntX, IntY`_                                         | Application         | Scroll viewport by _`IntX, IntY`_ pages.
@@ -774,12 +773,12 @@ Notes
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Option" action=SwitchHotkeyScheme label=" Keys0 " data="">
-                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="1"/>
+            <item type="Option" action=ExclusiveKeyboardMode label=" Keys0 " data="off">
+                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="on"/>
                 <tooltip>
-                    " Toggle hotkey scheme                          \n"
-                    "   Alternative hotkey scheme allows keystrokes \n"
-                    "   to be passed through without processing     "
+                    " Toggle exclusive keyboard mode              \n"
+                    "   Exclusive keyboard mode allows keystrokes \n"
+                    "   to be passed through without processing   "
                 </tooltip>
             </item>
             <item label="Wrap" type="Option" action=TerminalWrapMode data="off">
@@ -860,8 +859,6 @@ Notes
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. -->
             <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-            <key="Ctrl-Alt | Alt-Ctrl" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            <key="Ctrl-Alt | Alt-Ctrl" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"   action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
@@ -871,6 +868,7 @@ Notes
             <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <terminal key*>  <!-- Application specific layer key bindings. -->
+            <key="Ctrl-Alt | Alt-Ctrl" raw="on" action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
             <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Alt+LeftArrow"  action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"       ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -773,8 +773,8 @@ Notes
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Option" action=ExclusiveKeyboardMode label=" Keys0 " data="off">
-                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="on"/>
+            <item type="Option" action=ExclusiveKeyboardMode label=" Desktop " data="off">
+                <label="\e[48:2:0:128:128;38:2:0:255:0m Exclusive \e[m" data="on"/>
                 <tooltip>
                     " Toggle exclusive keyboard mode              \n"
                     "   Exclusive keyboard mode allows keystrokes \n"

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -330,7 +330,7 @@ Application `app_name` | `<config/hotkeys/app_name/>` | Application layer key bi
 The syntax for defining key combination bindings is:
 
 ```xml
-<key="Key+Chord | ... | Another+Key+Chord" [ raw="on | off" ]>
+<key="Key+Chord | ... | Another+Key+Chord" [ preview ]>
     <action="NameOfAction1" data="argument"/>
     ...
     <action="NameOfActionN" data="argument"/>
@@ -341,7 +341,7 @@ Tag      | Value
 ---------|--------
 `key`    | The text string containing the key combinations.
 `action` | The action name.
-`raw`    | Force hotkey action to be processed in exclusive keyboard mode. Default is `off`.
+`preview`| A Boolean value specifying that hotkey actions should be processed while traversing the focus tree until the target object is reached (ignoring keyboard exclusive mode). Default is `off`.
 `data`   | The arguments passed to the action.
 
 The following joiners are allowed for combining keys:
@@ -864,11 +864,11 @@ Notes
             <key="Ctrl+PageUp"   action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
             <key="Ctrl+PageDown" action=FocusNextWindow/>  <!-- Switch focus to the previous desktop window. -->
             <key="Shift+F7"      action=Disconnect/>       <!-- Disconnect from the desktop. -->
-            <key="F10"           action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
+            <key="F10" preview   action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
             <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <terminal key*>  <!-- Application specific layer key bindings. -->
-            <key="Ctrl-Alt | Alt-Ctrl" raw="on" action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            <key="Ctrl-Alt | Alt-Ctrl" preview action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
             <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Alt+LeftArrow"  action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"       ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -602,38 +602,20 @@ namespace netxs::app::shared
                 //->template plugin<pro::focus>()
                 ->template plugin<pro::grade>();
             auto state_block = title_grid_state->attach(ui::fork::ctor());
-            auto state_label = state_block->attach(slot::_1, ui::item::ctor("Alternate hotkey scheme:")->setpad({ 2, 1, 0, 0 }));
+            auto state_label = state_block->attach(slot::_1, ui::item::ctor("Exclusive keyboard mode:")->setpad({ 2, 1, 0, 0 }));
             auto state_state = state_block->attach(slot::_2, ui::item::ctor(ansi::bgc(reddk).fgx(0).add("█off ")))
                 ->setpad({ 1, 1, 0, 0 })
                 ->active()
                 ->shader(cell::shaders::xlight, e2::form::state::hover)
                 ->invoke([&](auto& boss)
                 {
-                    boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (subs_ptr = ptr::shared<subs>()))
+                    boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear, -, (state = faux))
                     {
-                        subs_ptr->clear();
-                        if (auto focusable_parent = boss.base::riseup(tier::request, e2::config::plugins::focus::owner))
-                        {
-                            focusable_parent->LISTEN(tier::release, e2::form::state::keybd::scheme, hscheme, (*subs_ptr))
-                            {
-                                //todo unify
-                                boss.set(hscheme.size() ? ansi::bgc(greendk).fgc(whitelt).add(" on █")
-                                                        : ansi::bgc(reddk).fgx(0)        .add("█off "));
-                                boss.base::reflow();
-                            };
-                        }
-                    };
-                    boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
-                    {
-                        //todo unify
-                        if (gear.hscheme != ""sv)
-                        {
-                            gear.set_hotkey_scheme("");
-                        }
-                        else
-                        {
-                            gear.set_hotkey_scheme("1");
-                        }
+                        state = !state;
+                        boss.set(state ? ansi::bgc(greendk).fgc(whitelt).add(" on █")
+                                       : ansi::bgc(reddk).fgx(0)        .add("█off "));
+                        //todo set Exclusive keyboard mode
+                        boss.base::reflow();
                         gear.dismiss_dblclick();
                     };
                 });
@@ -754,8 +736,7 @@ namespace netxs::app::shared
                 {
                     if (gear.keystat != input::key::repeated) (*update_ptr)(items_inst, gear, true);
                 });
-                keybd.template bind<tier::release>( "Any", "",  "UpdateChordPreview");
-                keybd.template bind<tier::release>( "Any", "1", "UpdateChordPreview");
+                keybd.bind( "Any", "UpdateChordPreview");
             });
             inside->attach(slot::_2, ui::post::ctor())
                 ->limits({ -1, 1 })

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -24,6 +24,7 @@ namespace netxs::events::userland
                 EVENT_XS( wrapln   , si32 ),
                 EVENT_XS( io_log   , bool ),
                 EVENT_XS( cwdsync  , bool ),
+                EVENT_XS( rawkbd   , bool ),
                 GROUP_XS( selection, si32 ),
                 GROUP_XS( colors   , argb ),
 
@@ -45,6 +46,7 @@ namespace netxs::events::userland
                 EVENT_XS( wrapln   , si32 ),
                 EVENT_XS( io_log   , bool ),
                 EVENT_XS( cwdsync  , bool ),
+                EVENT_XS( rawkbd   , bool ),
                 GROUP_XS( selection, si32 ),
                 GROUP_XS( colors   , argb ),
 
@@ -208,7 +210,7 @@ namespace netxs::app::terminal
 
             #define proc_list \
                 X(Noop                        ) /* */ \
-                X(SwitchHotkeyScheme          ) /* */ \
+                X(ExclusiveKeyboardMode       ) /* */ \
                 X(TerminalQuit                ) /* */ \
                 X(TerminalCwdSync             ) /* */ \
                 X(TerminalFullscreen          ) /* */ \
@@ -274,23 +276,16 @@ namespace netxs::app::terminal
                 using release = terminal::events::release;
 
                 static void Noop(ui::item& /*boss*/, menu::item& /*item*/) { }
-                static void SwitchHotkeyScheme(ui::item& boss, menu::item& item)
+                static void ExclusiveKeyboardMode(ui::item& boss, menu::item& item)
                 {
-                    item.reindex<text>([](auto& utf8){ return xml::take_or<text>(utf8, ""s); });
-                    _submit<true>(boss, item, [](auto& /*boss*/, auto& item, auto& gear)
+                    item.reindex([](auto& utf8){ return xml::take_or<bool>(utf8, faux); });
+                    _submit<true>(boss, item, [](auto& boss, auto& item, auto& /*gear*/)
                     {
-                        gear.set_handled();
-                        gear.set_hotkey_scheme(item.views[item.taken].data);
+                        boss.bell::signal(tier::anycast, preview::rawkbd, item.views[item.taken].value);
                     });
-                    boss.LISTEN(tier::anycast, e2::form::upon::started, root, -, (hook_ptr = ptr::shared<hook>()))
+                    boss.LISTEN(tier::anycast, release::rawkbd, state)
                     {
-                        if (auto focusable_parent = boss.base::riseup(tier::request, e2::config::plugins::focus::owner))
-                        {
-                            focusable_parent->LISTEN(tier::release, e2::form::state::keybd::scheme, hscheme, (*hook_ptr))
-                            {
-                                _update_to(boss, item, hscheme);
-                            };
-                        }
+                        _update_to(boss, item, state);
                     };
                 }
                 static void TerminalWrapMode(ui::item& boss, menu::item& item)
@@ -696,6 +691,10 @@ namespace netxs::app::terminal
         {
             boss.set_selalt(selbox);
         };
+        boss.LISTEN(tier::anycast, terminal::events::preview::rawkbd, rawkbd)
+        {
+            boss.set_rawkbd(rawkbd + 1);
+        };
         boss.LISTEN(tier::anycast, terminal::events::preview::wrapln, wrapln)
         {
             boss.set_wrapln(wrapln);
@@ -1033,6 +1032,7 @@ namespace netxs::app::terminal
             ->attach_property(ui::term::events::selmod,          terminal::events::release::selection::mode)
             ->attach_property(ui::term::events::onesht,          terminal::events::release::selection::shot)
             ->attach_property(ui::term::events::selalt,          terminal::events::release::selection::box)
+            ->attach_property(ui::term::events::rawkbd,          terminal::events::release::rawkbd)
             ->attach_property(ui::term::events::io_log,          terminal::events::release::io_log)
             ->attach_property(ui::term::events::layout::wrapln,  terminal::events::release::wrapln)
             ->attach_property(ui::term::events::layout::align,   terminal::events::release::align)

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "canvas.hpp"
-#include "quartz.hpp"
 
 #include <mutex>
 #include <array>

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -122,20 +122,18 @@ namespace netxs::app::shared
                 gear.set_handled();
             }
         });
-        keybd.proc("WindowClosePreview", [&, esc_pressed](hids& gear, txts&)
+        keybd.proc("WindowClosePreview", [&, esc_pressed](hids& /*gear*/, txts&)
         {
             if (std::exchange(*esc_pressed, true) != *esc_pressed)
             {
                 boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
-                gear.set_handled();
             }
         });
-        keybd.proc("CancelWindowClose", [&, esc_pressed](hids& gear, txts&)
+        keybd.proc("CancelWindowClose", [&, esc_pressed](hids& /*gear*/, txts&)
         {
             if (std::exchange(*esc_pressed, faux) != *esc_pressed)
             {
                 boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
-                gear.set_handled(); 
             }
         });
         keybd.proc("ScrollPageUp"    , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
@@ -150,11 +148,10 @@ namespace netxs::app::shared
         keybd.proc("ToggleMaximize"  , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); }); // Refocus-related operations require execution outside of keyboard eves.
         keybd.proc("ToggleFullscreen", [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); });
 
-        //todo revise (preview/release)
-        keybd.bind( "Esc", "DropAutoRepeat"    );
-        keybd.bind( "Esc", "WindowClosePreview");
-        keybd.bind("-Esc", "WindowClose"       );
-        keybd.bind( "Any", "CancelWindowClose" );
+        keybd.bind( "Esc", "DropAutoRepeat"    , true);
+        keybd.bind( "Esc", "WindowClosePreview", true);
+        keybd.bind("-Esc", "WindowClose"       , true);
+        keybd.bind( "Any", "CancelWindowClose" , true);
 
         keybd.bind("PageUp"    , "ScrollPageUp"    );
         keybd.bind("PageDown"  , "ScrollPageDown"  );

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -119,50 +119,57 @@ namespace netxs::app::shared
             if (*esc_pressed)
             {
                 boss.bell::signal(tier::anycast, e2::form::proceed::quit::one, true);
-                gear.set_handled(true);
+                gear.set_handled();
             }
         });
-        keybd.proc("WindowClosePreview", [&, esc_pressed](hids& /*gear*/, txts&)
+        keybd.proc("WindowClosePreview", [&, esc_pressed](hids& gear, txts&)
         {
-            if (std::exchange(*esc_pressed, true) != *esc_pressed) boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
+            if (std::exchange(*esc_pressed, true) != *esc_pressed)
+            {
+                boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
+                gear.set_handled();
+            }
         });
-        keybd.proc("CancelWindowClose", [&, esc_pressed](hids& /*gear*/, txts&)
+        keybd.proc("CancelWindowClose", [&, esc_pressed](hids& gear, txts&)
         {
-            if (std::exchange(*esc_pressed, faux) != *esc_pressed) boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
+            if (std::exchange(*esc_pressed, faux) != *esc_pressed)
+            {
+                boss.bell::signal(tier::anycast, e2::form::state::keybd::command::close, *esc_pressed);
+                gear.set_handled(); 
+            }
         });
-        keybd.proc("ScrollPageUp"    , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
-        keybd.proc("ScrollPageDown"  , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
-        keybd.proc("ScrollLineUp"    , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 3 }}); });
-        keybd.proc("ScrollLineDown"  , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-3 }}); });
-        keybd.proc("ScrollCharLeft"  , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 3, 0 }}); });
-        keybd.proc("ScrollCharRight" , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-3, 0 }}); });
-        keybd.proc("ScrollTop"       , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
-        keybd.proc("ScrollEnd"       , [&](hids& /*gear*/, txts&){ scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
+        keybd.proc("ScrollPageUp"    , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0, 1 }}); });
+        keybd.proc("ScrollPageDown"  , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bypage::y, { .vector = { 0,-1 }}); });
+        keybd.proc("ScrollLineUp"    , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0, 3 }}); });
+        keybd.proc("ScrollLineDown"  , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::y, { .vector = { 0,-3 }}); });
+        keybd.proc("ScrollCharLeft"  , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = { 3, 0 }}); });
+        keybd.proc("ScrollCharRight" , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::bystep::x, { .vector = {-3, 0 }}); });
+        keybd.proc("ScrollTop"       , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_top::y); });
+        keybd.proc("ScrollEnd"       , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.base::riseup(tier::preview, e2::form::upon::scroll::to_end::y); });
         //todo use sptr for gear when enqueueing (dangling reference)
-        keybd.proc("ToggleMaximize"  , [&](hids& gear, txts&){ scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); }); // Refocus-related operations require execution outside of keyboard eves.
-        keybd.proc("ToggleFullscreen", [&](hids& gear, txts&){ scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); });
-        auto binding = [&](qiew scheme)
-        {
-            keybd.template bind<tier::preview>( "Esc", scheme, "DropAutoRepeat"    );
-            keybd.template bind<tier::release>( "Esc", scheme, "WindowClosePreview");
-            keybd.template bind<tier::preview>("-Esc", scheme, "WindowClose"       );
-            keybd.template bind<tier::release>( "Any", scheme, "CancelWindowClose" );
-            keybd.bind("PageUp"    , scheme, "ScrollPageUp"    );
-            keybd.bind("PageDown"  , scheme, "ScrollPageDown"  );
-            keybd.bind("UpArrow"   , scheme, "ScrollLineUp"    );
-            keybd.bind("DownArrow" , scheme, "ScrollLineDown"  );
-            keybd.bind("LeftArrow" , scheme, "ScrollCharLeft"  );
-            keybd.bind("RightArrow", scheme, "ScrollCharRight" );
-            keybd.bind("Home"      , scheme, "DropAutoRepeat"  );
-            keybd.bind("Home"      , scheme, "ScrollTop"       );
-            keybd.bind("End"       , scheme, "DropAutoRepeat"  );
-            keybd.bind("End"       , scheme, "ScrollEnd"       );
-            keybd.bind("F11"       , scheme, "DropAutoRepeat"  );
-            keybd.bind("F11"       , scheme, "ToggleMaximize"  );
-            keybd.bind("F12"       , scheme, "DropAutoRepeat"  );
-            keybd.bind("F12"       , scheme, "ToggleFullscreen");
-        };
-        binding("");
+        keybd.proc("ToggleMaximize"  , [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::maximize,   gear); }); }); // Refocus-related operations require execution outside of keyboard eves.
+        keybd.proc("ToggleFullscreen", [&](hids& gear, txts&){ gear.set_handled(); scroll_inst.bell::enqueue(boss.This(), [&](auto& /*boss*/){ scroll_inst.base::riseup(tier::preview, e2::form::size::enlarge::fullscreen, gear); }); });
+
+        //todo revise (preview/release)
+        keybd.bind( "Esc", "DropAutoRepeat"    );
+        keybd.bind( "Esc", "WindowClosePreview");
+        keybd.bind("-Esc", "WindowClose"       );
+        keybd.bind( "Any", "CancelWindowClose" );
+
+        keybd.bind("PageUp"    , "ScrollPageUp"    );
+        keybd.bind("PageDown"  , "ScrollPageDown"  );
+        keybd.bind("UpArrow"   , "ScrollLineUp"    );
+        keybd.bind("DownArrow" , "ScrollLineDown"  );
+        keybd.bind("LeftArrow" , "ScrollCharLeft"  );
+        keybd.bind("RightArrow", "ScrollCharRight" );
+        keybd.bind("Home"      , "DropAutoRepeat"  );
+        keybd.bind("Home"      , "ScrollTop"       );
+        keybd.bind("End"       , "DropAutoRepeat"  );
+        keybd.bind("End"       , "ScrollEnd"       );
+        keybd.bind("F11"       , "DropAutoRepeat"  );
+        keybd.bind("F11"       , "ToggleMaximize"  );
+        keybd.bind("F12"       , "DropAutoRepeat"  );
+        keybd.bind("F12"       , "ToggleFullscreen");
     };
 
     using builder_t = std::function<ui::sptr(eccc, xmls&)>;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.53";
+    static const auto version = "v0.9.99.54";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -439,7 +439,6 @@ namespace netxs::events::userland
                         EVENT_XS( find     , ui::focus_test_t   ), // request: Check the focus.
                         EVENT_XS( next     , ui::focus_test_t   ), // request: Next hop count.
                         EVENT_XS( check    , bool               ), // anycast: Check any focus.
-                        EVENT_XS( exclusive, bool               ), // release: Exclusive keyboard mode.
                         GROUP_XS( command  , si32               ), // release: Hotkey command preview.
 
                         SUBSET_XS( command )

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -209,12 +209,18 @@ namespace netxs::events::userland
                     EVENT_XS( appear  , twod        ), // Fly to the specified coords.
                     EVENT_XS( swarp   , const dent  ), // preview: Do form swarping.
                     GROUP_XS( go      , ui::sptr    ), // preview: Do form swarping.
+                    GROUP_XS( focus   , id_t        ),
 
                     SUBSET_XS( go )
                     {
                         EVENT_XS( next , ui::sptr ), // request: Proceed request for available objects (next).
                         EVENT_XS( prev , ui::sptr ), // request: Proceed request for available objects (prev).
                         EVENT_XS( item , ui::sptr ), // request: Proceed request for available objects (current).
+                    };
+                    SUBSET_XS( focus )
+                    {
+                        EVENT_XS( next , id_t ), // request: Ask to switch focus to the next window.
+                        EVENT_XS( prev , id_t ), // request: Ask to switch focus to the prev window.
                     };
                 };
                 SUBSET_XS( upon )

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -429,12 +429,12 @@ namespace netxs::events::userland
                     };
                     SUBSET_XS( keybd )
                     {
-                        EVENT_XS( enlist  , ui::gear_id_list_t ), // anycast: Enumerate all available foci.
-                        EVENT_XS( find    , ui::focus_test_t   ), // request: Check the focus.
-                        EVENT_XS( next    , ui::focus_test_t   ), // request: Next hop count.
-                        EVENT_XS( check   , bool               ), // anycast: Check any focus.
-                        EVENT_XS( scheme  , text               ), // release: Hotkey scheme id.
-                        GROUP_XS( command , si32               ), // release: Hotkey command preview.
+                        EVENT_XS( enlist   , ui::gear_id_list_t ), // anycast: Enumerate all available foci.
+                        EVENT_XS( find     , ui::focus_test_t   ), // request: Check the focus.
+                        EVENT_XS( next     , ui::focus_test_t   ), // request: Next hop count.
+                        EVENT_XS( check    , bool               ), // anycast: Check any focus.
+                        EVENT_XS( exclusive, bool               ), // release: Exclusive keyboard mode.
+                        GROUP_XS( command  , si32               ), // release: Hotkey command preview.
 
                         SUBSET_XS( command )
                         {
@@ -819,6 +819,7 @@ namespace netxs::ui
         //          base::raw_riseup(tier::preview, e2::form::prop::ui::header, txt);
         void raw_riseup(si32 Tier, hint event_id, auto& param, bool forced = faux)
         {
+            //todo make it flat
             auto lock = bell::sync();
             bell::signal(Tier, event_id, param);
             if (forced)

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -589,8 +589,11 @@ namespace netxs::ui
                     if (gear_id)
                     {
                         auto& gear = *gear_ptr;
-                        gear.fire_fast();
-                        gear.fire(event_id);
+                        if (gear.m_sys.timecod != time{}) // Don't send mouse events if the mouse has not been used yet.
+                        {
+                            gear.fire_fast();
+                            gear.fire(event_id);
+                        }
                     }
                 }
             }

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1127,10 +1127,7 @@ namespace netxs::ui
         {
             keybd.proc("ToggleDebugOverlay", [&](hids& gear, txts&){ gear.set_handled(); debug ? debug.stop() : debug.start(); });
             auto bindings = keybd.load(config, "tui");
-            for (auto& r : bindings)
-            {
-                keybd.bind(r.chord, r.actions, r.mode);
-            }
+            keybd.bind(bindings);
 
             base::root(true);
             base::limits(dot_11);

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1168,7 +1168,7 @@ namespace netxs::ui
                     target->bell::signal(tier::preview, hids::events::keybd::key::post, gear);
                 }
             };
-            LISTEN(tier::release, hids::events::keybd::key::any, gear, tokens) // Forward unhandled events to the outside. Return back unhandled keybd events.
+            LISTEN(tier::release, hids::events::keybd::any, gear, tokens) // Forward unhandled events to the outside. Return back unhandled keybd events.
             {
                 if (!gear.handled)
                 {

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2010,19 +2010,17 @@ namespace netxs::ui
                     }
                 };
                 proc("Noop",           [&](hids& gear, txts&){ gear.set_handled(); interrupt_key_proc = true; });
-                proc("DropAutoRepeat", [&](hids& gear, txts&){ if (gear.keystat == input::key::repeated) gear.set_handled(); interrupt_key_proc = true; });
+                proc("DropAutoRepeat", [&](hids& gear, txts&){ if (gear.keystat == input::key::repeated) { gear.set_handled(); interrupt_key_proc = true; }});
             }
 
-            template<si32 Tier = tier::release>
             auto filter(hids& gear)
             {
                 if (gear.payload == input::keybd::type::keypress)
                 {
-                    if (!gear.handled) _dispatch<Tier>(gear, gear.vkchord);
-                    if (!gear.handled) _dispatch<Tier>(gear, gear.chchord);
-                    if (!gear.handled) _dispatch<Tier>(gear, gear.scchord);
+                    if (!gear.touched) _dispatch<tier::preview>(gear, gear.vkchord);
+                    if (!gear.touched) _dispatch<tier::preview>(gear, gear.chchord);
+                    if (!gear.touched) _dispatch<tier::preview>(gear, gear.scchord);
                 }
-                return !gear.handled;
             }
             void proc(qiew name, func proc)
             {

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1908,6 +1908,7 @@ namespace netxs::ui
             subs tokens;
             bool interrupt_key_proc;
             std::unordered_map<id_t, time> last_key;
+            si64 instance_id;
 
             auto _get_chord_list(qiew chord_str = {}) -> std::optional<std::invoke_result_t<decltype(input::key::kmap::chord_list), qiew>>
             {
@@ -1973,7 +1974,7 @@ namespace netxs::ui
                     }
                     else
                     {
-                        gear.touched = true;
+                        gear.touched = instance_id;
                     }
                 }
             }
@@ -1982,7 +1983,8 @@ namespace netxs::ui
             keybd(base&&) = delete;
             keybd(base& boss)
                 : skill{ boss },
-                  interrupt_key_proc{ faux }
+                  interrupt_key_proc{ faux },
+                  instance_id{ datetime::now().time_since_epoch().count() }
             {
 
                 boss.LISTEN(tier::anycast, e2::form::upon::started, root, memo)
@@ -1996,6 +1998,7 @@ namespace netxs::ui
                         };
                         focusable_parent->LISTEN(tier::release, hids::events::keybd::key::any, gear, tokens)
                         {
+                            gear.shared_event = gear.touched && gear.touched != instance_id;
                             auto& timecod = last_key[gear.id];
                             if (gear.timecod > timecod)
                             {
@@ -2016,6 +2019,7 @@ namespace netxs::ui
                         };
                         focusable_parent->LISTEN(tier::preview, hids::events::keybd::key::any, gear, tokens)
                         {
+                            gear.shared_event = gear.touched && gear.touched != instance_id;
                             if (gear.payload == input::keybd::type::keypress)
                             {
                                 if (!gear.touched && !gear.handled) _dispatch(gear, true, gear.vkchord);

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1204,7 +1204,6 @@ namespace netxs::ui
             //todo kb navigation type: transit, cyclic, plain, disabled, closed
             bool scope; // focus: Cutoff threshold for focus branch.
             umap gears; // focus: Registered gears.
-            text hotkey_scheme; // focus: Current hotkey scheme.
             si32 node_type; // focus: .
 
             void signal_state()
@@ -1255,10 +1254,6 @@ namespace netxs::ui
                 }
                 return iter->second;
             }
-            void hotkey_scheme_notify()
-            {
-                boss.bell::signal(tier::release, e2::form::state::keybd::scheme, hotkey_scheme);
-            }
             void notify_set_focus(auto& route, auto& seed)
             {
                 route.active = true;
@@ -1266,11 +1261,6 @@ namespace netxs::ui
                 {
                     boss.bell::signal(tier::release, e2::form::state::focus::on, seed.gear_id);
                     signal_state();
-                    if (auto gear_ptr = boss.bell::getref<hids>(seed.gear_id)) // Notify about current gear hotkey scheme.
-                    {
-                        hotkey_scheme = gear_ptr->hscheme;
-                        hotkey_scheme_notify();
-                    }
                 }
             }
             void notify_off_focus(auto& route, auto& seed)
@@ -1419,34 +1409,28 @@ namespace netxs::ui
                     }
                     gear.dismiss();
                 };
-                boss.LISTEN(tier::request, e2::form::state::keybd::scheme, scheme, memo)
-                {
-                    scheme = hotkey_scheme;
-                };
                 // pro::focus: Subscribe on keybd events.
                 boss.LISTEN(tier::preview, hids::events::keybd::key::post, gear, memo) // preview: Run after any.
                 {
-                    if (!gear) return;
-                    if (gear.payload == input::keybd::type::keypress && hotkey_scheme != gear.hscheme) // Notify if hotkey scheme has changed.
-                    {
-                        hotkey_scheme = gear.hscheme;
-                        hotkey_scheme_notify();
-                    }
                     auto& route = get_route(gear.id);
                     if (route.active)
                     {
-                        auto alive = gear.alive;
-                        auto accum = alive;
-                        route.foreach([&](auto& nexthop)
+                        if (route.next.size())
                         {
-                            nexthop->bell::signal(tier::preview, hids::events::keybd::key::post, gear);
-                            accum &= gear.alive;
-                            gear.alive = alive;
-                        });
-                        gear.alive = accum;
-                        if (accum)
+                            route.foreach([&](auto& nexthop)
+                            {
+                                nexthop->bell::signal(tier::preview, hids::events::keybd::key::post, gear);
+                            });
+                        }
+                        else if (node_type != mode::relay) // Send key::post event back.
                         {
-                            boss.bell::signal(tier::release, hids::events::keybd::key::post, gear);
+                            auto parent_ptr = boss.This();
+                            do
+                            {
+                                parent_ptr->bell::signal(tier::release, hids::events::keybd::key::post, gear);
+                                parent_ptr = parent_ptr->parent();
+                            }
+                            while (!gear.handled && parent_ptr);
                         }
                     }
                 };
@@ -1920,10 +1904,10 @@ namespace netxs::ui
             using skill::boss,
                   skill::memo;
 
-            std::unordered_map<text, std::unordered_map<text, std::list<std::pair<wptr, netxs::sptr<txts>>>, qiew::hash, qiew::equal>> handlers_preview;
-            std::unordered_map<text, std::unordered_map<text, std::list<std::pair<wptr, netxs::sptr<txts>>>, qiew::hash, qiew::equal>> handlers_release;
+            std::unordered_map<text, std::pair<std::list<std::pair<wptr, netxs::sptr<txts>>>, bool>, qiew::hash, qiew::equal> handlers;
             std::unordered_map<text, sptr, qiew::hash, qiew::equal> api_map;
             subs tokens;
+            bool interrupt_key_proc;
 
             auto _get_chord_list(qiew chord_str = {}) -> std::optional<std::invoke_result_t<decltype(input::key::kmap::chord_list), qiew>>
             {
@@ -1962,61 +1946,51 @@ namespace netxs::ui
                 }
                 return _get_chord_list();
             }
-            template<si32 Tier = tier::release>
-            auto _set(auto& chords, sptr handler_ptr, qiew scheme, auto args_ptr)
-            {
-                auto& handlers = Tier == tier::release ? handlers_release[scheme] : handlers_preview[scheme];
-                for (auto& chord : chords)
-                {
-                    handlers[chord].emplace_back(handler_ptr, args_ptr);
-                }
-            }
-            template<si32 Tier = tier::release>
-            auto _reset(auto& chords, qiew scheme)
-            {
-                auto& handlers = Tier == tier::release ? handlers_release[scheme] : handlers_preview[scheme];
-                for (auto& chord : chords)
-                {
-                    handlers[chord].clear();
-                }
-            }
-            template<si32 Tier = tier::release>
+            template<si32 Tier>
             void _dispatch(hids& gear, qiew chord)
             {
-                auto& handlers = Tier == tier::release ? handlers_release[gear.hscheme] : handlers_preview[gear.hscheme];
                 auto iter = handlers.find(chord);
                 if (iter != handlers.end())
                 {
-                    auto& procs = iter->second;
-                    std::erase_if(procs, [&](auto& rec)
+                    auto& [procs, raw_mode] = iter->second;
+                    if constexpr (Tier == tier::preview)
                     {
-                        auto& proc_wptr = rec.first;
-                        auto& args_ptr = rec.second;
-                        auto proc_ptr = proc_wptr.lock();
-                        if (proc_ptr)
+                        gear.touched = raw_mode ? 2 : 1;
+                    }
+                    else
+                    {
+                        std::erase_if(procs, [&](auto& rec)
                         {
-                            if (!gear.handled) (*proc_ptr)(gear, *args_ptr);
-                        }
-                        return !proc_ptr;
-                    });
-                    if (procs.empty()) handlers.erase(iter);
+                            auto& [proc_wptr, args_ptr] = rec;
+                            auto proc_ptr = proc_wptr.lock();
+                            if (proc_ptr)
+                            {
+                                if (!interrupt_key_proc) (*proc_ptr)(gear, *args_ptr);
+                            }
+                            return !proc_ptr;
+                        });
+                        if (procs.empty()) handlers.erase(iter);
+                    }
                 }
             }
 
         public:
             keybd(base&&) = delete;
             keybd(base& boss)
-                : skill{ boss }
+                : skill{ boss },
+                  interrupt_key_proc{ faux }
             {
                 boss.LISTEN(tier::anycast, e2::form::upon::started, root, memo)
                 {
                     tokens.clear();
                     if (auto focusable_parent = boss.base::riseup(tier::request, e2::config::plugins::focus::owner))
                     {
-                        focusable_parent->LISTEN(tier::release, hids::events::keybd::key::post, gear, tokens)
+                        focusable_parent->LISTEN(tier::release, hids::events::keybd::key::any, gear, tokens)
                         {
+                            //todo check digest
                             if (gear.payload == input::keybd::type::keypress)
                             {
+                                interrupt_key_proc = faux;
                                 if (!gear.handled) _dispatch<tier::release>(gear, input::key::kmap::any_key);
                                 if (!gear.handled) _dispatch<tier::release>(gear, gear.vkchord);
                                 if (!gear.handled) _dispatch<tier::release>(gear, gear.chchord);
@@ -2027,16 +2001,16 @@ namespace netxs::ui
                         {
                             if (gear.payload == input::keybd::type::keypress)
                             {
-                                if (!gear.handled) _dispatch<tier::preview>(gear, gear.vkchord);
-                                if (!gear.handled) _dispatch<tier::preview>(gear, gear.chchord);
-                                if (!gear.handled) _dispatch<tier::preview>(gear, gear.scchord);
-                                if (!gear.handled) _dispatch<tier::preview>(gear, input::key::kmap::any_key);
+                                if (!gear.touched) _dispatch<tier::preview>(gear, gear.vkchord);
+                                if (!gear.touched) _dispatch<tier::preview>(gear, gear.chchord);
+                                if (!gear.touched) _dispatch<tier::preview>(gear, gear.scchord);
+                                if (!gear.touched) _dispatch<tier::preview>(gear, input::key::kmap::any_key);
                             }
                         };
                     }
                 };
-                proc("Noop",           [](hids& gear, txts&){ gear.set_handled(); });
-                proc("DropAutoRepeat", [](hids& gear, txts&){ if (gear.keystat == input::key::repeated) gear.set_handled(); });
+                proc("Noop",           [&](hids& gear, txts&){ gear.set_handled(); interrupt_key_proc = true; });
+                proc("DropAutoRepeat", [&](hids& gear, txts&){ if (gear.keystat == input::key::repeated) gear.set_handled(); interrupt_key_proc = true; });
             }
 
             template<si32 Tier = tier::release>
@@ -2054,8 +2028,7 @@ namespace netxs::ui
             {
                 api_map[name] = ptr::shared(std::move(proc));
             }
-            template<si32 Tier = tier::release>
-            auto bind(qiew chord_str, qiew scheme, auto&& proc_names)
+            auto bind(qiew chord_str, auto&& proc_names, bool raw_mode = faux)
             {
                 if (!chord_str) return;
                 if (auto chord_list = _get_chords(chord_str))
@@ -2067,14 +2040,22 @@ namespace netxs::ui
                         {
                             if (auto iter = api_map.find(proc_name); iter != api_map.end())
                             {
-                                auto handle_ptr = iter->second;
-                                _set<Tier>(chords, handle_ptr, scheme, args_ptr);
+                                auto handler_ptr = iter->second;
+                                for (auto& chord : chords)
+                                {
+                                    auto& r = handlers[chord];
+                                    r.first.emplace_back(handler_ptr, args_ptr);
+                                    r.second = raw_mode;
+                                }
                             }
                             else log("%%Action '%proc%' not found", prompt::user, proc_name);
                         }
                         else
                         {
-                            _reset<Tier>(chords, scheme);
+                            for (auto& chord : chords)
+                            {
+                                handlers.erase(chord);
+                            }
                         }
                     };
                     if constexpr (std::is_same_v<char, std::decay_t<decltype(proc_names[0])>>) // The case it is a plain string.
@@ -2102,11 +2083,11 @@ namespace netxs::ui
                     for (auto keybind_ptr : keybinds)
                     {
                         auto chord = keybind_ptr->take_value();
-                        auto scheme = keybind_ptr->take("scheme", ""s);
+                        auto chord_mode = keybind_ptr->take("raw", faux);
                         auto action_ptr_list = keybind_ptr->list("action");
-                        bindings.push_back({ .chord = chord, .scheme = scheme });
+                        bindings.push_back({ .chord = chord, .mode = chord_mode });
                         auto& rec = bindings.back();
-                        //if constexpr (debugmode) log("chord=%% scheme=%%", chord, scheme);
+                        if constexpr (debugmode) log("chord=%% raw=%%", chord, chord_mode);
                         for (auto action_ptr : action_ptr_list)
                         {
                             rec.actions.push_back({ .action = action_ptr->take_value() });

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -861,7 +861,6 @@ namespace netxs::directvt
                                         (si32, whlsi)
                                         (bool, hzwhl)
                                         (fp2d, click))
-        STRUCT_macro(hotkey_scheme,     (id_t, gear_id) (text, hscheme))
         STRUCT_macro(fullscrn,          (id_t, gear_id))
         STRUCT_macro(maximize,          (id_t, gear_id))
         STRUCT_macro(header,            (id_t, window_id) (text, utf8))
@@ -891,11 +890,11 @@ namespace netxs::directvt
                                         (si32, keystat)  // syskeybd: Key state: unknown, pressed, repeated, released.
                                         (text, cluster)  // syskeybd: Generated string.
                                         (bool, handled)  // syskeybd: Key event is handled.
+                                        (si32, touched)  // syskeybd: Key event is touched.
                                         (si32, keycode)  // syskeybd: Key id.
                                         (text, vkchord)  // sysmouse: Key virtcode-based chord.
                                         (text, scchord)  // sysmouse: Key scancode-based chord.
-                                        (text, chchord)  // sysmouse: Key virtcode+cluster-based chord.
-                                        (text, hscheme)) // sysmouse: Current hotkey scheme.
+                                        (text, chchord)) // sysmouse: Key virtcode+cluster-based chord.
         STRUCT_macro(sysmouse,          (id_t, gear_id)  // sysmouse: Devide id.
                                         (si32, ctlstat)  // sysmouse: Keybd modifiers.
                                         (si32, enabled)  // sysmouse: Mouse device health status.
@@ -1411,7 +1410,6 @@ namespace netxs::directvt
             X(mouse_event      ) /* Mouse events.                                 */\
             X(tooltips         ) /* Tooltip list.                                 */\
             X(jgc_list         ) /* List of jumbo GC.                             */\
-            X(hotkey_scheme    ) /* Request hotkey scheme to set.                 */\
             X(fullscrn         ) /* Notify/Request to fullscreen.                 */\
             X(maximize         ) /* Request to maximize window.                   */\
             X(header           ) /* Set window title.                             */\

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -883,27 +883,28 @@ namespace netxs::directvt
         STRUCT_macro(sysfocus,          (id_t, gear_id) (bool, state) (si32, focus_type))
         STRUCT_macro(syskeybd,          (id_t, gear_id)  // syskeybd: Devide id.
                                         (si32, ctlstat)  // syskeybd: Keybd modifiers.
-                                        (bool, extflag)  // syskeybd: Win32 extflag.
-                                        (byte, payload)  // syskeybd: Payload type.
+                                        (time, timecod)  // syskeybd: Event time code.
                                         (si32, virtcod)  // syskeybd: Key virtual code.
                                         (si32, scancod)  // syskeybd: Scancode.
                                         (si32, keystat)  // syskeybd: Key state: unknown, pressed, repeated, released.
-                                        (text, cluster)  // syskeybd: Generated string.
+                                        (si32, keycode)  // syskeybd: Key id.
+                                        (byte, payload)  // syskeybd: Payload type.
+                                        (bool, extflag)  // syskeybd: Win32 extflag.
                                         (bool, handled)  // syskeybd: Key event is handled.
                                         (bool, touched)  // syskeybd: Key event is touched.
-                                        (si32, keycode)  // syskeybd: Key id.
+                                        (text, cluster)  // syskeybd: Generated string.
                                         (text, vkchord)  // sysmouse: Key virtcode-based chord.
                                         (text, scchord)  // sysmouse: Key scancode-based chord.
                                         (text, chchord)) // sysmouse: Key virtcode+cluster-based chord.
         STRUCT_macro(sysmouse,          (id_t, gear_id)  // sysmouse: Devide id.
                                         (si32, ctlstat)  // sysmouse: Keybd modifiers.
+                                        (time, timecod)  // sysmouse: Event time code.
                                         (si32, enabled)  // sysmouse: Mouse device health status.
                                         (si32, buttons)  // sysmouse: Buttons bit state.
                                         (bool, hzwheel)  // sysmouse: If true: Horizontal scroll wheel. If faux: Vertical scroll wheel.
                                         (fp32, wheelfp)  // sysmouse: Scroll delta in floating units.
                                         (si32, wheelsi)  // sysmouse: Scroll delta in integer units.
                                         (fp2d, coordxy)  // sysmouse: Pixel-wise cursor coordinates.
-                                        (time, timecod)  // sysmouse: Event time code.
                                         (ui32, changed)) // sysmouse: Update stamp.
         STRUCT_macro(mousebar,          (bool, mode)) // CCC_SMS/* 26:1p */
         STRUCT_macro(unknown_gc,        (ui64, token))

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -890,7 +890,7 @@ namespace netxs::directvt
                                         (si32, keystat)  // syskeybd: Key state: unknown, pressed, repeated, released.
                                         (text, cluster)  // syskeybd: Generated string.
                                         (bool, handled)  // syskeybd: Key event is handled.
-                                        (si32, touched)  // syskeybd: Key event is touched.
+                                        (bool, touched)  // syskeybd: Key event is touched.
                                         (si32, keycode)  // syskeybd: Key id.
                                         (text, vkchord)  // sysmouse: Key virtcode-based chord.
                                         (text, scchord)  // sysmouse: Key scancode-based chord.

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -891,7 +891,7 @@ namespace netxs::directvt
                                         (byte, payload)  // syskeybd: Payload type.
                                         (bool, extflag)  // syskeybd: Win32 extflag.
                                         (bool, handled)  // syskeybd: Key event is handled.
-                                        (bool, touched)  // syskeybd: Key event is touched.
+                                        (si64, touched)  // syskeybd: Key event is touched.
                                         (text, cluster)  // syskeybd: Generated string.
                                         (text, vkchord)  // sysmouse: Key virtcode-based chord.
                                         (text, scchord)  // sysmouse: Key scancode-based chord.

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2002,8 +2002,8 @@ namespace netxs::gui
             wkeybd.proc("RollFontsBackward"     , [&](hids& gear, txts&){ gear.set_handled(); RollFontList(feed::rev);  });
             wkeybd.proc("RollFontsForward"      , [&](hids& gear, txts&){ gear.set_handled(); RollFontList(feed::fwd);  });
             wkeybd.proc("_ResetWheelAccumulator", [&](hids& /*gear*/, txts&){ whlacc = {}; });
-            wkeybd.bind("-Ctrl", "_ResetWheelAccumulator");
-            wkeybd.bind("-Ctrl", "_ResetWheelAccumulator");
+            wkeybd.bind("-Ctrl", "_ResetWheelAccumulator", true);
+            wkeybd.bind("-Ctrl", "_ResetWheelAccumulator", true);
             wkeybd.bind(hotkeys);
         }
 

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2004,10 +2004,7 @@ namespace netxs::gui
             wkeybd.proc("_ResetWheelAccumulator", [&](hids& /*gear*/, txts&){ whlacc = {}; });
             wkeybd.bind("-Ctrl", "_ResetWheelAccumulator");
             wkeybd.bind("-Ctrl", "_ResetWheelAccumulator");
-            for (auto& r : hotkeys)
-            {
-                wkeybd.bind(r.chord, r.actions, r.mode);
-            }
+            wkeybd.bind(hotkeys);
         }
 
         virtual bool layer_create(layer& s, winbase* host_ptr = nullptr, twod win_coord = {}, twod grid_size = {}, dent border_dent = {}, twod cell_size = {}) = 0;

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3797,7 +3797,7 @@ namespace netxs::gui
             {
                 //log("\t", rect{{ update_area.left, update_area.top }, { update_area.right - update_area. left, update_area.bottom - update_area.top }});
                 auto ok = ::UpdateLayeredWindowIndirect((HWND)s.hWnd, &update_info);
-                if (!ok) log("%%UpdateLayeredWindowIndirect call failed", prompt::gui);
+                if constexpr (debugmode) if (!ok) log("%%UpdateLayeredWindowIndirect call failed", prompt::gui);
             };
             //static auto clr = 0; clr++;
             for (auto r : s.sync)

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1652,10 +1652,8 @@ namespace netxs::gui
                     lock.thing.set(gear);
                     lock.thing.sendfx([&](auto block)
                     {
-                        if (proc(block))
-                        {
-                            intio.send(block);
-                        }
+                        proc(block);
+                        intio.send(block);
                     });
                 }
             };
@@ -2844,13 +2842,13 @@ namespace netxs::gui
         {
             gear.handled = {};
             gear.touched = {};
+            wkeybd.filter(gear);
             stream.keybd(gear, [&](view block)
             {
                 if (mfocus.active())
                 {
                     keybd_send_block(block); // Send multifocus events.
                 }
-                return wkeybd.filter<tier::preview>(gear);
             });
         }
         void keybd_send_state(si32 virtcod = {}, si32 keystat = {}, si32 scancod = {}, bool extflag = {}, view cluster = {}, bool synth = faux)
@@ -3072,10 +3070,9 @@ namespace netxs::gui
                         stream.m.ctlstat = keymod;
                         keybd.syncto(gear);
                         gear.gear_id = gear.bell::id; // Restore gear id.
-                        if (wkeybd.filter<tier::preview>(gear))
-                        {
-                            stream.keybd(gear);
-                        }
+                        gear.touched = {};
+                        wkeybd.filter(gear);
+                        stream.keybd(gear);
                     }
                 }
                 else command = 0;

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2839,6 +2839,7 @@ namespace netxs::gui
         {
             gear.handled = {};
             gear.touched = {};
+            gear.timecod = datetime::now();
             wkeybd.filter(gear);
             stream.keybd(gear, [&](view block)
             {

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1168,6 +1168,7 @@ namespace netxs::input
 
         id_t gear_id{};
         si32 ctlstat{};
+        time timecod{};
         si32 keystat{};
         si32 virtcod{};
         si32 scancod{};

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -710,7 +710,7 @@ namespace netxs::input
                 txts args;
             };
             text chord;
-            bool mode{};
+            bool preview{};
             std::vector<action_t> actions;
         };
         using keybind_list_t = std::vector<keybind_t>;
@@ -1166,20 +1166,20 @@ namespace netxs::input
 
         si32 nullkey = key::Key2;
 
-        si32 ctlstat{};
         id_t gear_id{};
-        text cluster{};
-        byte payload{}; // keybd: Payload type.
-        bool extflag{};
+        si32 ctlstat{};
         si32 keystat{};
-        bool handled{};
-        si32 touched{};
         si32 virtcod{};
         si32 scancod{};
         si32 keycode{};
+        bool extflag{};
+        bool handled{};
+        bool touched{};
+        text cluster{};
         text vkchord{};
         text scchord{};
         text chchord{};
+        byte payload{}; // keybd: Payload type.
 
         auto doinput()
         {

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1175,7 +1175,7 @@ namespace netxs::input
         si32 keycode{};
         bool extflag{};
         bool handled{};
-        bool touched{};
+        si64 touched{};
         text cluster{};
         text vkchord{};
         text scchord{};
@@ -1500,6 +1500,8 @@ namespace netxs::input
 
         id_t user_index; // hids: User/Device image/icon index.
         kmap other_key; // hids: Dynamic key-vt mapping.
+
+        bool shared_event = faux; // hids: The key event was touched by another procees/handler. See pro::keybd(release, key::post) for detailts.
 
         template<class T>
         hids(auth& indexer, T& props, base& owner, core const& idmap)

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -21,8 +21,7 @@ namespace netxs::events::userland
 
             SUBSET_XS( keybd )
             {
-                EVENT_XS( scheme, input::hids ),
-                GROUP_XS( key   , input::hids ),
+                GROUP_XS( key, input::hids ),
 
                 SUBSET_XS( key )
                 {
@@ -711,7 +710,7 @@ namespace netxs::input
                 txts args;
             };
             text chord;
-            text scheme;
+            bool mode{};
             std::vector<action_t> actions;
         };
         using keybind_list_t = std::vector<keybind_t>;
@@ -1174,13 +1173,13 @@ namespace netxs::input
         bool extflag{};
         si32 keystat{};
         bool handled{};
+        si32 touched{};
         si32 virtcod{};
         si32 scancod{};
         si32 keycode{};
         text vkchord{};
         text scchord{};
         text chchord{};
-        text hscheme{};
 
         auto doinput()
         {
@@ -1659,23 +1658,9 @@ namespace netxs::input
         {
             nodbl = true;
         }
-        void set_handled(bool b = true)
+        void set_handled()
         {
-            if (keybd::keystat == input::key::released) // Don't stop the key release event, just break the chord processing.
-            {
-                keybd::vkchord.clear();
-                keybd::scchord.clear();
-                keybd::chchord.clear();
-            }
-            else
-            {
-                handled = b;
-            }
-        }
-        void set_hotkey_scheme(qiew scheme)
-        {
-            keybd::hscheme = scheme;
-            owner.bell::signal(tier::preview, hids::events::keybd::scheme, *this);
+            keybd::handled = true;
         }
 
         void take(sysfocus& f)
@@ -1875,7 +1860,6 @@ namespace netxs::input
         }
         void fire_keybd()
         {
-            alive = true;
             owner.bell::signal(tier::preview, hids::events::keybd::key::post, *this);
         }
         void fire_board()

--- a/src/netxs/desktopio/quartz.hpp
+++ b/src/netxs/desktopio/quartz.hpp
@@ -44,7 +44,7 @@ namespace netxs::datetime
     // quartz: Return current moment.
     auto now()
     {
-        return std::chrono::steady_clock::now();
+        return std::chrono::steady_clock::now(); // Note: steady_clock does not contain the current time (it is a monotonic clock).
     }
     auto breakdown(span t)
     {
@@ -54,6 +54,16 @@ namespace netxs::datetime
         auto seconds      = datetime::round<ui32, std::chrono::     seconds>(t -= std::chrono::minutes{ minutes });
         auto milliseconds = datetime::round<ui32, std::chrono::milliseconds>(t -= std::chrono::seconds{ seconds });
         return std::tuple{ days, hours, minutes, seconds, milliseconds };
+    }
+    auto breakdown(time t)
+    {
+        auto d = t.time_since_epoch();
+        auto hours        = datetime::round<ui32, std::chrono::       hours>(d);
+        auto minutes      = datetime::round<ui32, std::chrono::     minutes>(d -= std::chrono::       hours{ hours        });
+        auto seconds      = datetime::round<ui32, std::chrono::     seconds>(d -= std::chrono::     minutes{ minutes      });
+        auto milliseconds = datetime::round<ui32, std::chrono::milliseconds>(d -= std::chrono::     seconds{ seconds      });
+        auto microseconds = datetime::round<ui32, std::chrono::microseconds>(d -= std::chrono::milliseconds{ milliseconds });
+        return std::tuple{ hours % 24, minutes, seconds, milliseconds, microseconds };
     }
     auto milliseconds(time t)
     {

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4841,7 +4841,6 @@ namespace netxs::os
         {
             struct adapter : s11n
             {
-                text hscheme;
                 id_t gear_id = 1;
 
                 void direct(s11n::xs::bitmap_vt16    /*lock*/, view& data) { io::send(data); }
@@ -4910,44 +4909,6 @@ namespace netxs::os
                 void handle(s11n::xs::clipdata_request lock)
                 {
                     s11n::recycle_cliprequest(dtvt::client, lock);
-                }
-                void handle(s11n::xs::sysfocus         lock)
-                {
-                    auto& item = lock.thing;
-                    if (item.state)
-                    {
-                        sync_hotkey_scheme();
-                    }
-                }
-                void handle(s11n::xs::hotkey_scheme    lock)
-                {
-                    auto& k = lock.thing;
-                    hscheme = k.hscheme;
-                    sync_hotkey_scheme();
-                }
-                // adapter: Send an empty hotkey scheme packet.
-                void sync_hotkey_scheme()
-                {
-                    auto item = s11n::syskeybd.freeze();
-                    auto temp = input::syskeybd{}; //todo same code in gui.hpp:2860
-                    std::swap(temp.vkchord, item.thing.vkchord);
-                    std::swap(temp.scchord, item.thing.scchord);
-                    std::swap(temp.chchord, item.thing.chchord);
-                    std::swap(temp.cluster, item.thing.cluster);
-                    std::swap(temp.keystat, item.thing.keystat);
-                    item.thing.gear_id = gear_id;
-                    item.thing.hscheme = hscheme;
-                    item.thing.virtcod = 0;
-                    item.thing.scancod = 0;
-                    item.thing.keycode = 0;
-                    item.thing.payload = input::keybd::type::keypress;
-                    item.thing.set();
-                    item.thing.sendby<faux, faux>(dtvt::client);
-                    std::swap(temp.vkchord, item.thing.vkchord);
-                    std::swap(temp.scchord, item.thing.scchord);
-                    std::swap(temp.chchord, item.thing.chchord);
-                    std::swap(temp.cluster, item.thing.cluster);
-                    std::swap(temp.keystat, item.thing.keystat);
                 }
 
                 adapter()
@@ -6091,14 +6052,7 @@ namespace netxs::os
 
             auto alarm = fire{};
             auto alive = flag{ true };
-            auto keybd = [&](auto& data)
-            {
-                if (alive)
-                {
-                    data.hscheme = proxy.hscheme; // Inject current hotkey scheme.
-                    proxy.syskeybd.send(intio, data);
-                }
-            };
+            auto keybd = [&](auto& data){ if (alive)                proxy.syskeybd.send(intio, data); };
             auto mouse = [&](auto& data){ if (alive)                proxy.sysmouse.send(intio, data); };
             auto focus = [&](auto state){ if (alive)                proxy.sysfocus.send(intio, proxy.gear_id, state, 0); };
             auto winsz = [&](auto& data){ if (alive)                proxy.syswinsz.send(intio, data); };

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -5083,7 +5083,6 @@ namespace netxs::os
                     if (count == 0) continue;
                     items.resize(count);
                     if (!::ReadConsoleInputW(os::stdin_fd, items.data(), count, &count)) break;
-                    auto timecode = datetime::now();
                     auto head = items.begin();
                     auto tail = items.end();
                     while (alive && head != tail)
@@ -5109,7 +5108,7 @@ namespace netxs::os
                                 m.hzwheel = faux;
                                 m.wheelfp = 0;
                                 m.wheelsi = 0;
-                                m.timecod = timecode;
+                                m.timecod = datetime::now();
                                 m.changed++;
                                 mouse(m); // Fire mouse event to update kb modifiers.
                             }
@@ -5223,7 +5222,7 @@ namespace netxs::os
                             if (changed || wheeldt) // Don't fire the same state (conhost fires the same events every second).
                             {
                                 m.changed++;
-                                m.timecod = timecode;
+                                m.timecod = datetime::now();
                                 mouse(m);
                             }
                         }
@@ -6052,7 +6051,14 @@ namespace netxs::os
 
             auto alarm = fire{};
             auto alive = flag{ true };
-            auto keybd = [&](auto& data){ if (alive)                proxy.syskeybd.send(intio, data); };
+            auto keybd = [&](auto& data)
+            {
+                if (alive)
+                {
+                    data.timecod = datetime::now();
+                    proxy.syskeybd.send(intio, data);
+                }
+            };
             auto mouse = [&](auto& data){ if (alive)                proxy.sysmouse.send(intio, data); };
             auto focus = [&](auto state){ if (alive)                proxy.sysfocus.send(intio, proxy.gear_id, state, 0); };
             auto winsz = [&](auto& data){ if (alive)                proxy.syswinsz.send(intio, data); };

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7774,10 +7774,7 @@ namespace netxs::ui
             chords.proc("TerminalWrapMode",             [&](hids& gear, txts& args){ gear.set_handled(); if (args.empty()) exec_cmd(commands::ui::togglewrp); else set_wrapln(1 + (si32)!xml::take_or<bool>(args.front(), true)); });
             chords.proc("ExclusiveKeyboardMode",        [&](hids& gear, txts& args){ gear.set_handled(); if (args.empty()) exec_cmd(commands::ui::toggleraw); else set_rawkbd(1 + (si32)!xml::take_or<bool>(args.front(), true)); });
             auto bindings = chords.load(xml_config, "terminal");
-            for (auto& r : bindings)
-            {
-                chords.bind(r.chord, r.actions, r.mode);
-            }
+            chords.bind(bindings);
 
             LISTEN(tier::general, e2::timer::tick, timestamp) // Update before world rendering.
             {
@@ -7832,7 +7829,7 @@ namespace netxs::ui
             };
             LISTEN(tier::release, hids::events::keybd::key::post, gear)
             {
-                if (gear.touched > 0 && (!rawkbd || gear.touched == 2) && gear.keystat != input::key::released) return;
+                if (gear.touched && !rawkbd && gear.keystat != input::key::released) return;
                 switch (gear.payload)
                 {
                     case keybd::type::keypress:

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -15,6 +15,7 @@ namespace netxs::events::userland
             EVENT_XS( selmod, si32 ),
             EVENT_XS( onesht, si32 ),
             EVENT_XS( selalt, si32 ),
+            EVENT_XS( rawkbd, bool ),
             GROUP_XS( toggle, bool ),
             GROUP_XS( colors, argb ),
             GROUP_XS( layout, si32 ),
@@ -82,6 +83,7 @@ namespace netxs::ui
                 enum commands : si32
                 {
                     center,
+                    toggleraw,
                     togglewrp,
                     togglejet,
                     togglesel,
@@ -6527,6 +6529,7 @@ namespace netxs::ui
         eccc       appcfg; // term: Application startup config.
         os::fdrw   fdlink; // term: Optional DirectVT uplink.
         hook       onerun; // term: One-shot token for restart session.
+        bool       rawkbd; // term: Exclusive keyboard access.
         vtty       ipccon; // term: IPC connector. Should be destroyed first.
 
         // term: Place rectangle block to the scrollback buffer.
@@ -7452,6 +7455,12 @@ namespace netxs::ui
             console.brush.reset(brush);
             bell::signal(tier::release, ui::term::events::colors::fg, fg);
         }
+        void set_rawkbd(si32 state = {})
+        {
+            if (!state) rawkbd = !rawkbd;
+            else        rawkbd = state - 1;
+            bell::signal(tier::release, ui::term::events::rawkbd, rawkbd);
+        }
         void set_wrapln(si32 wrapln = {})
         {
             target->selection_setwrp((wrap)wrapln);
@@ -7496,6 +7505,7 @@ namespace netxs::ui
             auto& console = *target;
             switch (cmd)
             {
+                case commands::ui::toggleraw:    set_rawkbd();                        break;
                 case commands::ui::togglewrp:    console.selection_setwrp();          break;
                 case commands::ui::togglejet:    console.selection_setjet();          break;
                 case commands::ui::togglesel:    selection_selmod();                  break;
@@ -7711,7 +7721,8 @@ namespace netxs::ui
               onesht{ mime::disabled },
               altscr{ config.def_alt_on },
               kbmode{ prot::vt },
-              ime_on{  faux }
+              ime_on{  faux }, 
+              rawkbd{  faux }
         {
             set_fg_color(config.def_fcolor);
             set_bg_color(config.def_bcolor);
@@ -7725,6 +7736,7 @@ namespace netxs::ui
             publish_property(ui::term::events::selmod,         [&](auto& v){ v = selmod; });
             publish_property(ui::term::events::onesht,         [&](auto& v){ v = onesht; });
             publish_property(ui::term::events::selalt,         [&](auto& v){ v = selalt; });
+            publish_property(ui::term::events::rawkbd,         [&](auto& v){ v = rawkbd; });
             publish_property(ui::term::events::colors::bg,     [&](auto& v){ v = target->brush.bgc(); });
             publish_property(ui::term::events::colors::fg,     [&](auto& v){ v = target->brush.fgc(); });
             publish_property(ui::term::events::layout::wrapln, [&](auto& v){ v = (si32)target->style.wrp(); });
@@ -7760,10 +7772,11 @@ namespace netxs::ui
             chords.proc("TerminalOutput",               [&](hids& gear, txts& args){ gear.set_handled(); if (args.size()) data_in(args.front()); });
             chords.proc("TerminalAlignMode",            [&](hids& gear, txts& args){ gear.set_handled(); if (args.empty()) exec_cmd(commands::ui::togglejet); else set_align((si32)netxs::get_or(xml::options::align, args.front(), bias::none)); });
             chords.proc("TerminalWrapMode",             [&](hids& gear, txts& args){ gear.set_handled(); if (args.empty()) exec_cmd(commands::ui::togglewrp); else set_wrapln(1 + (si32)!xml::take_or<bool>(args.front(), true)); });
+            chords.proc("ExclusiveKeyboardMode",        [&](hids& gear, txts& args){ gear.set_handled(); if (args.empty()) exec_cmd(commands::ui::toggleraw); else set_rawkbd(1 + (si32)!xml::take_or<bool>(args.front(), true)); });
             auto bindings = chords.load(xml_config, "terminal");
             for (auto& r : bindings)
             {
-                chords.bind<tier::release>(r.chord, r.scheme, r.actions);
+                chords.bind(r.chord, r.actions, r.mode);
             }
 
             LISTEN(tier::general, e2::timer::tick, timestamp) // Update before world rendering.
@@ -7817,12 +7830,12 @@ namespace netxs::ui
                     origin = new_area.coor;
                 }
             };
-            LISTEN(tier::release, hids::events::keybd::key::any, gear)
+            LISTEN(tier::release, hids::events::keybd::key::post, gear)
             {
+                if (gear.touched > 0 && (!rawkbd || gear.touched == 2) && gear.keystat != input::key::released) return;
                 switch (gear.payload)
                 {
                     case keybd::type::keypress:
-                        if (gear.handled) break; // Don't pass registered keyboard shortcuts.
                         if (config.resetonkey && gear.doinput())
                         {
                             this->base::riseup(tier::release, e2::form::animate::reset, 0); // Reset scroll animation.
@@ -7831,6 +7844,7 @@ namespace netxs::ui
                             follow[axis::Y] = true;
                         }
                         ipccon.keybd(gear, decckm, kbmode);
+                        if (!gear.touched || gear.keystat != input::key::released) gear.set_handled();
                         break;
                     case keybd::type::imeinput:
                     case keybd::type::keypaste:
@@ -8054,19 +8068,6 @@ namespace netxs::ui
                     }
                 }
             }
-            void handle(s11n::xs::hotkey_scheme       lock)
-            {
-                auto k = lock.thing;
-                lock.unlock();
-                if (owner.active)
-                {
-                    auto guard = owner.sync();
-                    if (auto gear_ptr = owner.bell::getref<hids>(k.gear_id))
-                    {
-                        gear_ptr->set_hotkey_scheme(k.hscheme);
-                    }
-                }
-            }
             void handle(s11n::xs::syskeybd            lock)
             {
                 auto k = lock.thing;
@@ -8075,18 +8076,10 @@ namespace netxs::ui
                 {
                     auto guard = owner.sync();
                     if (auto gear_ptr = owner.bell::getref<hids>(k.gear_id))
-                    if (auto parent_ptr = owner.base::parent())
                     {
                         auto& gear = *gear_ptr;
-                        //todo should we use temp gear object here?
-                        gear.alive = true;
                         k.syncto(gear);
-                        do
-                        {
-                            parent_ptr->bell::signal(tier::release, hids::events::keybd::key::post, gear);
-                            parent_ptr = parent_ptr->parent();
-                        }
-                        while (gear && parent_ptr);
+                        owner.base::riseup(tier::release, hids::events::keybd::key::post, gear);
                     }
                 }
             };
@@ -8437,7 +8430,7 @@ namespace netxs::ui
                 auto state = deed == hids::events::focus::set.id;
                 stream.sysfocus.send(*this, seed.gear_id, state, seed.focus_type);
             };
-            LISTEN(tier::release, hids::events::keybd::key::any, gear)
+            LISTEN(tier::preview, hids::events::keybd::key::any, gear)
             {
                 gear.gear_id = gear.id;
                 stream.syskeybd.send(*this, gear);

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "intmath.hpp"
+#include "quartz.hpp"
 #include "unidata.hpp"
 
 #include <string>
@@ -1954,6 +1954,15 @@ namespace netxs::utf
             else break;
         }
         return qiew{ utf8.substr(0, crop) };
+    }
+    auto& operator << (std::ostream& s, time const& o)
+    {
+        auto [hours, mins, secs, milli, micro] = datetime::breakdown(o);
+        return s << utf::adjust(std::to_string(hours), 2, '0', true) << ':'
+                 << utf::adjust(std::to_string(mins ), 2, '0', true) << ':'
+                 << utf::adjust(std::to_string(secs ), 2, '0', true) << '.'
+                 << utf::adjust(std::to_string(milli), 3, '0', true)
+                 << utf::adjust(std::to_string(micro), 3, '0', true);
     }
     void print2(auto& input, view& format)
     {

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "canvas.hpp"
-#include "quartz.hpp"
 
 namespace netxs::xml
 {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -748,10 +748,7 @@ namespace netxs::app::vtm
             keybd.proc("TryToQuit",       [&](hids& gear, txts&){ try_quit(gear); });
             keybd.proc("RunApplication",  [&](hids& gear, txts& args){ create_app(gear, args.empty() ? "" : args.front()); gear.set_handled(); });
             auto bindings = keybd.load(config, "desktop");
-            for (auto& r : bindings)
-            {
-                keybd.bind(r.chord, r.actions, r.mode);
-            }
+            keybd.bind(bindings);
 
             LISTEN(tier::preview, e2::form::proceed::createby, gear, tokens)
             {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1976,7 +1976,7 @@ namespace netxs::app::vtm
                 hall::focus = gear.id;
             };
             //todo mimic pro::focus
-            LISTEN(tier::release, hids::events::keybd::key::any, gear) // Last resort for unhandled kb events. Forward the keybd event to the gate for sending it to the outside.
+            LISTEN(tier::release, hids::events::keybd::any, gear) // Last resort for unhandled kb events. Forward the keybd event to the gate for sending it to the outside.
             {
                 if (!gear.handled)
                 {

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -322,8 +322,8 @@ R"==(
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Option" action=ExclusiveKeyboardMode label=" Keys0 " data="off">
-                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="on"/>
+            <item type="Option" action=ExclusiveKeyboardMode label=" Desktop " data="off">
+                <label="\e[48:2:0:128:128;38:2:0:255:0m Exclusive \e[m" data="on"/>
                 <tooltip>
                     " Toggle exclusive keyboard mode              \n"
                     "   Exclusive keyboard mode allows keystrokes \n"

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -415,18 +415,18 @@ R"==(
             <key="Ctrl+PageUp"   action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
             <key="Ctrl+PageDown" action=FocusNextWindow/>  <!-- Switch focus to the previous desktop window. -->
             <key="Shift+F7"      action=Disconnect/>       <!-- Disconnect from the desktop. -->
-            <key="F10"           action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
+            <key="F10" preview   action=TryToQuit/>        <!-- Shut down the desktop server if no applications are running. -->
             <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <terminal key*>  <!-- Application specific layer key bindings. -->
 )=="
 #if defined (WIN32)
 R"==(
-            <key="Ctrl-Alt | Alt-Ctrl" raw="on" action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            <key="Ctrl-Alt | Alt-Ctrl" preview action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
 )=="
 #else
 R"==(
-            <key="Alt+Shift+B" raw="on" action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+            <key="Alt+Shift+B" preview action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
 )=="
 #endif
 R"==(

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -322,12 +322,12 @@ R"==(
                     "   Left+RightClick to clear clipboard           "
                 </tooltip>
             </item>
-            <item type="Option" action=SwitchHotkeyScheme label=" Keys0 " data="">
-                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="1"/>
+            <item type="Option" action=ExclusiveKeyboardMode label=" Keys0 " data="off">
+                <label="\e[48:2:0:128:128;38:2:0:255:0m Keys1 \e[m" data="on"/>
                 <tooltip>
-                    " Toggle hotkey scheme                          \n"
-                    "   Alternative hotkey scheme allows keystrokes \n"
-                    "   to be passed through without processing     "
+                    " Toggle exclusive keyboard mode              \n"
+                    "   Exclusive keyboard mode allows keystrokes \n"
+                    "   to be passed through without processing   "
                 </tooltip>
             </item>
             <item label="Wrap" type="Option" action=TerminalWrapMode data="off">
@@ -410,19 +410,6 @@ R"==(
         </gui>
         <tui key*>  <!-- TUI matrix layer key bindings. -->
             <key="Space-Backspace | Backspace-Space" action=ToggleDebugOverlay/>  <!-- Toggle debug overlay. -->
-)=="
-#if defined (WIN32)
-R"==(
-            <key="Ctrl-Alt | Alt-Ctrl" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            <key="Ctrl-Alt | Alt-Ctrl" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-)=="
-#else
-R"==(
-            <key="Alt+Shift+B" scheme=""><action=SwitchHotkeyScheme data="1"/></key>  <!-- Switch the hotkey scheme to "1" by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-            <key="Alt+Shift+B" scheme="1"><action=SwitchHotkeyScheme data=""/></key>  <!-- Switch the hotkey scheme to default by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
-)=="
-#endif
-R"==(
         </tui>
         <desktop key*>  <!-- Desktop layer key bindings. -->
             <key="Ctrl+PageUp"   action=FocusPrevWindow/>  <!-- Switch focus to the next desktop window. -->
@@ -432,6 +419,17 @@ R"==(
             <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <terminal key*>  <!-- Application specific layer key bindings. -->
+)=="
+#if defined (WIN32)
+R"==(
+            <key="Ctrl-Alt | Alt-Ctrl" raw="on" action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+)=="
+#else
+R"==(
+            <key="Alt+Shift+B" raw="on" action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->
+)=="
+#endif
+R"==(
             <key="Alt+RightArrow" action=TerminalFindNext/>  <!-- Highlight next match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Alt+LeftArrow"  action=TerminalFindPrev/>  <!-- Highlight previous match of selected text fragment. Clipboard content is used if no active selection. -->
             <key="Shift+Ctrl+PageUp"    ><action=TerminalScrollViewportByPage data=" 0, 1"/></key>  <!-- Scroll viewport one page up. -->


### PR DESCRIPTION
### Changes

- Reimplement hotkey handling (drop schemes in favor of exclusive keyboard mode).
  Hotkey                       | Description
  -----------------------------|------------
  `Ctrl-Alt \| Alt-Ctrl`       | Win32: Toggle exclusive keyboard mode.
  `Alt=Shift+B`                | Unix: Toggle exclusive keyboard mode.