### PR TITLE
Allow moving and resizing tile's grips using arrow keys

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -468,23 +468,25 @@ Tiling Window Manager is a window container that organizes the workspace into mu
             <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <tile key*>
-            <key="Ctrl+PageUp"   action=TileFocusPrevPane     />  <!-- Focus the previous pane or splitting grip. -->
-            <key="Ctrl+PageDown" action=TileFocusNextPane     />  <!-- Focus the next pane or splitting grip. -->
-            <key="Alt+Shift+N"   action=TileRunApplicatoin    />  <!-- Launch application instances in active empty slots. The app to run can be set by RightClick on the taskbar. -->
-            <key="Alt+Shift+A"   action=TileSelectAllPanes    />  <!-- Select all panes. -->
-            <key="Alt+Shift+'|'">
-                <action=DropAutoRepeat/>         <!-- Don't autorepeat the split action. -->
-                <action=TileSplitHorizontally/>  <!-- Split active panes horizontally. -->
-            </key>
-            <key="Alt+Shift+Minus">
-                <action=DropAutoRepeat/>       <!-- Don't autorepeat the split action. -->
-                <action=TileSplitVertically/>  <!-- Split active panes vertically. -->
-            </key>
-            <key="Alt+Shift+R"   action=TileSplitOrientation  />  <!-- Change split orientation. -->
-            <key="Alt+Shift+S"   action=TileSwapPanes         />  <!-- Swap two or more panes. -->
-            <key="Alt+Shift+E"   action=TileEqualizeSplitRatio/>  <!-- Equalize split ratio. -->
-            <key="Alt+Shift+F2"  action=TileSetManagerTitle   />  <!-- Set tiling window manager title using clipboard data. -->
-            <key="Alt+Shift+W"   action=TileClosePane         />  <!-- Close active application. -->
+            <key="Ctrl+PageUp"     action=TileFocusPrevPane     />  <!-- Focus the previous pane or splitting grip. -->
+            <key="Ctrl+PageDown"   action=TileFocusNextPane     />  <!-- Focus the next pane or splitting grip. -->
+            <key="Alt+Shift+N"     action=TileRunApplicatoin    />  <!-- Launch application instances in active empty slots. The app to run can be set by RightClick on the taskbar. -->
+            <key="Alt+Shift+A"     action=TileSelectAllPanes    />  <!-- Select all panes. -->
+            <key="Alt+Shift+'|'"   action=TileSplitHorizontally />  <!-- Split active panes horizontally. -->
+            <key="Alt+Shift+Minus" action=TileSplitVertically   />  <!-- Split active panes vertically. -->
+            <key="Alt+Shift+R"     action=TileSplitOrientation  />  <!-- Change split orientation. -->
+            <key="Alt+Shift+S"     action=TileSwapPanes         />  <!-- Swap two or more panes. -->
+            <key="Alt+Shift+E"     action=TileEqualizeSplitRatio/>  <!-- Equalize split ratio. -->
+            <key="Alt+Shift+F2"    action=TileSetManagerTitle   />  <!-- Set tiling window manager title using clipboard data. -->
+            <key="Alt+Shift+W"     action=TileClosePane         />  <!-- Close active application. -->
+            <grips key*>
+                <key="LeftArrow" ><action=TileMoveGrip   data="-1, 0"/></key>  <!-- Move the split grip to the left. -->
+                <key="RightArrow"><action=TileMoveGrip   data=" 1, 0"/></key>  <!-- Move the split grip to the right. -->
+                <key="UpArrow"   ><action=TileMoveGrip   data=" 0,-1"/></key>  <!-- Move the split grip up. -->
+                <key="DownArrow" ><action=TileMoveGrip   data=" 0, 1"/></key>  <!-- Move the split grip down. -->
+                <key="'-'"       ><action=TileResizeGrip data="-1"   /></key>  <!-- Decrease the split grip width. -->
+                <key="Shift+'+'" ><action=TileResizeGrip data=" 1"   /></key>  <!-- Increase the split grip width. -->
+            </grips>
         </tile>
     </hotkeys>
 </config>

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -920,6 +920,14 @@ Notes
             <key="Alt+Shift+E"   action=TileEqualizeSplitRatio/>  <!-- Equalize split ratio. -->
             <key="Alt+Shift+F2"  action=TileSetManagerTitle   />  <!-- Set tiling window manager title using clipboard data. -->
             <key="Alt+Shift+W"   action=TileClosePane         />  <!-- Close active application. -->
