### PR TITLE
Make the Esc key in the terminal fire only when it is physically released

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -342,6 +342,8 @@ Hotkey                       | Description
     </terminal>
     <events>  <!-- The required key combination sequence can be generated on the Info page, accessible by clicking on the label in the lower right corner of the vtm desktop. The 'key*' statement here is to clear all previous bindings and start a new list. -->
         <terminal key*>  <!-- Terminal key bindings. -->
+            <key="Esc"                   script="vtm.gear.SetHandled()"/> <!-- Do nothing. We use the Esc key as a modifier. Its press+release events will only be sent after the key is physically released, and only if no other keys were pressed along with Esc. -->
+            <key="-Esc"                  script="vtm.terminal.ClearSelection(); vtm.terminal.KeyEvent({ virtcod=0x1b, scancod=1, keystat=1, cluster='\\u{1b}' }, { virtcod=0x1b, scancod=1, keystat=0 })"/> <!-- Clear selection if it is and send Esc press and release events. -->
             <key="Alt+Shift+B" preview   script=ExclusiveKeyboardMode/>
             <key="Alt+RightArrow"        script=TerminalFindNext/>
             <key="Alt+LeftArrow"         script=TerminalFindPrev/>
@@ -363,7 +365,6 @@ Hotkey                       | Description
             <key=""                      script=TerminalClipboardWipe/>
             <key=""                      script=TerminalClipboardFormat/>
             <key=""                      script=TerminalSelectionRect/>
-            <key="Esc" preview           script=TerminalSelectionCancel/>
             <key=""                      script=TerminalSelectionOneShot/>
             <key=""                      script=TerminalUndo/>
             <key=""                      script=TerminalRedo/>

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -979,6 +979,8 @@ Notes
             </grip>
         </tile>
         <terminal key*>  <!-- Terminal key bindings. -->
+            <key="Esc"                   script="vtm.gear.SetHandled()"/> <!-- Do nothing. We use the Esc key as a modifier. Its press+release events will only be sent after the key is physically released, and only if no other keys were pressed along with Esc. -->
+            <key="-Esc"                  script="vtm.terminal.ClearSelection(); vtm.terminal.KeyEvent({ virtcod=0x1b, scancod=1, keystat=1, cluster='\\u{1b}' }, { virtcod=0x1b, scancod=1, keystat=0 })"/> <!-- Clear selection if it is and send Esc press and release events. -->
             <key="Ctrl-Alt | Alt-Ctrl" preview script=ExclusiveKeyboardMode/>
             <key="Alt+Shift+B" preview   script=ExclusiveKeyboardMode/>
             <key="Alt+RightArrow"        script=TerminalFindNext/>
@@ -1001,7 +1003,6 @@ Notes
             <key=""                      script=TerminalClipboardWipe/>
             <key=""                      script=TerminalClipboardFormat/>
             <key=""                      script=TerminalSelectionRect/>
-            <key="Esc" preview           script=TerminalSelectionCancel/>
             <key=""                      script=TerminalSelectionOneShot/>
             <key=""                      script=TerminalUndo/>
             <key=""                      script=TerminalRedo/>

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.64";
+    static const auto version = "v0.9.99.65";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2998,12 +2998,12 @@ namespace netxs::ui
                 }
                 set_return(ok);
             }
