### PR TITLE
Clarify supported OSes in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ It can wrap any console application and be nested indefinitely, forming a text-b
 
 - Windows
   - Windows 8.1 and later
-- Unix
+- [*nix](https://en.wikipedia.org/wiki/Unix-like)
   - Linux
   - macOS
   - FreeBSD
@@ -22,7 +22,7 @@ It can wrap any console application and be nested indefinitely, forming a text-b
 
 [Tested Terminals](https://github.com/directvt/vtm/discussions/72)
 
-<sup>Currently, rendering into a native GUI window is only available on the Windows platform; on Unix platforms, a terminal emulator is required.</sup>
+<sup>Currently, rendering into a native GUI window is only available on the Windows platform; on *nix platforms, a terminal emulator is required.</sup>
 
 # Binary downloads
 


### PR DESCRIPTION
This is for sure a nitpick, but Linux is not Unix. Linux is Unix-like, but has independent ancestry.

The BSDs, including macOS, however, can indeed trace their source code back to AT&T “Ma Bell” Unix.

Awesome project, by the way! Just stumbled upon it from HN!