+            <grips key*>
+                <key="LeftArrow"  ><action=TileMoveGrip   data="-1, 0"/></key>  <!-- Move the split grip to the left. -->
+                <key="RightArrow" ><action=TileMoveGrip   data=" 1, 0"/></key>  <!-- Move the split grip to the right. -->
+                <key="UpArrow"    ><action=TileMoveGrip   data=" 0,-1"/></key>  <!-- Move the split grip up. -->
+                <key="DownArrow"  ><action=TileMoveGrip   data=" 0, 1"/></key>  <!-- Move the split grip down. -->
+                <key="'-'"        ><action=TileResizeGrip data="-1"   /></key>  <!-- Decrease the split grip width. -->
+                <key="Shift+'+'"  ><action=TileResizeGrip data=" 1"   /></key>  <!-- Increase the split grip width. -->
+            </grips>
         </tile>
         <terminal key*>  <!-- Application specific layer key bindings. -->
             <key="Ctrl-Alt | Alt-Ctrl" preview action=ExclusiveKeyboardMode/>  <!-- Toggle exclusive keyboard mode by pressing and releasing Ctrl-Alt or Alt-Ctrl (reversed release order). -->

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -903,30 +903,24 @@ Notes
             <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <tile key*>
-            <key="Ctrl+PageUp"   action=TileFocusPrevPane     />  <!-- Focus the previous pane or splitting grip. -->
-            <key="Ctrl+PageDown" action=TileFocusNextPane     />  <!-- Focus the next pane or splitting grip. -->
-            <key="Alt+Shift+N"   action=TileRunApplicatoin    />  <!-- Launch application instances in active empty slots. The app to run can be set by RightClick on the taskbar. -->
-            <key="Alt+Shift+A"   action=TileSelectAllPanes    />  <!-- Select all panes. -->
-            <key="Alt+Shift+'|'">
-                <action=DropAutoRepeat/>         <!-- Don't autorepeat the split action. -->
-                <action=TileSplitHorizontally/>  <!-- Split active panes horizontally. -->
-            </key>
-            <key="Alt+Shift+Minus">
-                <action=DropAutoRepeat/>       <!-- Don't autorepeat the split action. -->
-                <action=TileSplitVertically/>  <!-- Split active panes vertically. -->
-            </key>
-            <key="Alt+Shift+R"   action=TileSplitOrientation  />  <!-- Change split orientation. -->
-            <key="Alt+Shift+S"   action=TileSwapPanes         />  <!-- Swap two or more panes. -->
-            <key="Alt+Shift+E"   action=TileEqualizeSplitRatio/>  <!-- Equalize split ratio. -->
-            <key="Alt+Shift+F2"  action=TileSetManagerTitle   />  <!-- Set tiling window manager title using clipboard data. -->
-            <key="Alt+Shift+W"   action=TileClosePane         />  <!-- Close active application. -->
+            <key="Ctrl+PageUp"     action=TileFocusPrevPane     />  <!-- Focus the previous pane or splitting grip. -->
+            <key="Ctrl+PageDown"   action=TileFocusNextPane     />  <!-- Focus the next pane or splitting grip. -->
+            <key="Alt+Shift+N"     action=TileRunApplicatoin    />  <!-- Launch application instances in active empty slots. The app to run can be set by RightClick on the taskbar. -->
+            <key="Alt+Shift+A"     action=TileSelectAllPanes    />  <!-- Select all panes. -->
+            <key="Alt+Shift+'|'"   action=TileSplitHorizontally />  <!-- Split active panes horizontally. -->
+            <key="Alt+Shift+Minus" action=TileSplitVertically   />  <!-- Split active panes vertically. -->
+            <key="Alt+Shift+R"     action=TileSplitOrientation  />  <!-- Change split orientation. -->
+            <key="Alt+Shift+S"     action=TileSwapPanes         />  <!-- Swap two or more panes. -->
+            <key="Alt+Shift+E"     action=TileEqualizeSplitRatio/>  <!-- Equalize split ratio. -->
+            <key="Alt+Shift+F2"    action=TileSetManagerTitle   />  <!-- Set tiling window manager title using clipboard data. -->
+            <key="Alt+Shift+W"     action=TileClosePane         />  <!-- Close active application. -->
             <grips key*>