-            auto read_args(auto add_item)
+            auto read_args(si32 index, auto add_item)
             {
-                if (lua_istable(lua, -1))
+                if (lua_istable(lua, index))
                 {
                     ::lua_pushnil(lua); // Push prev key.
-                    while (::lua_next(lua, -2)) // Table is in the stack at index -2. { "<item " + text{ table } + " />" }
+                    while (::lua_next(lua, index)) // Table is in the stack at index. { "<item " + text{ table } + " />" }
                     {
                         auto key = ::lua_torawstring(lua, -2);
                         if (!key.empty()) // Allow stringable keys only.
@@ -3036,7 +3036,6 @@ namespace netxs::ui
                         ::lua_pop(lua, 1); // Pop val.
                     }
                 }
-                ::lua_pop(lua, 1); // Pop arg.
             }
             auto run_script(auto& script_body, auto& scripting_context)
             {

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -3000,40 +3000,43 @@ namespace netxs::ui
             }
             auto read_args(auto add_item)
             {
-                if (!lua_istable(lua, -1)) return;
-                ::lua_pushnil(lua); // Push prev key.
-                while (::lua_next(lua, -2)) // Table is in the stack at index -2. { "<item " + text{ table } + " />" }
+                if (lua_istable(lua, -1))
                 {
-                    auto key = ::lua_torawstring(lua, -2);
-                    if (!key.empty()) // Allow stringable keys only.
+                    ::lua_pushnil(lua); // Push prev key.
+                    while (::lua_next(lua, -2)) // Table is in the stack at index -2. { "<item " + text{ table } + " />" }
                     {
-                        auto val = ::lua_torawstring(lua, -1);
-                        if (val.empty() && lua_istable(lua, -1)) // Extract item list.
+                        auto key = ::lua_torawstring(lua, -2);
+                        if (!key.empty()) // Allow stringable keys only.
                         {
-                            ::lua_pushnil(lua); // Push prev key.
-                            while (::lua_next(lua, -2)) // Table is in the stack at index -2. { "<key="key2=val2"/>" }
+                            auto val = ::lua_torawstring(lua, -1);
+                            if (val.empty() && lua_istable(lua, -1)) // Extract item list.
                             {
-                                auto val2 = ::lua_torawstring(lua, -1);
-                                auto key2_type = ::lua_type(lua, -2);
-                                if (key2_type != LUA_TSTRING) // key2 is integer index.
+                                ::lua_pushnil(lua); // Push prev key.
+                                while (::lua_next(lua, -2)) // Table is in the stack at index -2. { "<key="key2=val2"/>" }
                                 {
-                                    add_item(key, val2);
+                                    auto val2 = ::lua_torawstring(lua, -1);
+                                    auto key2_type = ::lua_type(lua, -2);
+                                    if (key2_type != LUA_TSTRING) // key2 is integer index.
+                                    {
+                                        add_item(key, val2);
+                                    }
+                                    else
+                                    {
+                                        auto key2 = ::lua_torawstring(lua, -2);
+                                        add_item(key, utf::concat(key2, '=', val2));
+                                    }
+                                    ::lua_pop(lua, 1); // Pop val2.
                                 }
-                                else
-                                {
-                                    auto key2 = ::lua_torawstring(lua, -2);
-                                    add_item(key, utf::concat(key2, '=', val2));
-                                }
-                                ::lua_pop(lua, 1); // Pop val2.
+                            }
+                            else
+                            {
+                                add_item(key, val);
                             }
                         }
-                        else
-                        {
-                            add_item(key, val);
-                        }
+                        ::lua_pop(lua, 1); // Pop val.
                     }
-                    ::lua_pop(lua, 1); // Pop val.
                 }
+                ::lua_pop(lua, 1); // Pop arg.
             }
             auto run_script(auto& script_body, auto& scripting_context)
             {
@@ -3045,7 +3048,7 @@ namespace netxs::ui
                     }
                 }
                 log_context();
-                log("%%script:\n%pads%%script%", prompt::lua, prompt::pads, ansi::hi(script_body));
+                log("%%script:\n%pads%%script%", prompt::lua, prompt::pads, ansi::hi(utf::debase437(script_body)));
                 ::lua_settop(lua, 0);
                 auto error = ::luaL_loadbuffer(lua, script_body.data(), script_body.size(), "script body")
                           || ::lua_pcall(lua, 0, 0, 0);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7899,13 +7899,14 @@ namespace netxs::ui
                                                         auto backup = syskeybd{};
                                                         backup.set(gear);
                                                         auto args_count = luafx.args_count();
-                                                        //todo reverse args enumeration
-                                                        log("key args:");
-                                                        while (args_count--)
+                                                        auto index = 0;
+                                                        while (index < args_count)
                                                         {
+                                                            //log("key args:");
                                                             auto k = syskeybd{};
                                                             k.syncto(gear);
-                                                            luafx.read_args([&](qiew key, qiew val)
+                                                            gear.ctlstat = backup.ctlstat;
+                                                            luafx.read_args(++index, [&](qiew key, qiew val)
                                                             {
                                                                      if (key == "keystat") gear.keystat = xml::take_or(val, input::key::released);
                                                                 else if (key == "ctlstat") gear.ctlstat = xml::take_or(val, backup.ctlstat);
@@ -7915,7 +7916,7 @@ namespace netxs::ui
                                                                 else if (key == "extflag") gear.extflag = xml::take_or(val, 0);
                                                                 else if (key == "cluster") gear.cluster = val;
                                                                 else log("%%Unknown key event parameters %%=%%", prompt::lua, key, utf::debase437(val));
-                                                                log("  %%=%%", key, utf::debase437(val));
+                                                                //log("  %%=%%", key, utf::debase437(val));
                                                             });
                                                             key_event(gear);
                                                         }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7773,6 +7773,56 @@ namespace netxs::ui
             imefmt.flow::compose<faux>(imebox, test);
             return composit_cursor;
         }
