### PR TITLE
Fix Ctrl+B key chord

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.99.69";
+    static const auto version = "v0.9.99.70";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -466,7 +466,7 @@ namespace netxs::utf
                 if (next.is_cmd())
                 {
                     code.step();
-                    if (Clusterize && code && next.cdpoint == 0x02 /*ansi::c0_stx*/) // Custom cluster initiator.
+                    if (Clusterize && next.cdpoint == 0x02/*ansi::c0_stx*/ && code) // Custom cluster initiator.
                     {
                         next = code.take();
                         auto rest = code.rest();

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -466,7 +466,7 @@ namespace netxs::utf
                 if (next.is_cmd())
                 {
                     code.step();
-                    if (Clusterize && next.cdpoint == 0x02 /*ansi::c0_stx*/) // Custom cluster initiator.
+                    if (Clusterize && code && next.cdpoint == 0x02 /*ansi::c0_stx*/) // Custom cluster initiator.
                     {
                         next = code.take();
                         auto rest = code.rest();

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -466,7 +466,7 @@ namespace netxs::utf
                 if (next.is_cmd())
                 {
                     code.step();
-                    if (next.cdpoint == 0x02 /*ansi::c0_stx*/) // Custom cluster initiator.
+                    if (Clusterize && next.cdpoint == 0x02 /*ansi::c0_stx*/) // Custom cluster initiator.
                     {
                         next = code.take();
                         auto rest = code.rest();

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -466,7 +466,8 @@ namespace netxs::utf
                 if (next.is_cmd())
                 {
                     code.step();
-                    if (Clusterize && next.cdpoint == 0x02/*ansi::c0_stx*/ && code) // Custom cluster initiator.
+                    auto custom_cluster_initiator = Clusterize && next.cdpoint == 0x02/*ansi::c0_stx*/ && code;
+                    if (custom_cluster_initiator)
                     {
                         next = code.take();
                         auto rest = code.rest();

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -736,6 +736,21 @@ namespace netxs::xml
                         past->next = next;  // Release an element from the previous list.
                         if (next) next->prev = past;
                         dest.push_back(item);
+                        if (mode != elem::form::attr) // Prepend '\n    <' to item when inserting it to gate==insB.
+                        {
+                            if (from->utf8.empty()) // Checking indent. Take indent from parent + pads if it is absent.
+                            {
+                                from->utf8 = parent->from->utf8 + "    ";
+                            }
+                            if (from->next && from->next->kind == type::begin_tag) // Checking begin_tag.
+                            {
+                                auto shadow = view{ from->next->utf8 };
+                                if (utf::trim_front(shadow, whitespaces).empty()) // Set it to '<' if it is absent.
+                                {
+                                    from->next->utf8 = "<";
+                                }
+                            }
+                        }
                         continue;
                     }
                     log("%%Unexpected format for item '%parent_path%/%item->name->utf8%'", prompt::xml, parent_path, item->name->utf8);
@@ -1199,6 +1214,7 @@ namespace netxs::xml
                         item->mode = elem::form::pact;
                         auto next = ptr::shared<elem>();
                         open(next);
+                        page.append(type::begin_tag); // Add begin_tag placeholder.
                         peek(data, what, last);
                         temp = pair(next, data, what, last, type::top_token);
                         auto& sub_name = next->name->utf8;


### PR DESCRIPTION
### Changes

- Fix crash when Ctrl+B key combination is assigned. #717
- Fix compact syntax config overlay.
  The following bindings now work as expected:
  ```pwsh
  vtm -c "<config/events/desktop/key=Ctrl+B script='vtm.gate.Disconnect()'/>"
  ```

Closes #717.