-                <key="LeftArrow"  ><action=TileMoveGrip   data="-1, 0"/></key>  <!-- Move the split grip to the left. -->
-                <key="RightArrow" ><action=TileMoveGrip   data=" 1, 0"/></key>  <!-- Move the split grip to the right. -->
-                <key="UpArrow"    ><action=TileMoveGrip   data=" 0,-1"/></key>  <!-- Move the split grip up. -->
-                <key="DownArrow"  ><action=TileMoveGrip   data=" 0, 1"/></key>  <!-- Move the split grip down. -->
-                <key="'-'"        ><action=TileResizeGrip data="-1"   /></key>  <!-- Decrease the split grip width. -->
-                <key="Shift+'+'"  ><action=TileResizeGrip data=" 1"   /></key>  <!-- Increase the split grip width. -->
+                <key="LeftArrow" ><action=TileMoveGrip   data="-1, 0"/></key>  <!-- Move the split grip to the left. -->
+                <key="RightArrow"><action=TileMoveGrip   data=" 1, 0"/></key>  <!-- Move the split grip to the right. -->
+                <key="UpArrow"   ><action=TileMoveGrip   data=" 0,-1"/></key>  <!-- Move the split grip up. -->
+                <key="DownArrow" ><action=TileMoveGrip   data=" 0, 1"/></key>  <!-- Move the split grip down. -->
+                <key="'-'"       ><action=TileResizeGrip data="-1"   /></key>  <!-- Decrease the split grip width. -->
+                <key="Shift+'+'" ><action=TileResizeGrip data=" 1"   /></key>  <!-- Increase the split grip width. -->
             </grips>
         </tile>
         <terminal key*>  <!-- Application specific layer key bindings. -->

--- a/doc/user-interface.md
+++ b/doc/user-interface.md
@@ -260,6 +260,12 @@
     <tr><th>Alt+Shift+E</th>      <td>Equalize split ratio.</td></tr>
     <tr><th>Alt+Shift+F2</th>     <td>Set tiling window manager title using clipboard data.</td></tr>
     <tr><th>Alt+Shift+W</th>      <td>Close active application.</td></tr>
+    <tr><th>LeftArrow</th>        <td>Move the split grip to the left.</td></tr>
+    <tr><th>RightArrow</th>       <td>Move the split grip to the right.</td></tr>
+    <tr><th>UpArrow</th>          <td>Move the split grip up.</td></tr>
+    <tr><th>DownArrow</th>        <td>Move the split grip down.</td></tr>
+    <tr><th>'-'</th>              <td>Decrease the split grip width.</td></tr>
+    <tr><th>Shift+'+'</th>        <td>Increase the split grip width.</td></tr>
   </tbody>
 </table>
 

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -1110,16 +1110,20 @@ namespace netxs::app::tile
                     {
                         auto deed = boss.bell::protos(tier::preview);
                         auto root_veer_ptr = boss.base::subset[1];
-                        foreach(root_veer_ptr, gear.id, [&](auto& item_ptr, si32 /*item_type*/, auto)
+                        foreach(root_veer_ptr, gear.id, [&](auto& item_ptr, si32 /*item_type*/, auto node_veer_ptr)
                         {
-                            boss.bell::enqueue(boss.This(), [&, deed, gear_id = gear.id, item_wptr = ptr::shadow(item_ptr)](auto& /*boss*/) // Enqueue to keep the focus tree intact while processing key events.
+                            auto room = node_veer_ptr->base::size() / 3;
+                            if (room.x * room.y) // Suppress split if there is no space.
                             {
-                                if (auto gear_ptr = boss.bell::template getref<hids>(gear_id))
-                                if (auto item_ptr = item_wptr.lock())
+                                boss.bell::enqueue(boss.This(), [&, deed, gear_id = gear.id, item_wptr = ptr::shadow(item_ptr)](auto& /*boss*/) // Enqueue to keep the focus tree intact while processing key events.
                                 {
-                                    item_ptr->base::raw_riseup(tier::release, deed, *gear_ptr);
-                                }
-                            });
+                                    if (auto gear_ptr = boss.bell::template getref<hids>(gear_id))
+                                    if (auto item_ptr = item_wptr.lock())
+                                    {
+                                        item_ptr->base::raw_riseup(tier::release, deed, *gear_ptr);
+                                    }
+                                });
+                            }
                             gear.set_handled();
                         });
                     };

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -293,7 +293,6 @@ namespace netxs::app::tile
                                    : ui::fork::ctor(axis::Y, grip_width == -1 ? 1 : grip_width, slot1, slot2);
             node->isroot(faux, base::node) // Set object kind to 1 to be different from others. See node_veer::select.
                 ->template plugin<pro::focus>()
-                ->template plugin<pro::keybd>()
                 ->limits(dot_00)
                 ->invoke([&](auto& boss)
                 {
@@ -328,27 +327,27 @@ namespace netxs::app::tile
                             boss.set_grip_width(grip_width + step);
                         }
                     };