+        void key_event(hids& gear)
+        {
+            if (gear.touched && !rawkbd) return;
+            switch (gear.payload)
+            {
+                case keybd::type::keypress:
+                    if (config.resetonkey && gear.doinput())
+                    {
+                        base::riseup(tier::release, e2::form::animate::reset, 0); // Reset scroll animation.
+                        unsync = true;
+                        follow[axis::X] = true;
+                        follow[axis::Y] = true;
+                    }
+                    ipccon.keybd(gear, decckm, kbmode);
+                    if (!gear.touched || gear.keystat != input::key::released) gear.set_handled();
+                    break;
+                case keybd::type::imeinput:
+                case keybd::type::keypaste:
+                    _paste(gear.cluster);
+                    gear.dismiss();
+                    break;
+                case keybd::type::imeanons:
+                    if (imetxt != gear.cluster)
+                    {
+                        imetxt = gear.cluster;
+                        imebox.wipe();
+                        ansi::parse(gear.cluster, &imebox);
+                        ime_on = imebox.length();
+                        if (ime_on)
+                        {
+                            imebox.style.wrp(wrap::on);
+                            //if (imebox.locus.size())
+                            auto iter = std::find_if(imebox.locus.begin(), imebox.locus.end(), [](auto cmd){ return cmd.cmd == ansi::fn::sc; });
+                            if (iter != imebox.locus.end())
+                            {
+                                //auto [cmd, arg] = imebox.locus.back();
+                                auto [cmd, arg] = *iter;
+                                if (cmd == ansi::fn::sc) imebox.caret = arg;
+                            }
+                        }
+                        if (io_log) log(prompt::key, "IME composition preview: ", ansi::hi(ansi::s11n(imebox.content(), rect{.size = imebox.size()})));
+                        unsync = true;
+                    }
+                    else unsync = std::exchange(ime_on, imebox.length()) != ime_on;
+                    break;
+                case keybd::type::kblayout:
+                    //todo
+                    break;
+            }
+        }
 
     protected:
         // term: Recalc metrics for the new viewport size.
