### PR TITLE
Detect Lua operators "<<", "< " and "<=" in settings

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -65,6 +65,8 @@ The file list is built in the following order from the following sources:
    - `name=2000` and `name="2000"` have the same meaning.
  - There is no distinction between XML-attribute and XML-subobject, i.e. any attributes are sub-objects:
    - `<name param=value />` and `<name> <param=value /> </name>` have the same meaning.
+ - No spaces are allowed between the opening angle bracket and the name when declaring an XML-subobject.
+   - `... < name ...`, `... <= ...`, `... << ...` are treated as parts of Lua script code.
  - In addition to a set of sub-objects each object can contain its own text value:
    - E.g. `<name=names_value param=params_value />` - subobject `name` has text value `names_value`.
  - Each object can be defined in any way, either using an XML-attribute or an XML-subobject syntax:

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.05.21";
+    static const auto version = "v2025.05.21a";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -418,9 +418,9 @@ R"==(
             <autohide=menu/autohide/>
             <slim=menu/slim/>
             <!-- //todo implement "linked nodes" (ala operator '|' ):
-                <LeftClick  on="LeftClick"/>
+                <OnLeftClick  on="LeftClick"/>
                 <AlwaysOnTopApplet="vtm.applet.ZOrder(vtm.applet.ZOrder()==1 and 0 or 1);"/>
-                <item label=" script="vtm.gear.SetHandled();"|AlwaysOnTopApplet|LeftClick  tooltip=" AlwaysOnTop "/>  -->
+                <item label=" AlwaysOnTop " script="vtm.gear.SetHandled();"|AlwaysOnTopApplet|OnLeftClick  tooltip=" AlwaysOnTop "/>  -->
             <item label="  " tooltip=" AlwaysOnTop off ">
                 <script=AlwaysOnTopApplet on="LeftClick"/> <!-- The default event source is the parent object, i.e. source="item" (aka vtm.item). -->
                 <script>  <!-- A binding to update the menu item label at runtime. -->


### PR DESCRIPTION
### Changes

- Fix `Unexpected closing tag name...` errors by detecting Lua operators "<<", "<_space_" and "<=" in Lua scripts.
  `settings.xml`:
  ```xml
  <config>
      <events>
          <desktop>
              <script on="F2">
                  vtm.desktop.Run({ id="Logs" });
                  a = 10
                  b = 2
                  log("a > b = ", (a > b))
                  log("a < b = ", (a < b))
                  log("a <= b = ", (a <= b))
                  log("a << b = ", (a << b))
                  log("a<=b = ", (a<=b))
                  log("a<<b = ", (a<<b))
              </script>
          </desktop>
      </events>
  </config>
  ```