-                    auto& keybd = boss.template plugins<pro::keybd>();
-                    keybd.proc(action::TileMoveGrip  , [&](hids& gear, txts& args){ gear.set_handled(); boss.base::riseup(tier::preview, app::tile::events::ui::grips::move,   { args.size() ? xml::take_or<twod>(args.front(), dot_00) : dot_00 }); });
-                    keybd.proc(action::TileResizeGrip, [&](hids& gear, txts& args){ gear.set_handled(); boss.base::riseup(tier::preview, app::tile::events::ui::grips::resize, { args.size() ? xml::take_or<si32>(args.front(), 0) : 0 }); });
-                    keybd.bind(*grip_bindings_ptr);
                 });
-                auto grip = node->attach(slot::_I,
-                                ui::mock::ctor()
-                                ->isroot(true)
-                                ->template plugin<pro::mover>() //todo GCC 11 requires template keyword
-                                ->template plugin<pro::focus>(pro::focus::mode::focusable)
-                                ->shader(c3, e2::form::state::focus::count)
-                                ->template plugin<pro::shade<cell::shaders::xlight>>()
-                                ->invoke([&](auto& boss)
-                                {
-                                    boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear)
-                                    {
-                                        boss.base::riseup(tier::release, e2::form::size::minimize, gear);
-                                        gear.dismiss();
-                                    };
-                                })
-                                ->active());
+                auto grip = node->attach(slot::_I, ui::mock::ctor())
+                    ->isroot(true)
+                    ->active()
+                    ->template plugin<pro::mover>() //todo GCC 11 requires template keyword
+                    ->template plugin<pro::focus>(pro::focus::mode::focusable)
+                    ->template plugin<pro::keybd>()
+                    ->shader(c3, e2::form::state::focus::count)
+                    ->template plugin<pro::shade<cell::shaders::xlight>>()
+                    ->invoke([&](auto& boss)
+                    {
+                        boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear)
+                        {
+                            boss.base::riseup(tier::release, e2::form::size::minimize, gear);
+                            gear.dismiss();
+                        };
+                        auto& keybd = boss.template plugins<pro::keybd>();
+                        keybd.proc(action::TileMoveGrip  , [&](hids& gear, txts& args){ gear.set_handled(); boss.base::riseup(tier::preview, app::tile::events::ui::grips::move,   { args.size() ? xml::take_or<twod>(args.front(), dot_00) : dot_00 }); });
+                        keybd.proc(action::TileResizeGrip, [&](hids& gear, txts& args){ gear.set_handled(); boss.base::riseup(tier::preview, app::tile::events::ui::grips::resize, { args.size() ? xml::take_or<si32>(args.front(), 0) : 0 }); });
+                        keybd.bind(*grip_bindings_ptr);
+                    });
             return node;
         };
         auto empty_slot = []
@@ -370,6 +369,7 @@ namespace netxs::app::tile
                 {
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                     {
+                        pro::focus::set(boss.This(), gear.id, solo::on);
                         boss.base::riseup(tier::request, e2::form::proceed::createby, gear);
                         gear.dismiss(true);
                     };
@@ -424,6 +424,7 @@ namespace netxs::app::tile
                     mouse_subs(boss);
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear)
                     {
+                        pro::focus::set(boss.This(), gear.id, solo::on);
                         boss.base::riseup(tier::request, e2::form::proceed::createby, gear);
                         gear.dismiss(true);
                     };

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -24,6 +24,7 @@ namespace netxs::events::userland
                 EVENT_XS( title   , input::hids ), // Set window manager title using clipboard.
                 GROUP_XS( focus   , input::hids ), // Focusize prev/next pane.
                 GROUP_XS( split   , input::hids ), // Split panes.
+                GROUP_XS( grips   , twod        ), // Splitting grip modification.
 
                 SUBSET_XS( focus )
                 {
@@ -34,6 +35,11 @@ namespace netxs::events::userland
                 {
                     EVENT_XS( vt, input::hids ),
                     EVENT_XS( hz, input::hids ),
+                };
+                SUBSET_XS( grips )
+                {
+                    EVENT_XS( move  , twod ),
+                    EVENT_XS( resize, si32 ),
                 };
             };
         };
@@ -62,7 +68,9 @@ namespace netxs::app::tile
         X(TileSwapPanes         ) \
         X(TileEqualizeSplitRatio) \
         X(TileSetManagerTitle   ) \
-        X(TileClosePane         )
+        X(TileClosePane         ) \
+        X(TileMoveGrip          ) \
+        X(TileResizeGrip        )
 
     struct action
     {
@@ -276,7 +284,7 @@ namespace netxs::app::tile
                         }))
                     ->branch(slot::_2, what.applet);
         };