@@ -7842,6 +7892,37 @@ namespace netxs::ui
             keybd.bind(bindings);
             luafx.activate("terminal.proc_map",
             {
+                { "KeyEvent",                   [&]
+                                                {
+                                                    luafx.run_with_gear([&](auto& gear)
+                                                    {
+                                                        auto backup = syskeybd{};
+                                                        backup.set(gear);
+                                                        auto args_count = luafx.args_count();
+                                                        //todo reverse args enumeration
+                                                        log("key args:");
+                                                        while (args_count--)
+                                                        {
+                                                            auto k = syskeybd{};
+                                                            k.syncto(gear);
+                                                            luafx.read_args([&](qiew key, qiew val)
+                                                            {
+                                                                     if (key == "keystat") gear.keystat = xml::take_or(val, input::key::released);
+                                                                else if (key == "ctlstat") gear.ctlstat = xml::take_or(val, backup.ctlstat);
+                                                                else if (key == "virtcod") gear.virtcod = xml::take_or(val, 0);
+                                                                else if (key == "scancod") gear.scancod = xml::take_or(val, 0);
+                                                                else if (key == "keycode") gear.keycode = xml::take_or(val, 0);
+                                                                else if (key == "extflag") gear.extflag = xml::take_or(val, 0);
+                                                                else if (key == "cluster") gear.cluster = val;
+                                                                else log("%%Unknown key event parameters %%=%%", prompt::lua, key, utf::debase437(val));
+                                                                log("  %%=%%", key, utf::debase437(val));
+                                                            });
+                                                            key_event(gear);
+                                                        }
+                                                        backup.syncto(gear);
+                                                        gear.set_handled();
+                                                    });
+                                                }},
                 { "SetExclusiveKeyboardMode",   [&]
                                                 {
                                                     luafx.run_with_gear([&](auto& gear)
@@ -8161,53 +8242,7 @@ namespace netxs::ui
             };
             LISTEN(tier::release, input::events::keybd::key::post, gear)
             {
-                if (gear.touched && !rawkbd && gear.keystat != input::key::released) return;
-                switch (gear.payload)
-                {
-                    case keybd::type::keypress:
-                        if (config.resetonkey && gear.doinput())
-                        {
-                            this->base::riseup(tier::release, e2::form::animate::reset, 0); // Reset scroll animation.
-                            unsync = true;
-                            follow[axis::X] = true;
-                            follow[axis::Y] = true;
-                        }
-                        ipccon.keybd(gear, decckm, kbmode);
-                        if (!gear.touched || gear.keystat != input::key::released) gear.set_handled();
-                        break;
-                    case keybd::type::imeinput:
-                    case keybd::type::keypaste:
-                        _paste(gear.cluster);
-                        gear.dismiss();
-                        break;
-                    case keybd::type::imeanons:
-                        if (imetxt != gear.cluster)
-                        {
-                            imetxt = gear.cluster;
-                            imebox.wipe();
-                            ansi::parse(gear.cluster, &imebox);
-                            ime_on = imebox.length();
-                            if (ime_on)
-                            {
-                                imebox.style.wrp(wrap::on);
-                                //if (imebox.locus.size())
-                                auto iter = std::find_if(imebox.locus.begin(), imebox.locus.end(), [](auto cmd){ return cmd.cmd == ansi::fn::sc; });
-                                if (iter != imebox.locus.end())
-                                {
-                                    //auto [cmd, arg] = imebox.locus.back();
-                                    auto [cmd, arg] = *iter;
-                                    if (cmd == ansi::fn::sc) imebox.caret = arg;
-                                }
-                            }
-                            if (io_log) log(prompt::key, "IME composition preview: ", ansi::hi(ansi::s11n(imebox.content(), rect{.size = imebox.size()})));
-                            unsync = true;
-                        }
-                        else unsync = std::exchange(ime_on, imebox.length()) != ime_on;
-                        break;
-                    case keybd::type::kblayout:
-                        //todo
-                        break;
-                }
+                key_event(gear);
             };
             LISTEN(tier::release, e2::render::any, parent_canvas)
             {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1320,7 +1320,7 @@ namespace netxs::app::vtm
                                             {
                                                 auto utf8_xml = ansi::escx{};
                                                 utf8_xml += "<item>";
-                                                luafx.read_args([&](qiew key, qiew val)
+                                                luafx.read_args(0, [&](qiew key, qiew val)
                                                 {
                                                     //log("  %%=%%", key, utf::debase437(val));
                                                     utf8_xml += "<";

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -588,7 +588,7 @@ R"==(
 #endif
 R"==(
             <key="Esc"                   script="vtm.gear.SetHandled()"/> <!-- Do nothing. We use the Esc key as a modifier. Its press+release events will only be sent after the key is physically released, and only if no other keys were pressed along with Esc. -->
-            <key="-Esc"                  script="vtm.terminal.KeyEvent({ virtcod=0x1b, scancod=1, keystat=1, cluster='\\u{1b}' }); vtm.terminal.KeyEvent({ virtcod=0x1b, scancod=1 })"/> <!-- Send Esc press and release. -->
+            <key="-Esc"                  script="vtm.terminal.ClearSelection(); vtm.terminal.KeyEvent({ virtcod=0x1b, scancod=1, keystat=1, cluster='\\u{1b}' }, { virtcod=0x1b, scancod=1, keystat=0 })"/> <!-- Clear selection if it is and send Esc press and release events. -->
             <key="Alt+RightArrow"        script=TerminalFindNext/>
             <key="Alt+LeftArrow"         script=TerminalFindPrev/>
             <key="Shift+Ctrl+PageUp"     script=TerminalScrollViewportOnePageUp/>
@@ -609,7 +609,6 @@ R"==(
             <key=""                      script=TerminalClipboardWipe/>
             <key=""                      script=TerminalClipboardFormat/>
             <key=""                      script=TerminalSelectionRect/>
-            <key="Esc" preview           script=TerminalSelectionCancel/>
             <key=""                      script=TerminalSelectionOneShot/>
             <key=""                      script=TerminalUndo/>
             <key=""                      script=TerminalRedo/>

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -587,6 +587,8 @@ R"==(
 )=="
 #endif
 R"==(
+            <key="Esc"                   script="vtm.gear.SetHandled()"/> <!-- Do nothing. We use the Esc key as a modifier. Its press+release events will only be sent after the key is physically released, and only if no other keys were pressed along with Esc. -->
+            <key="-Esc"                  script="vtm.terminal.KeyEvent({ virtcod=0x1b, scancod=1, keystat=1, cluster='\\u{1b}' }); vtm.terminal.KeyEvent({ virtcod=0x1b, scancod=1 })"/> <!-- Send Esc press and release. -->
             <key="Alt+RightArrow"        script=TerminalFindNext/>
             <key="Alt+LeftArrow"         script=TerminalFindPrev/>
             <key="Shift+Ctrl+PageUp"     script=TerminalScrollViewportOnePageUp/>


### PR DESCRIPTION
### Changes

- Make the Esc key in the terminal fire only when it is physically released.
- Introduce `vtm.terminal.KeyEvent({...}, ..., {...})` function.
  attribute    | type      | description
  -------------|-----------|------------
  `keystat`    | Integer   | Key state: 0 - released; 1 - pressed; 2 - repeated.
  `ctlstat`    | Integer   | Keyboard modifiers (bit-field).
  `virtcod`    | Integer   | Key virtual code.
  `scancod`    | Integer   | Key scan code.
  `keycode`    | Integer   | Vtm specific key code.
  `extflag`    | Integer   | Extended flag (win32 specific).
  `cluster`    | String    | Text string generated by the key.

  Example:
  ```
  vtm.terminal.KeyEvent({ keystat=1, virtcod=0x1b, scancod=1, cluster='\\u{1b}' })
  ```