### PR TITLE
Fix vtm.desktop.Run() crash

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.65";
+    static const auto version = "v0.9.99.66";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1320,7 +1320,7 @@ namespace netxs::app::vtm
                                             {
                                                 auto utf8_xml = ansi::escx{};
                                                 utf8_xml += "<item>";
-                                                luafx.read_args(0, [&](qiew key, qiew val)
+                                                luafx.read_args(1, [&](qiew key, qiew val)
                                                 {
                                                     //log("  %%=%%", key, utf::debase437(val));
                                                     utf8_xml += "<";


### PR DESCRIPTION
### Changes

- Fix `vtm.desktop.Run()` crash.