-        auto build_node = [](auto tag, auto slot1, auto slot2, auto grip_width)
+        auto build_node = [](auto tag, auto slot1, auto slot2, auto grip_width, auto grip_bindings_ptr)
         {
             auto highlight_color = skin::color(tone::winfocus);
             auto c3 = highlight_color.bga(0x40);
@@ -285,6 +293,7 @@ namespace netxs::app::tile
                                    : ui::fork::ctor(axis::Y, grip_width == -1 ? 1 : grip_width, slot1, slot2);
             node->isroot(faux, base::node) // Set object kind to 1 to be different from others. See node_veer::select.
                 ->template plugin<pro::focus>()
+                ->template plugin<pro::keybd>()
                 ->limits(dot_00)
                 ->invoke([&](auto& boss)
                 {
@@ -300,6 +309,29 @@ namespace netxs::app::tile
                             gear.dismiss();
                         }
                     };
+                    boss.LISTEN(tier::preview, app::tile::events::ui::grips::move, delta)
+                    {
+                        if (delta)
+                        {
+                            auto [orientation, griparea, ratio] = boss.get_config();
+                            auto step = orientation == axis::X ? delta.x : delta.y;
+                            if (step == 0) boss.bell::expire(tier::preview, true);
+                            else           boss.move_slider(step);
+                        }
+                    };
+                    boss.LISTEN(tier::preview, app::tile::events::ui::grips::resize, step)
+                    {
+                        if (step)
+                        {
+                            auto [orientation, griparea, ratio] = boss.get_config();
+                            auto grip_width = orientation == axis::X ? griparea.size.x : griparea.size.y;
+                            boss.set_grip_width(grip_width + step);
+                        }
+                    };
+                    auto& keybd = boss.template plugins<pro::keybd>();
+                    keybd.proc(action::TileMoveGrip  , [&](hids& gear, txts& args){ gear.set_handled(); boss.base::riseup(tier::preview, app::tile::events::ui::grips::move,   { args.size() ? xml::take_or<twod>(args.front(), dot_00) : dot_00 }); });
+                    keybd.proc(action::TileResizeGrip, [&](hids& gear, txts& args){ gear.set_handled(); boss.base::riseup(tier::preview, app::tile::events::ui::grips::resize, { args.size() ? xml::take_or<si32>(args.front(), 0) : 0 }); });
+                    keybd.bind(*grip_bindings_ptr);
                 });
                 auto grip = node->attach(slot::_I,
                                 ui::mock::ctor()
@@ -407,7 +439,7 @@ namespace netxs::app::tile
                     menu_block->alignment({ snap::head, snap::head })
                 );
         };
-        auto node_veer = [](auto&& node_veer, auto min_state) -> netxs::sptr<ui::veer>
+        auto node_veer = [](auto&& node_veer, auto min_state, auto grip_bindings_ptr) -> netxs::sptr<ui::veer>
         {
             return ui::veer::ctor()
                 ->plugin<pro::focus>()
@@ -566,7 +598,7 @@ namespace netxs::app::tile
                             }
                         }
                     };
-                    boss.LISTEN(tier::release, app::tile::events::ui::split::any, gear)
+                    boss.LISTEN(tier::release, app::tile::events::ui::split::any, gear, -, (grip_bindings_ptr))
                     {
                         if (auto deed = boss.bell::protos(tier::release))
                         {
@@ -576,9 +608,9 @@ namespace netxs::app::tile
                             if (depth > inheritance_limit) return;
 
                             auto heading = deed == app::tile::events::ui::split::vt.id;
-                            auto newnode = build_node(heading ? 'v':'h', 1, 1, heading ? 1 : 2);
-                            auto empty_1 = node_veer(node_veer, ui::fork::min_ratio);
-                            auto empty_2 = node_veer(node_veer, ui::fork::max_ratio);
+                            auto newnode = build_node(heading ? 'v':'h', 1, 1, heading ? 1 : 2, grip_bindings_ptr);
+                            auto empty_1 = node_veer(node_veer, ui::fork::min_ratio, grip_bindings_ptr);
+                            auto empty_2 = node_veer(node_veer, ui::fork::max_ratio, grip_bindings_ptr);
                             auto gear_id_list = pro::focus::cut(boss.back());
                             auto curitem = boss.pop_back();
                             if (boss.empty())
@@ -664,9 +696,9 @@ namespace netxs::app::tile
                 })
                 ->branch(empty_slot());
         };
