### PR TITLE
Filter control codepoints

### DIFF
--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1801,27 +1801,33 @@ namespace netxs::ansi
                 proto_cells.push_back(brush);
                 //debug += (debug.size() ? "_"s : ""s) + text(utf8);
             }
-            else
+            else // Invisible controls: non-controls.
             {
-                auto& marker = get_ansi_marker();
-                if (auto set_prop = marker.setter[attr.control])
-                {
-                    if (proto_cells.size())
-                    {
-                        set_prop(proto_cells.back());
-                    }
-                    else
-                    {
-                        auto empty = brush;
-                        empty.txt(whitespace).wdt(v);
-                        set_prop(empty);
-                        proto_cells.push_back(empty);
-                    }
-                }
-                else
+                // Test :
+                //      echo -e '\U2069+123'; echo -e '+\U2068+123'; echo -e '\e[42m+123\U2068\e[m'; echo -e '123\U202C++';
+
+                //todo implement LRE RLE etc. Now all Cf's are stored within clusters.
+                //auto& marker = get_ansi_marker();
+                //if (auto set_prop = marker.setter[attr.control])
+                //{
+                //    if (proto_cells.size())
+                //    {
+                //        set_prop(proto_cells.back());
+                //    }
+                //    else
+                //    {
+                //        auto empty = brush;
+                //        empty.txt(whitespace).wdt(v);
+                //        set_prop(empty);
+                //        proto_cells.push_back(empty);
+                //        ++proto_count; // Account zero width cells.
+                //    }
+                //}
+                //else
                 {
                     brush.txt(utf8, v);
                     proto_cells.push_back(brush);
+                    ++proto_count; // Account zero width cells.
                 }
                 //auto i = utf::to_hex((size_t)attr.control, 5, true);
                 //debug += (debug.size() ? "_<fn:"s : "<fn:"s) + i + ">"s;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.06.03a";
+    static const auto version = "v2025.06.05";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -1250,7 +1250,7 @@ namespace netxs::directvt
                         c.scan_attr<Mode>(state, stream::block);
                     }
                     else cache.scan_attr<Mode>(state, stream::block);
-                    stream::block += cluster;
+                    utf::filter_non_control(cluster, stream::block); //stream::block += cluster;
                 };
                 auto print_rtl = [&](cell const& cache, view cluster)
                 {

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1036,7 +1036,7 @@ namespace netxs::gui
                     else if (codepoint.cdpoint == utf::vs08_code) img_alignment.y = snap::center;
                     else if (codepoint.cdpoint == utf::vs09_code) img_alignment.y = snap::tail;
                 }
-                else
+                else if (utf::non_control(codepoint.cdpoint))
                 {
                     codepoints.push_back(codepoint);
                 }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2464,7 +2464,7 @@ namespace netxs::ui
             void el(si32 n) override
             {
                 bufferbase::flush();
-                _el(n, canvas, coord, panel, brush.nul());
+                _el(n, canvas, coord, panel, brush.spc());
             }
             // alt_screen: CSI n @  ICH. Insert n blanks after cursor. No wrap. Existing chars after cursor shifts to the right. Don't change cursor pos.
             void ins(si32 n) override
@@ -2472,13 +2472,13 @@ namespace netxs::ui
                 bufferbase::flush();
                 assert(coord.y < panel.y);
                 assert(coord.x >= 0);
-                canvas.insert(coord, n, brush.nul());
+                canvas.insert(coord, n, brush.spc());
             }
             // alt_screen: CSI n P  Delete (not Erase) letters under the cursor.
             void dch(si32 n) override
             {
                 bufferbase::flush();
-                canvas.cutoff(coord, n, brush.nul());
+                canvas.cutoff(coord, n, brush.spc());
             }
             // alt_screen: '\x7F'  Delete letter backward.
             void del(si32 n) override
@@ -2490,7 +2490,7 @@ namespace netxs::ui
                 {
                     wrapup();
                 }
-                canvas.backsp(coord, n, brush.nul());
+                canvas.backsp(coord, n, brush.spc());
                 if (coord.y < 0) coord = dot_00;
             }
             // alt_screen: Move cursor by n in line.
@@ -4391,7 +4391,7 @@ namespace netxs::ui
                 bufferbase::flush();
                 //todo revise - nul() or dry()
                 //auto blank = brush.dry();
-                auto blank = brush.nul();
+                auto blank = brush.spc();
                 if (auto ctx = get_context(coord))
                 {
                     auto  start = si32{};
@@ -4446,7 +4446,7 @@ namespace netxs::ui
             void ins(si32 n) override
             {
                 bufferbase::flush();
-                auto blank = brush.nul();
+                auto blank = brush.spc();
                 if (auto ctx = get_context(coord))
                 {
                     n = std::min(n, panel.x - coord.x);
@@ -4465,7 +4465,7 @@ namespace netxs::ui
             void dch(si32 n) override
             {
                 bufferbase::flush();
-                auto blank = brush.nul();
+                auto blank = brush.spc();
                 if (auto ctx = get_context(coord))
                 {
                     auto& curln = batch.current();
@@ -4596,7 +4596,7 @@ namespace netxs::ui
                 {
                     _fwd(-n);
                     auto& curln = batch.current();
-                    curln.splice<faux>(batch.caret, n, brush.nul());
+                    curln.splice<faux>(batch.caret, n, brush.spc());
                 }
             }
             // scroll_buf: Move cursor by n in line.

--- a/src/netxs/desktopio/unidata.hpp
+++ b/src/netxs/desktopio/unidata.hpp
@@ -266,7 +266,7 @@ namespace netxs::unidata
 
         constexpr unidata& operator = (unidata const&) = default;
 
-        auto is_cmd()
+        auto is_cmd() const
         {
             return control < cntrls::non_control;
         }

--- a/src/netxs/desktopio/unidatagen.py
+++ b/src/netxs/desktopio/unidatagen.py
@@ -310,7 +310,7 @@ namespace netxs::unidata
 
         constexpr unidata& operator = (unidata const&) = default;
 
-        auto is_cmd()
+        auto is_cmd() const
         {{
             return control < cntrls::non_control;
         }}

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -868,7 +868,6 @@ namespace netxs::utf
     void reverse_clusters(view utf8, auto& dest)
     {
         auto rest = (si32)utf8.size();
-        auto drop = 0;
         dest.resize(dest.size() + rest);
         auto a = dest.end();
         utf::decode_clusters(utf8, [&](auto cluster)


### PR DESCRIPTION
### Changes

- Use spaces instead of nulls to erase cells in terminal.
- Filter grapheme clusters from control codepoints.