-        auto parse_data = [](auto&& parse_data, view& utf8, auto min_ratio) -> netxs::sptr<ui::veer>
+        auto parse_data = [](auto&& parse_data, view& utf8, auto min_ratio, auto grip_bindings_ptr) -> netxs::sptr<ui::veer>
         {
-            auto slot = node_veer(node_veer, min_ratio);
+            auto slot = node_veer(node_veer, min_ratio, grip_bindings_ptr);
             utf::trim_front(utf8, ", ");
             if (utf8.empty()) return slot;
             auto tag = utf8.front();
@@ -701,9 +733,9 @@ namespace netxs::app::tile
                 }
                 if (utf8.empty() || utf8.front() != '(') return slot;
                 utf8.remove_prefix(1);
-                auto node = build_node(tag, s1, s2, w);
-                auto slot1 = node->attach(slot::_1, parse_data(parse_data, utf8, ui::fork::min_ratio));
-                auto slot2 = node->attach(slot::_2, parse_data(parse_data, utf8, ui::fork::max_ratio));
+                auto node = build_node(tag, s1, s2, w, grip_bindings_ptr);
+                auto slot1 = node->attach(slot::_1, parse_data(parse_data, utf8, ui::fork::min_ratio, grip_bindings_ptr));
+                auto slot2 = node->attach(slot::_2, parse_data(parse_data, utf8, ui::fork::max_ratio, grip_bindings_ptr));
                 slot->attach(node);
                 utf::trim_front(utf8, ") ");
             }
@@ -1152,6 +1184,7 @@ namespace netxs::app::tile
                 { tile::action::TileClosePane         , [](auto& boss, auto& /*item*/){ on_left_click(boss, app::tile::events::ui::close      ); }},
             };
             config.cd("/config/tile", "/config/defapp");
+            auto grip_bindings_ptr = ptr::shared(pro::keybd::load(config, "tile/grips"));
             auto [menu_block, cover, menu_data] = menu::load(config, proc_map);
             object->attach(slot::_1, menu_block)
                 ->invoke([](auto& boss)
@@ -1182,7 +1215,7 @@ namespace netxs::app::tile
                 if (err) log("%%Failed to change current directory to '%cwd%', error code: %error%", prompt::tile, appcfg.cwd, err.value());
                 else     log("%%Change current directory to '%cwd%'", prompt::tile, appcfg.cwd);
             }
-            object->attach(slot::_2, parse_data(parse_data, param, ui::fork::min_ratio))
+            object->attach(slot::_2, parse_data(parse_data, param, ui::fork::min_ratio, grip_bindings_ptr))
                 ->invoke([&](auto& boss)
                 {
                     boss.LISTEN(tier::release, e2::form::proceed::attach, fullscreen_item)

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -1114,7 +1114,7 @@ namespace netxs::app::tile
                         foreach(root_veer_ptr, gear.id, [&](auto& item_ptr, si32 /*item_type*/, auto node_veer_ptr)
                         {
                             auto room = node_veer_ptr->base::size() / 3;
-                            if (room.x * room.y) // Suppress split if there is no space.
+                            if (room.x && room.y) // Suppress split if there is no space.
                             {
                                 boss.bell::enqueue(boss.This(), [&, deed, gear_id = gear.id, item_wptr = ptr::shadow(item_ptr)](auto& /*boss*/) // Enqueue to keep the focus tree intact while processing key events.
                                 {

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -24,7 +24,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.56";
+    static const auto version = "v0.9.99.57";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2229,7 +2229,7 @@ namespace netxs::ui
                     {
                         for (auto& proc_name : proc_names)
                         {
-                            auto args_ptr = ptr::shared(std::move(proc_name.args));
+                            auto args_ptr = ptr::shared(proc_name.args);
                             set(proc_name.action, args_ptr);
                         }
                     }
@@ -2920,10 +2920,14 @@ namespace netxs::ui
         {
             return rotation == axis::X ? p : twod{ p.y, p.x };
         }
+        void _set_grip_width(si32 grip_width)
+        {
+            griparea.size = xpose({ std::max(0, grip_width), 0 });
+        }
         void _config(axis orientation, si32 grip_width, si32 s1 = 1, si32 s2 = 1)
         {
             rotation = orientation;
-            griparea.size = xpose({ std::max(0, grip_width), 0 });
+            _set_grip_width(grip_width);
             _config_ratio(s1, s2);
         }
         void _config_ratio(si32 s1, si32 s2)
@@ -3046,6 +3050,12 @@ namespace netxs::ui
             fraction = new_ratio;
         }
         // fork: .
+        auto set_grip_width(si32 new_grip_width)
+        {
+            _set_grip_width(new_grip_width);
+            base::reflow();
+        }
+        // fork: .
         void config(si32 s1, si32 s2 = 1)
         {
             _config_ratio(s1, s2);
@@ -3056,6 +3066,11 @@ namespace netxs::ui
         {
             _config(orientation, grip_width, s1, s2);
             return This();
+        }
+        // fork: .
+        auto get_config()
+        {
+            return std::tuple{ rotation, griparea, fraction };
         }
         // fork: .
         void rotate()
@@ -3078,7 +3093,7 @@ namespace netxs::ui
         {
             if (splitter)
             {
-                auto delta = griparea.size * xpose({ step, 0 });
+                auto delta = std::max(dot_11, griparea.size) * xpose({ step, 0 });
                 splitter->bell::signal(tier::preview, e2::form::upon::changed, delta);
             }
         }

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -10,6 +10,7 @@ namespace netxs::xml
     template<class T>
     auto take(qiew utf8) -> std::optional<T>
     {
+        utf::trim_front(utf8);
         if (utf8.starts_with("0x"))
         {
             utf8.remove_prefix(2);
@@ -21,6 +22,7 @@ namespace netxs::xml
     template<>
     auto take<fp32>(qiew utf8) -> std::optional<fp32>
     {
+        utf::trim_front(utf8);
         return utf8 ? utf::to_int<fp32>(utf8)
                     : std::nullopt;
     }
@@ -32,6 +34,7 @@ namespace netxs::xml
     template<>
     auto take<bool>(qiew utf8) -> std::optional<bool>
     {
+        utf::trim_front(utf8);
         auto value = utf::to_lower(utf8.str());
         if (value.starts_with("undef")) return std::nullopt; // Use default.
         if (value.empty() || value == "1"

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -471,6 +471,14 @@ R"==(
             <key="Alt+Shift+E"   action=TileEqualizeSplitRatio/>  <!-- Equalize split ratio. -->
             <key="Alt+Shift+F2"  action=TileSetManagerTitle   />  <!-- Set tiling window manager title using clipboard data. -->
             <key="Alt+Shift+W"   action=TileClosePane         />  <!-- Close active application. -->
+            <grips key*>
+                <key="LeftArrow"  ><action=TileMoveGrip   data="-1, 0"/></key>  <!-- Move the split grip to the left. -->
+                <key="RightArrow" ><action=TileMoveGrip   data=" 1, 0"/></key>  <!-- Move the split grip to the right. -->
+                <key="UpArrow"    ><action=TileMoveGrip   data=" 0,-1"/></key>  <!-- Move the split grip up. -->
+                <key="DownArrow"  ><action=TileMoveGrip   data=" 0, 1"/></key>  <!-- Move the split grip down. -->
+                <key="'-'"        ><action=TileResizeGrip data="-1"   /></key>  <!-- Decrease the split grip width. -->
+                <key="Shift+'+'"  ><action=TileResizeGrip data=" 1"   /></key>  <!-- Increase the split grip width. -->
+            </grips>
         </tile>
         <terminal key*>  <!-- Application specific layer key bindings. -->
 )=="

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -454,30 +454,24 @@ R"==(
             <key="Alt+Shift+N"   action=RunApplication/>   <!-- Run default application. -->
         </desktop>
         <tile key*>
-            <key="Ctrl+PageUp"   action=TileFocusPrevPane     />  <!-- Focus the previous pane or splitting grip. -->
-            <key="Ctrl+PageDown" action=TileFocusNextPane     />  <!-- Focus the next pane or splitting grip. -->
-            <key="Alt+Shift+N"   action=TileRunApplicatoin    />  <!-- Launch application instances in active empty slots. The app to run can be set by RightClick on the taskbar. -->
-            <key="Alt+Shift+A"   action=TileSelectAllPanes    />  <!-- Select all panes. -->
-            <key="Alt+Shift+'|'">
-                <action=DropAutoRepeat/>         <!-- Don't autorepeat the split action. -->
-                <action=TileSplitHorizontally/>  <!-- Split active panes horizontally. -->
-            </key>
-            <key="Alt+Shift+Minus">
-                <action=DropAutoRepeat/>       <!-- Don't autorepeat the split action. -->
-                <action=TileSplitVertically/>  <!-- Split active panes vertically. -->
-            </key>
-            <key="Alt+Shift+R"   action=TileSplitOrientation  />  <!-- Change split orientation. -->
-            <key="Alt+Shift+S"   action=TileSwapPanes         />  <!-- Swap two or more panes. -->
-            <key="Alt+Shift+E"   action=TileEqualizeSplitRatio/>  <!-- Equalize split ratio. -->
-            <key="Alt+Shift+F2"  action=TileSetManagerTitle   />  <!-- Set tiling window manager title using clipboard data. -->
-            <key="Alt+Shift+W"   action=TileClosePane         />  <!-- Close active application. -->
+            <key="Ctrl+PageUp"     action=TileFocusPrevPane     />  <!-- Focus the previous pane or splitting grip. -->
+            <key="Ctrl+PageDown"   action=TileFocusNextPane     />  <!-- Focus the next pane or splitting grip. -->
+            <key="Alt+Shift+N"     action=TileRunApplicatoin    />  <!-- Launch application instances in active empty slots. The app to run can be set by RightClick on the taskbar. -->
+            <key="Alt+Shift+A"     action=TileSelectAllPanes    />  <!-- Select all panes. -->
+            <key="Alt+Shift+'|'"   action=TileSplitHorizontally />  <!-- Split active panes horizontally. -->
+            <key="Alt+Shift+Minus" action=TileSplitVertically   />  <!-- Split active panes vertically. -->
+            <key="Alt+Shift+R"     action=TileSplitOrientation  />  <!-- Change split orientation. -->
+            <key="Alt+Shift+S"     action=TileSwapPanes         />  <!-- Swap two or more panes. -->
+            <key="Alt+Shift+E"     action=TileEqualizeSplitRatio/>  <!-- Equalize split ratio. -->
+            <key="Alt+Shift+F2"    action=TileSetManagerTitle   />  <!-- Set tiling window manager title using clipboard data. -->
+            <key="Alt+Shift+W"     action=TileClosePane         />  <!-- Close active application. -->
             <grips key*>
-                <key="LeftArrow"  ><action=TileMoveGrip   data="-1, 0"/></key>  <!-- Move the split grip to the left. -->
-                <key="RightArrow" ><action=TileMoveGrip   data=" 1, 0"/></key>  <!-- Move the split grip to the right. -->
-                <key="UpArrow"    ><action=TileMoveGrip   data=" 0,-1"/></key>  <!-- Move the split grip up. -->
-                <key="DownArrow"  ><action=TileMoveGrip   data=" 0, 1"/></key>  <!-- Move the split grip down. -->
-                <key="'-'"        ><action=TileResizeGrip data="-1"   /></key>  <!-- Decrease the split grip width. -->
-                <key="Shift+'+'"  ><action=TileResizeGrip data=" 1"   /></key>  <!-- Increase the split grip width. -->
+                <key="LeftArrow" ><action=TileMoveGrip   data="-1, 0"/></key>  <!-- Move the split grip to the left. -->
+                <key="RightArrow"><action=TileMoveGrip   data=" 1, 0"/></key>  <!-- Move the split grip to the right. -->
+                <key="UpArrow"   ><action=TileMoveGrip   data=" 0,-1"/></key>  <!-- Move the split grip up. -->
+                <key="DownArrow" ><action=TileMoveGrip   data=" 0, 1"/></key>  <!-- Move the split grip down. -->
+                <key="'-'"       ><action=TileResizeGrip data="-1"   /></key>  <!-- Decrease the split grip width. -->
+                <key="Shift+'+'" ><action=TileResizeGrip data=" 1"   /></key>  <!-- Increase the split grip width. -->
             </grips>
         </tile>
         <terminal key*>  <!-- Application specific layer key bindings. -->


### PR DESCRIPTION
### Changes

- Suppress tile's pane split if there is no space.
- Remove DropAutoRepeat for tile splitting hot keys.
- Allow moving and resizing tile's grips using arrow keys.
  ```
  <config>
    <hotkeys>  <!-- The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop. -->
        <tile>
            <grips key*>
                <key="LeftArrow" ><action=TileMoveGrip   data="-1, 0"/></key>  <!-- Move the split grip to the left. -->
                <key="RightArrow"><action=TileMoveGrip   data=" 1, 0"/></key>  <!-- Move the split grip to the right. -->
                <key="UpArrow"   ><action=TileMoveGrip   data=" 0,-1"/></key>  <!-- Move the split grip up. -->
                <key="DownArrow" ><action=TileMoveGrip   data=" 0, 1"/></key>  <!-- Move the split grip down. -->
                <key="'-'"       ><action=TileResizeGrip data="-1"   /></key>  <!-- Decrease the split grip width. -->
                <key="Shift+'+'" ><action=TileResizeGrip data=" 1"   /></key>  <!-- Increase the split grip width. -->
            </grips>
        </tile>
    </hotkeys>
  </config>
  ```