### PR TITLE
Add custom color names lookup for OSC4,10-12

### DIFF
--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -718,7 +718,7 @@ namespace netxs::app::shared
             chord_block->attach_cells({ 5, 3 }, {           {}, label("Generic"), label("Literal"), label("Specific"), label("Scancodes"),
                                                  pressed_label, pressed[0],       pressed[1],       pressed[2],        pressed[3],
                                                 released_label, released[0],      released[1],      released[2],       released[3] });
-            released[0]->set("<Press any keys>")->hidden = faux;;
+            released[0]->set("<Press any keys>")->hidden = faux;
             auto& update = window_ptr->base::field([pressed, released](auto& boss, hids& gear, bool is_key_event)
             {
                 //log("vkchord=%% keyid=%% hexvkchord=%% hexscchord=%% hexchchord=%%", input::key::kmap::to_string(gear.vkchord, faux),

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -358,10 +358,10 @@ namespace netxs::ansi
         }
 
         auto& bld(bool b)    { return add(b ? "\033[1m" : "\033[22m"         ); } // basevt: SGR 𝗕𝗼𝗹𝗱 attribute.
-        auto& und(si32 n)    { return n==unln::none   ? add("\033[24m")
-                                    : n==unln::line   ? add("\033[4m")
-                                    : n==unln::biline ? add("\033[21m")
-                                                      : add("\033[4:", n, "m"); } // basevt: SGR 𝗨𝗻𝗱𝗲𝗿𝗹𝗶𝗻𝗲 attribute.
+        auto& und(si32 n)    { return n == unln::none   ? add("\033[24m")
+                                    : n == unln::line   ? add("\033[4m")
+                                    : n == unln::biline ? add("\033[21m")
+                                                        : add("\033[4:", n, "m"); } // basevt: SGR 𝗨𝗻𝗱𝗲𝗿𝗹𝗶𝗻𝗲 attribute.
         auto& unc(argb c) // basevt: SGR 58/59 Underline color. RGB: red, green, blue.
         {
             return c.token == 0 ? add("\033[59m")

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -789,7 +789,7 @@ namespace netxs::ansi
         auto& link(si32 i)       { return add("\033[31:", i  , csi_ccc); } // escx: Set object id link.
         auto& styled(si32 b)     { return add("\033[32:", b  , csi_ccc); } // escx: Enable line style reporting (0/1).
         auto& style(si32 i)      { return add("\033[33:", i  , csi_ccc); } // escx: Line style response (deco::format: alignment, wrapping, RTL, etc).
-        auto& cursor0(si32 i)    { return add("\033[34:", i  , csi_ccc); } // escx: Set cursor  0: None, 1: Underline, 2: Block, 3: I-bar. cell::px stores cursor fg/bg if cursor is set.
+        auto& cursor0(si32 i)    { return add("\033[34:", i  , csi_ccc); } // escx: Set cursor  0: None, 1: Underline, 2: Block, 3: I-bar.
         //auto& hplink0(si32 i)    { return add("\033[35:", i  , csi_ccc); } // escx: Set hyperlink cell.
         //auto& bitmap0(si32 i)    { return add("\033[36:", i  , csi_ccc); } // escx: Set bitmap inside the cell.
         //auto& fusion0(si32 i)    { return add("\033[37:", i  , csi_ccc); } // escx: Object outline boundary.

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -172,6 +172,8 @@ namespace netxs::ansi
     static const auto sgr_no_blink  = 25;
     static const auto sgr_inv       = 7;
     static const auto sgr_noinv     = 27;
+    static const auto sgr_hidden    = 8;
+    static const auto sgr_nonhidden = 28;
     static const auto sgr_strike    = 9;
     static const auto sgr_nostrike  = 29;
     static const auto sgr_overln    = 53;
@@ -373,6 +375,7 @@ namespace netxs::ansi
             c &= 0xFF;
             return c ? unc(argb{ argb::vt256[c] }) : add("\033[59m");
         }
+        auto& hid(bool b)    { return add(b ? "\033[8m" : "\033[28m"         ); } // basevt: SGR Hidden attribute.
         auto& blk(bool b)    { return add(b ? "\033[5m" : "\033[25m"         ); } // basevt: SGR Blink attribute.
         auto& inv(bool b)    { return add(b ? "\033[7m" : "\033[27m"         ); } // basevt: SGR 𝗡𝗲𝗴𝗮𝘁𝗶𝘃𝗲 attribute.
         auto& itc(bool b)    { return add(b ? "\033[3m" : "\033[23m"         ); } // basevt: SGR 𝑰𝒕𝒂𝒍𝒊𝒄 attribute.
@@ -858,6 +861,7 @@ namespace netxs::ansi
     auto bld(bool b = true)    { return escx{}.bld(b);        } // ansi: SGR 𝗕𝗼𝗹𝗱 attribute.
     auto und(si32 n = 1   )    { return escx{}.und(n);        } // ansi: SGR 𝗨𝗻𝗱𝗲𝗿𝗹𝗶𝗻𝗲 attribute. 0: none, 1: line, 2: biline, 3: wavy, 4: dotted, 5: dashed, 6 - 7: unknown.
     auto unc(argb c)           { return escx{}.unc(c);        } // ansi: SGR SGR 58/59 Underline color. RGB: red, green, blue.
+    auto hid(bool b = true)    { return escx{}.hid(b);        } // ansi: SGR Hidden attribute.
     auto blk(bool b = true)    { return escx{}.blk(b);        } // ansi: SGR Blink attribute.
     auto inv(bool b = true)    { return escx{}.inv(b);        } // ansi: SGR 𝗡𝗲𝗴𝗮𝘁𝗶𝘃𝗲 attribute.
     auto itc(bool b = true)    { return escx{}.itc(b);        } // ansi: SGR 𝑰𝒕𝒂𝒍𝒊𝒄 attribute.
@@ -1298,6 +1302,8 @@ namespace netxs::ansi
                     sgr[sgr_nonitalic] = V{ p->brush.itc(faux); };
                     sgr[sgr_inv      ] = V{ p->brush.inv(true); };
                     sgr[sgr_noinv    ] = V{ p->brush.inv(faux); };
+                    sgr[sgr_hidden   ] = V{ p->brush.hid(true); };
+                    sgr[sgr_nonhidden] = V{ p->brush.hid(faux); };
                     sgr[sgr_und      ] = V{ p->brush.und(q.subarg(unln::line)); };
                     sgr[sgr_doubleund] = V{ p->brush.und(unln::biline        ); };
                     sgr[sgr_nound    ] = V{ p->brush.und(unln::none          ); };

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -160,7 +160,8 @@ namespace netxs::ansi
     static const auto sgr_rst       = 0;
     static const auto sgr_sav       = 10;
     static const auto sgr_bold      = 1;
-    static const auto sgr_faint     = 22;
+    static const auto sgr_nonbold   = 22;
+    static const auto sgr_faint     = 2;
     static const auto sgr_italic    = 3;
     static const auto sgr_nonitalic = 23;
     static const auto sgr_und       = 4;
@@ -1290,8 +1291,9 @@ namespace netxs::ansi
                     sgr[sgr_rst      ] = V{ p->brush.nil( );    };
                     sgr[sgr_fg       ] = V{ p->brush.rfg( );    };
                     sgr[sgr_bg       ] = V{ p->brush.rbg( );    };
+                    sgr[sgr_faint    ] = V{ p->brush.dim(2);    };
                     sgr[sgr_bold     ] = V{ p->brush.bld(true); };
-                    sgr[sgr_faint    ] = V{ p->brush.bld(faux); };
+                    sgr[sgr_nonbold  ] = V{ p->brush.bld(faux); };
                     sgr[sgr_italic   ] = V{ p->brush.itc(true); };
                     sgr[sgr_nonitalic] = V{ p->brush.itc(faux); };
                     sgr[sgr_inv      ] = V{ p->brush.inv(true); };

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.06.06a";
+    static const auto version = "v2025.06.08";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -515,6 +515,14 @@ namespace netxs
             chan.b = chan.b < k ? 0x00 : chan.b - k;
             return *this;
         }
+        // argb: Dim color.
+        auto dim()
+        {
+            chan.r >>= 1;
+            chan.g >>= 1;
+            chan.b >>= 1;
+            return *this;
+        }
         // argb: Lighten the color.
         void bright(si32 factor = 1)
         {
@@ -1836,11 +1844,18 @@ namespace netxs
             st.reverse();
         }
         // cell: Desaturate and dim fg color.
-        void dim()
+        void dim(si32 k = 1)
         {
-            uv.fg.grayscale();
-            uv.fg.shadow(80);
-            uv.fg.chan.a = 0xff;
+            if (k == 1)
+            {
+                uv.fg.grayscale();
+                uv.fg.shadow(78);
+                uv.fg.chan.a = 0xff;
+            }
+            else
+            {
+                uv.fg.dim();
+            }
         }
         // cell: Is the cell not transparent?
         bool is_alpha_blendable() const
@@ -1881,7 +1896,16 @@ namespace netxs
         auto& fga(si32 k)        { uv.fg.chan.a = (byte)k; return *this; } // cell: Set foreground alpha/transparency.
         auto& alpha(si32 k)      { uv.bg.chan.a = (byte)k;
                                    uv.fg.chan.a = (byte)k; return *this; } // cell: Set alpha/transparency (background and foreground).
-        auto& bld(bool b)        { st.bld(b);              return *this; } // cell: Set bold attribute.
+        // cell: Set/Reset bold attribute. //todo ? SGR22: If b=faux and st.bld()=faux then un-dim fg color.
+        auto& bld(bool b)
+        {
+            //if (st.bld() == faux && b == faux) // Un-dim fg color.
+            //{
+            //    uv.fg.bright(2);
+            //}
+            st.bld(b);
+            return *this;
+        }
         auto& itc(bool b)        { st.itc(b);              return *this; } // cell: Set italic attribute.
         auto& und(si32 n)        { st.und(n);              return *this; } // cell: Set underline attribute.
         auto& unc(argb c)        { st.unc(c.to_256cube()); return *this; } // cell: Set underline color.

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -253,8 +253,7 @@ namespace netxs
         auto to_256cube() const
         {
             auto clr = 0;
-            if (chan.r == chan.g
-             && chan.r == chan.b)
+            if (chan.r == chan.g && chan.r == chan.b)
             {
                 clr = 232 + ((chan.r * 24) >> 8);
             }
@@ -1175,30 +1174,32 @@ namespace netxs
             struct pxtype
             {
                 static constexpr auto none   = 0;
-                static constexpr auto colors = 1; // argb colors pair (cursor/grid/whatever).
-                static constexpr auto bitmap = 2; // Attached argb bitmap reference: First 32 bit: bitmap index. Last 32 bit: offset inside bitmap.
-                static constexpr auto reserv = 3;
+                static constexpr auto bitmap = 1; // Attached argb bitmap reference: 32 bit: bitmap index.
+                static constexpr auto reserv = 2;
             };
 
             // Shared attributes.
-            static constexpr auto bolded_mask = (ui32)0b00000000'00000000'00000000'00000001; // bolded : 1;
-            static constexpr auto italic_mask = (ui32)0b00000000'00000000'00000000'00000010; // italic : 1;
-            static constexpr auto invert_mask = (ui32)0b00000000'00000000'00000000'00000100; // invert : 1;
-            static constexpr auto overln_mask = (ui32)0b00000000'00000000'00000000'00001000; // overln : 1;
-            static constexpr auto strike_mask = (ui32)0b00000000'00000000'00000000'00010000; // strike : 1;
-            static constexpr auto unline_mask = (ui32)0b00000000'00000000'00000000'11100000; // unline : 3; // 0: none, 1: line, 2: biline, 3: wavy, 4: dotted, 5: dashed, 6 - 7: unknown.
-            static constexpr auto ucolor_mask = (ui32)0b00000000'00000000'11111111'00000000; // ucolor : 8; // Underline 256-color 6x6x6-cube index. Alpha not used - it is shared with fgc alpha. If zero - sync with fgc.
-            static constexpr auto cursor_mask = (ui32)0b00000000'00000011'00000000'00000000; // cursor : 2; // 0: None, 1: Underline, 2: Block, 3: I-bar. cell::px stores cursor fg/bg if cursor is set.
-            static constexpr auto hplink_mask = (ui32)0b00000000'00000100'00000000'00000000; // hyperlink : 1; // cell::px strores string hash.
-            static constexpr auto blinks_mask = (ui32)0b00000000'00001000'00000000'00000000; // blinks : 1;
-            static constexpr auto bitmap_mask = (ui32)0b00000000'00110000'00000000'00000000; // bitmap : 2; // body::pxtype: Cursor losts its colors when it covers bitmap.
-            static constexpr auto fusion_mask = (ui32)0b00000000'11000000'00000000'00000000; // fusion : 2; // todo The outlines of object boundaries must be set when rendering each window (pro::shape).
+            static constexpr auto bolded_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000000'00000000'00000001; // bolded : 1;
+            static constexpr auto italic_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000000'00000000'00000010; // italic : 1;
+            static constexpr auto invert_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000000'00000000'00000100; // invert : 1;
+            static constexpr auto overln_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000000'00000000'00001000; // overln : 1;
+            static constexpr auto strike_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000000'00000000'00010000; // strike : 1;
+            static constexpr auto unline_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000000'00000000'11100000; // unline : 3; // 0: none, 1: line, 2: biline, 3: wavy, 4: dotted, 5: dashed, 6 - 7: unknown.
+            static constexpr auto ucolor_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000000'11111111'00000000; // ucolor : 8; // Underline 256-color 6x6x6-cube index. Alpha not used - it is shared with fgc alpha. If zero - sync with fgc.
+            static constexpr auto cursor_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000011'00000000'00000000; // cursor : 2; // 0: None, 1: Underline, 2: Block, 3: I-bar.
+            static constexpr auto hplink_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000100'00000000'00000000; // hyperlink : 1; // cell::px strores string hash.
+            static constexpr auto blinks_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00001000'00000000'00000000; // blinks : 1;
+            static constexpr auto bitmap_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00110000'00000000'00000000; // bitmap : 2; // body::pxtype: Cursor losts its colors when it covers bitmap.
+            static constexpr auto fusion_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'11000000'00000000'00000000; // fusion : 2; // todo The outlines of object boundaries must be set when rendering each window (pro::shape).
+            static constexpr auto shadow_mask = (ui64)0b00000000'00000000'00000000'00000000'11111111'00000000'00000000'00000000; // shadow : 8; // Shadow bits.
             // Unique attributes. From 24th bit.
-            static constexpr auto mosaic_mask = (ui32)0b11111111'00000000'00000000'00000000; // ui32 mosaic : 8; // High 3 bits -> y-fragment (0-4 utf::matrix::ky), low 5 bits -> x-fragment (0-16 utf::matrix::kx). // Ref:  https://gitlab.freedesktop.org/terminal-wg/specifications/-/issues/23
+            static constexpr auto mosaic_mask = (ui64)0b00000000'00000000'00000000'11111111'00000000'00000000'00000000'00000000; // ui32 mosaic : 8; // High 3 bits -> y-fragment (0-4 utf::matrix::ky), low 5 bits -> x-fragment (0-16 utf::matrix::kx). // Ref:  https://gitlab.freedesktop.org/terminal-wg/specifications/-/issues/23
+            static constexpr auto curbgc_mask = (ui64)0b00000000'00000000'11111111'00000000'00000000'00000000'00000000'00000000; // bgcclr : 8; // Cursor 256-color 6x6x6-cube index. Alpha not used.
+            static constexpr auto curfgc_mask = (ui64)0b00000000'11111111'00000000'00000000'00000000'00000000'00000000'00000000; // fgcclr : 8; // Cursor 256-color 6x6x6-cube index. Alpha not used.
 
             static constexpr auto x_bits = utf::matrix::x_bits; // Character geometry x fragment selector bits (for mosaic_mask).
             static constexpr auto y_bits = utf::matrix::y_bits; // Character geometry y fragment selector bits offset (for mosaic_mask).
-            static constexpr auto shared_bits = (ui32)((1 << netxs::field_offset<mosaic_mask>()) - 1);
+            static constexpr auto shared_bits = ((ui64)1 << netxs::field_offset<mosaic_mask>()) - 1;
 
             // Fusion: Background interpolation current c0 with neighbor c1 and c2 cells:
             //    c0 c1
@@ -1218,19 +1219,19 @@ namespace netxs
             // append prev: U+200C ZERO WIDTH NON-JOINER
             // append prev: U+00AD SOFT HYPHEN
 
-            ui32 token;
+            ui64 token;
 
             constexpr body()
-                : token{ 0 }
+                : token{ }
             { }
             constexpr body(body const& b)
                 : token{ b.token }
             { }
             constexpr body(si32 mosaic)
-                : token{ (ui32)mosaic << netxs::field_offset<mosaic_mask>() }
+                : token{ (ui64)(ui32)mosaic << netxs::field_offset<mosaic_mask>() }
             { }
             constexpr body(body const& b, si32 mosaic)
-                : token{ (b.token & ~mosaic_mask) | ((ui32)mosaic << netxs::field_offset<mosaic_mask>()) }
+                : token{ (b.token & ~mosaic_mask) | ((ui64)(ui32)mosaic << netxs::field_offset<mosaic_mask>()) }
             { }
 
             constexpr body& operator = (body const&) = default;
@@ -1248,7 +1249,7 @@ namespace netxs
             }
             void meta(body const& b)
             {
-                token = (token & ~body::shared_bits) | (b.token & body::shared_bits); // Keep mosaic.
+                token = (token & body::mosaic_mask) | (b.token & ~body::mosaic_mask); // Keep mosaic.
             }
             template<svga Mode = svga::vtrgb, bool UseSGR = true, class T>
             void get(body& base, T& dest) const
@@ -1294,23 +1295,31 @@ namespace netxs
                 token ^= invert_mask;
             }
 
-            void bld(bool b)         { token &= ~bolded_mask; token |= ((ui32)b << netxs::field_offset<bolded_mask>()); }
-            void itc(bool b)         { token &= ~italic_mask; token |= ((ui32)b << netxs::field_offset<italic_mask>()); }
-            void inv(bool b)         { token &= ~invert_mask; token |= ((ui32)b << netxs::field_offset<invert_mask>()); }
-            void ovr(bool b)         { token &= ~overln_mask; token |= ((ui32)b << netxs::field_offset<overln_mask>()); }
-            void stk(bool b)         { token &= ~strike_mask; token |= ((ui32)b << netxs::field_offset<strike_mask>()); }
-            void blk(bool b)         { token &= ~blinks_mask; token |= ((ui32)b << netxs::field_offset<blinks_mask>()); }
-            void und(si32 n)         { token &= ~unline_mask; token |= ((ui32)n << netxs::field_offset<unline_mask>()); }
-            void unc(si32 c)         { token &= ~ucolor_mask; token |= ((ui32)c << netxs::field_offset<ucolor_mask>()); }
-            void cur(si32 s)         { token &= ~cursor_mask; token |= ((ui32)s << netxs::field_offset<cursor_mask>()); }
-            void mosaic(si32 m)      { token &= ~mosaic_mask; token |= (ui32)(m << netxs::field_offset<mosaic_mask>()); }
-            void bitmap(si32 r)      { token &= ~bitmap_mask; token |= (ui32)(r << netxs::field_offset<bitmap_mask>()); }
-            void  xy(ui32 m)         { token &= ~mosaic_mask; token |= m; }
-            void raw(ui32 r)         { token &= ~bitmap_mask; token |= r; }
+            void bld(bool b)         { token &= ~bolded_mask; token |= ((ui64)b << netxs::field_offset<bolded_mask>()); }
+            void itc(bool b)         { token &= ~italic_mask; token |= ((ui64)b << netxs::field_offset<italic_mask>()); }
+            void inv(bool b)         { token &= ~invert_mask; token |= ((ui64)b << netxs::field_offset<invert_mask>()); }
+            void ovr(bool b)         { token &= ~overln_mask; token |= ((ui64)b << netxs::field_offset<overln_mask>()); }
+            void stk(bool b)         { token &= ~strike_mask; token |= ((ui64)b << netxs::field_offset<strike_mask>()); }
+            void blk(bool b)         { token &= ~blinks_mask; token |= ((ui64)b << netxs::field_offset<blinks_mask>()); }
+            void und(si32 n)         { token &= ~unline_mask; token |= ((ui64)(ui32)n << netxs::field_offset<unline_mask>()); }
+            void unc(si32 c)         { token &= ~ucolor_mask; token |= ((ui64)(ui32)c << netxs::field_offset<ucolor_mask>()); }
+            void cur(si32 s)         { token &= ~cursor_mask; token |= ((ui64)(ui32)s << netxs::field_offset<cursor_mask>()); }
+            void mosaic(si32 m)      { token &= ~mosaic_mask; token |= ((ui64)(ui32)m << netxs::field_offset<mosaic_mask>()); }
+            void bitmap(si32 r)      { token &= ~bitmap_mask; token |= ((ui64)(ui32)r << netxs::field_offset<bitmap_mask>()); }
+            void  xy(ui64 m)         { token &= ~mosaic_mask; token |= m; }
+            void raw(ui64 r)         { token &= ~bitmap_mask; token |= r; }
             void  xy(si32 x, si32 y) { mosaic(x + (y << y_bits)); }
-            void cursor0(ui32 c)     { token &= ~cursor_mask; token |= (ui32)(c << netxs::field_offset<cursor_mask>()); }
-            //void hplink0(ui32 c) { token &= ~hplink_mask; token |= (ui32)(c << netxs::field_offset<hplink_mask>()); }
-            //void fusion0(ui32 c) { token &= ~fusion_mask; token |= (ui32)(c << netxs::field_offset<fusion_mask>()); }
+            void cursor0(si32 c)     { token &= ~cursor_mask; token |= ((ui64)(ui32)c << netxs::field_offset<cursor_mask>()); }
+            void cursor_color(argb bgc, argb fgc)
+            {
+                auto bg = bgc.to_256cube();
+                auto fg = fgc.to_256cube();
+                token &= ~(curbgc_mask | curfgc_mask);
+                token |= ((ui64)bg << netxs::field_offset<curbgc_mask>());
+                token |= ((ui64)fg << netxs::field_offset<curfgc_mask>());
+            }
+            //void hplink0(ui64 c) { token &= ~hplink_mask; token |= (ui64)(c << netxs::field_offset<hplink_mask>()); }
+            //void fusion0(ui64 c) { token &= ~fusion_mask; token |= (ui64)(c << netxs::field_offset<fusion_mask>()); }
 
             bool bld()    const { return !!(token & bolded_mask); }
             bool itc()    const { return !!(token & italic_mask); }
@@ -1324,10 +1333,18 @@ namespace netxs
             //si32 cursor0() const { return (token & cursor_mask); }
             //si32 hplink0() const { return (token & hplink_mask); }
             //si32 fusion0() const { return (token & fusion_mask); }
-            ui32  xy()    const { return (token & mosaic_mask); }
-            ui32 raw()    const { return (token & bitmap_mask); }
+            ui64  xy()    const { return (token & mosaic_mask); }
+            ui64 raw()    const { return (token & bitmap_mask); }
             si32 mosaic() const { return (si32)((token & mosaic_mask) >> netxs::field_offset<mosaic_mask>()); }
             si32 bitmap() const { return (si32)((token & bitmap_mask) >> netxs::field_offset<bitmap_mask>()); }
+            auto cursor_color() const
+            {
+                auto bgi = (byte)((token & curbgc_mask) >> netxs::field_offset<curbgc_mask>());
+                auto fgi = (byte)((token & curfgc_mask) >> netxs::field_offset<curfgc_mask>());
+                auto bgc = bgi ? argb{ argb::vt256[bgi] } : argb{};
+                auto fgc = fgi ? argb{ argb::vt256[fgi] } : argb{};
+                return std::pair{ bgc, fgc };
+            }
         };
         struct clrs
         {
@@ -1428,7 +1445,7 @@ namespace netxs
         };
         struct pict
         {
-            ui64 token;
+            ui32 token;
             constexpr pict()
                 : token{ 0 }
             { }
@@ -1449,9 +1466,9 @@ namespace netxs
 
         clrs uv; // 8U, cell: Fg and bg colors.
         glyf gc; // 8U, cell: Grapheme cluster.
-        body st; // 4U, cell: Style attributes.
+        body st; // 8U, cell: Style attributes.
         id_t id; // 4U, cell: Link ID.
-        pict px; // 8U, cell: Reference to the raw bitmap attached to the cell.
+        pict px; // 4U, cell: Reference to the raw bitmap attached to the cell.
 
         cell()
             : id{ 0 }
@@ -1870,7 +1887,7 @@ namespace netxs
         auto& unc(argb c)        { st.unc(c.to_256cube()); return *this; } // cell: Set underline color.
         auto& unc(si32 c)        { st.unc(c);              return *this; } // cell: Set underline color.
         auto& cur(si32 s)        { st.cur(s);              return *this; } // cell: Set cursor style.
-        auto& img(ui64 p)        { px.token = p;           return *this; } // cell: Set attached bitmap.
+        auto& img(ui32 p)        { px.token = p;           return *this; } // cell: Set attached bitmap.
         auto& ovr(bool b)        { st.ovr(b);              return *this; } // cell: Set overline attribute.
         auto& inv(bool b)        { st.inv(b);              return *this; } // cell: Set invert attribute.
         auto& stk(bool b)        { st.stk(b);              return *this; } // cell: Set strikethrough attribute.
@@ -1949,7 +1966,7 @@ namespace netxs
         auto  len() const  { return gc.len();      } // cell: Return grapheme cluster cell storage length (in bytes).
         auto  tkn() const  { return gc.token;      } // cell: Return grapheme cluster token.
         bool  jgc() const  { return gc.jgc();      } // cell: Check the grapheme cluster registration (foreign jumbo clusters).
-        ui32   xy() const  { return st.xy();       } // cell: Return matrix fragment metadata.
+        ui64   xy() const  { return st.xy();       } // cell: Return matrix fragment metadata.
         template<svga Mode = svga::vtrgb>
         auto  txt() const  { return gc.get<Mode>(); } // cell: Return grapheme cluster.
         auto& egc()        { return gc;            } // cell: Get grapheme cluster object.
@@ -1998,17 +2015,12 @@ namespace netxs
         auto set_cursor(si32 style, cell color = {})
         {
             st.cur(style);
-            if (st.bitmap() != body::pxtype::bitmap && (color.uv.bg.token || color.uv.fg.token))
-            {
-                st.bitmap(body::pxtype::colors);
-                px.token = ((ui64)color.uv.bg.token << 32) | (ui64)color.uv.fg.token;
-            }
+            st.cursor_color(color.uv.bg, color.uv.fg);
         }
         auto cursor_color() const
         {
-            auto colored = st.bitmap() == body::pxtype::colors;
-            return colored ? std::pair{ argb{ (ui32)(px.token >> 32) }, argb{ (ui32)(px.token & 0xFFFF'FFFF) }}
-                           : std::pair{ argb{}, argb{} };
+            //todo support for multiple cursor inside the cell
+            return st.cursor_color();
         }
         // cell: Return whitespace cell.
         cell spc() const

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -1263,6 +1263,12 @@ namespace netxs::directvt
                     {
                         auto c = cache;
                         c.draw_cursor();
+                        auto& fgc = c.inv() ? c.bgc() : c.fgc();
+                        if (fgc == 0xFF'000000 && cluster == " ")
+                        {
+                            auto [cursor_bgc, cursor_fgc] = c.cursor_color();
+                            fgc = cursor_bgc;
+                        }
                         c.scan_attr<Mode>(state, stream::block);
                     }
                     else cache.scan_attr<Mode>(state, stream::block);
@@ -1274,6 +1280,12 @@ namespace netxs::directvt
                     {
                         auto c = cache;
                         c.draw_cursor();
+                        auto& fgc = c.inv() ? c.bgc() : c.fgc();
+                        if (fgc == 0xFF'000000 && cluster == " ")
+                        {
+                            auto [cursor_bgc, cursor_fgc] = c.cursor_color();
+                            fgc = cursor_bgc;
+                        }
                         c.scan_attr<Mode>(state, stream::block);
                     }
                     else cache.scan_attr<Mode>(state, stream::block);

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1263,7 +1263,7 @@ namespace netxs::gui
                     else if (src == 255) dst = fgc;
                     else
                     {
-                        auto f_dst = irgb{ dst }.sRGB2Linear();;
+                        auto f_dst = irgb{ dst }.sRGB2Linear();
                         dst = f_dst.blend_nonpma(f_fgc, src).linear2sRGB();
                     }
                 };

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1287,7 +1287,7 @@ namespace netxs::gui
             }
             else
             {
-                if (c.blk())
+                if (c.blk() && !c.hid())
                 {
                     target_ptr = &blink_canvas;
                     blink_canvas.clip(placeholder);
@@ -1296,6 +1296,7 @@ namespace netxs::gui
                 }
                 else netxs::onrect(canvas, placeholder, cell::shaders::full(bgc));
             }
+            if (c.hid()) return;
             auto& target = *target_ptr;
             if (auto u = c.und())
             {

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -166,7 +166,7 @@ namespace netxs
         return value.type() == typeid(T) ? std::any_cast<T>(value)
                                          : fallback;
     }
-    template<ui32 FieldMask>
+    template<ui64 FieldMask>
     static constexpr si32 field_offset()
     {
         auto mask = FieldMask;
@@ -1248,7 +1248,7 @@ namespace netxs
         if (w <= r1) // All pixels on a line have the same average value.
         {
             auto s_end = s_ptr + s_hop;
-            auto d_end = d_ptr + d_hop;;
+            auto d_end = d_ptr + d_hop;
             while (true)
             {
                 auto accum = Accum_t{};

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -2108,6 +2108,7 @@ namespace netxs::ui
             }
             auto ovr(bool) { } // not supported
             auto blk(bool) { } // not supported
+            auto hid(bool) { } // not supported
         };
 
         auto to_rich(text font = {}) const
@@ -2245,6 +2246,7 @@ namespace netxs::ui
             auto stk(bool ) { }
             auto ovr(bool ) { }
             auto blk(bool ) { }
+            auto hid(bool ) { }
             auto cursor0(si32 ) { }
         };
 
@@ -2326,6 +2328,7 @@ namespace netxs::ui
             auto stk(bool ) { }
             auto ovr(bool ) { }
             auto blk(bool ) { }
+            auto hid(bool ) { }
             auto cursor0(si32 ) { }
         };
 

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -673,6 +673,11 @@ namespace netxs::ui
                     data.remove_prefix(1);
                     return { type::request, 0 };
                 }
+                //todo do xorg colornames lookup (store it in xml)
+                else if (data.starts_with("red"))
+                {
+                    return std::pair{ type::rgbcolor, argb::vt256[reddk] };
+                }
                 else if (data.starts_with("rgb:"))
                 {
                     auto get_color = [&](auto n)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1062,6 +1062,16 @@ namespace netxs::ui
                         proc = [i](auto& q, auto& p){ p->not_implemented_CSI(i, q); };
                     }
                 }
+                // Log all unimplemented SGR attributes.
+                auto& vt_csier_table_csi_sgr = vt.csier.table[csi_sgr];
+                for (auto i = 0; i < vt_csier_table_csi_sgr.size(); ++i)
+                {
+                    auto& proc = vt_csier_table_csi_sgr[i];
+                    if (!proc)
+                    {
+                        proc = [i](auto&, auto&){ log("%%SGR %val% attribute is not implemented", prompt::term, i); };
+                    }
+                }
                 auto& esc_lookup = vt.intro[ctrl::esc];
                 // Log all unimplemented ESC+rest.
                 for (auto i = 0; i < 0x100; ++i)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1069,7 +1069,7 @@ namespace netxs::ui
                     auto& proc = vt_csier_table_csi_sgr[i];
                     if (!proc)
                     {
-                        proc = [i](auto&, auto&){ log("%%SGR %val% attribute is not implemented", prompt::term, i); };
+                        proc = [i](auto&, auto&){ log("%%SGR %val% attribute is not supported", prompt::term, i); };
                     }
                 }
                 auto& esc_lookup = vt.intro[ctrl::esc];

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -20,6 +20,7 @@ namespace netxs
 
     static constexpr auto whitespaces = " \t\r\n\v\f"sv;
     static constexpr auto onlydigits  = "0123456789"sv;
+    static constexpr auto sharpdigit  = "0123456789#"sv;
     static constexpr auto alphabetic  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_"sv;
     static constexpr auto base64code  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     static constexpr auto whitespace  = ' '; // '.';

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -2461,6 +2461,19 @@ namespace netxs::utf
     {
         return to_upper(utf8);
     }
+    auto name2token(view utf8)
+    {
+        auto name_token = text{};
+        name_token.reserve(utf8.size());
+        for (auto c : utf8)
+        {
+            if (c != ' ' && c != '-')
+            {
+                name_token += utf::to_lower(c);
+            }
+        }
+        return name_token;
+    }
     template<class W, class P>
     void for_each(text& utf8, W const& what, P proc)
     {

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -418,7 +418,13 @@ namespace netxs::xml
                         case type::raw_text:      fgc = value_fg;     break;
                         case type::quoted_text:
                         case type::raw_quoted:
-                        case type::tag_numvalue:
+                        case type::tag_numvalue:  if (utf8.size() == 7 && utf8.front() == '#')
+                                                  if (auto rgb = xml::take<argb>(utf8))
+                                                  {
+                                                      auto c = rgb.value();
+                                                      yield.fgc(c).add("■"sv).nil();
+                                                  }
+                                                  [[fallthrough]];
                         case type::tag_value:     fgc = value_fg;
                                                   bgc = value_bg;     break;
                         case type::error:         fgc = whitelt;
@@ -651,7 +657,7 @@ namespace netxs::xml
             static constexpr auto view_token_first      = " \t\r\n\v\f!\"#$%&'()*+<=>?@[\\]^`{|}~;,/-.0123456789"sv; // Element name cannot contain any of [[:whitespaces:]!"#$%&'()*+,/;<=>?@[\]^`{|}~], and cannot begin with "-", ".", or a numeric digit.
             static constexpr auto view_token_delims     = " \t\r\n\v\f!\"#$%&'()*+<=>?@[\\]^`{|}~;,/"sv;
             static constexpr auto view_reference_delims = " \t\r\n\v\f!\"#$%&'()*+<=>?@[\\]^`{|}~;,"sv;
-            static constexpr auto view_digit_delims     = " \t\r\n\v\f!\"#$%&'()*+<=>?@[\\]^`{|}~/"sv; // Allow ';' and ',' between digits: (123;456).
+            static constexpr auto view_digit_delims     = " \t\r\n\v\f!\"$%&'()*+<=>?@[\\]^`{|}~/"sv; // Allow '#' in digits (#rgb). Also allow ';' and ',' between digits: (123;456).
             static constexpr auto view_comment_begin    = "<!--"sv;
             static constexpr auto view_comment_close    = "-->"sv;
             static constexpr auto view_close_tag        = "</"sv;
@@ -784,7 +790,7 @@ namespace netxs::xml
                     case type::top_token:
                     case type::end_token:     utf::take_front(temp, view_reference_delims); break;
                     case type::raw_text:      utf::take_front(temp, view_find_start); break;
-                    case type::tag_numvalue:
+                    case type::tag_numvalue:  utf::take_front(temp, view_digit_delims); break;
                     case type::tag_reference: utf::take_front(temp, view_reference_delims); break;
                     case type::quotes:
                     case type::tag_value:     utf::take_quote(temp, temp.front()); break;
@@ -843,7 +849,7 @@ namespace netxs::xml
                         {
                             append_prepending_spaces();
                                 what = type::tag_value;
-                                auto is_digit = netxs::onlydigits.find(temp.front()) != text::npos;
+                                auto is_digit = netxs::sharpdigit.find(temp.front()) != text::npos;
                                 if (is_digit) // #number
                                 {
                                     auto frag_ptr = append(type::tag_numvalue, utf::take_front(temp, view_digit_delims));
@@ -967,7 +973,7 @@ namespace netxs::xml
                             peek_forward();
                             if (what != type::quoted_text)
                             {
-                                auto is_reference = what == type::raw_text && netxs::onlydigits.find(temp.front()) == text::npos; // Only literal raw text is allowed as a reference name.
+                                auto is_reference = what == type::raw_text && netxs::sharpdigit.find(temp.front()) == text::npos; // Only literal raw text is allowed as a reference name.
                                 if (!is_reference)
                                 {
                                     fail();

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -422,7 +422,8 @@ namespace netxs::xml
                                                   if (auto rgb = xml::take<argb>(utf8))
                                                   {
                                                       auto c = rgb.value();
-                                                      yield.fgc(c).add("■"sv).nil();
+                                                      //yield.fgc(c).add("■"sv).nil();
+                                                      yield.bgc(c).unc(pureblack).und(true).add("  "sv).nil().add(" ");
                                                   }
                                                   [[fallthrough]];
                         case type::tag_value:     fgc = value_fg;

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -418,7 +418,7 @@ namespace netxs::xml
                         case type::raw_text:      fgc = value_fg;     break;
                         case type::quoted_text:
                         case type::raw_quoted:
-                        case type::tag_numvalue:  if (utf8.size() == 7 && utf8.front() == '#')
+                        case type::tag_numvalue:  if (utf8.size() && utf8.front() == '#')
                                                   if (auto rgb = xml::take<argb>(utf8))
                                                   {
                                                       auto c = rgb.value();

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -224,7 +224,7 @@ int main(int argc, char* argv[])
     auto denied = faux;
     auto syslog = os::tty::logger();
     auto userid = os::env::user();
-    auto prefix = vtpipe.length() ? vtpipe : utf::concat(os::path::ipc_prefix, os::process::elevated ? "!-" : "-", userid.second);;
+    auto prefix = vtpipe.length() ? vtpipe : utf::concat(os::path::ipc_prefix, os::process::elevated ? "!-" : "-", userid.second);
     auto prefix_log = prefix + os::path::log_suffix;
     auto failed = [&](auto cause)
     {

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -45,10 +45,10 @@ R"==(<include*/>  <!-- Ordered list of <include="/path/to/settings.xml"/>. The s
         <format="html"/>  <!-- Default clipboard format for screenshots: "text" | "ansi" | "rich" | "html" | "protected" . -->
     </clipboard>
     <colors>  <!-- Along with fgc, bgc and txt, other SGR attributes (boolean) are allowed here: itc: italic, bld: bold, und: underline, inv: reverse, ovr: overline, blk: blink. -->
-        <window   fgc=whitelt   bgc=0x80404040        />  <!-- Base desktop window color. -->
+        <window   fgc=whitelt   bgc=#40404080         />  <!-- Base desktop window color. -->
         <focus    fgc=purewhite bgc=bluelt            />  <!-- Focused item tinting. -->
         <brighter fgc=purewhite bgc=purewhite alpha=60/>  <!-- Brighter. -->
-        <shadower               bgc=0xB4202020        />  <!-- Dimmer. -->
+        <shadower               bgc=#202020B4         />  <!-- Dimmer. -->
         <warning  fgc=whitelt   bgc=yellowdk          />  <!-- "Warning" color. -->
         <danger   fgc=whitelt   bgc=purered           />  <!-- "Danger" color. -->
         <action   fgc=whitelt   bgc=greenlt           />  <!-- "Action" color. -->
@@ -138,7 +138,7 @@ R"==(
             </width>
             <timeout=250ms/>  <!-- Taskbar collaplse timeout after mouse leave. -->
             <colors>
-                <bground  fgc=whitedk bgc=0xC0202020 />  <!-- Set the bgc color non-transparent (alpha to FF) to disable acrylics in taskbar. -->
+                <bground  fgc=whitedk bgc=#202020C0  />  <!-- Set the bgc color non-transparent (alpha to FF) to disable acrylics in taskbar. -->
                 <focused  fgc=puregreen              />  <!-- Focused taskbar item color. -->
                 <selected fgc=whitelt                />  <!-- Default taskbar item color. -->
                 <active   fgc=whitelt                />  <!-- Running taskbar item color. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -196,7 +196,7 @@ R"==(
             <color15 = whitelt    />
             <default fgc=whitedk bgc=pureblack/>  <!-- Default/current colors (SGR49/39). -->
             <bground = DefaultColor/>  <!-- Independent background color of the scrollback canvas. Set to 0x00ffffff(or =DefaultColor) to sync with SGR49 (default background). -->
-            <match fx="color" fgc=whitelt bgc=0xFF007F00/>  <!-- Color of the selected text occurrences. Set an fx to use cell::shaders: "xlight" | "color" | "invert" | "reverse". -->
+            <match fx="color" fgc=whitelt bgc=#007F00/>  <!-- Color of the selected text occurrences. Set an fx to use cell::shaders: "xlight" | "color" | "invert" | "reverse". -->
             <selection>
                 <text      fx="color"  fgc=whitelt bgc=bluelt/>  <!-- Highlighting of the selected text in plaintext mode. -->
                 <protected fx="color"  fgc=whitelt bgc=bluelt/>  <!-- Note: The bgc and fgc attributes only apply to the fx=color shader. -->
@@ -205,6 +205,8 @@ R"==(
                 <html      fx="xlight" fgc=whitelt bgc=bluelt/>
                 <none      fx="color"  fgc=whitedk bgc=blacklt/>  <!-- Inactive selection color. -->
             </selection>
+            <names=/X11ColorNames>  <!-- Color names for OSC 4,10-12. -->
+            </names>
         </colors>
         <border=0/>  <!-- Width of the left and right border of the terminal window. -->
         <tablen=8/>  <!-- Tab length. -->
@@ -498,31 +500,180 @@ R"==(
 <Colors>
     <DefaultColor = 0x00ffffff />
     <Transparent  = 0x00000000 />
-    <blackdk      = 0xFF101010 />
-    <reddk        = 0xFFc40f1f />
-    <greendk      = 0xFF12a10e />
-    <yellowdk     = 0xFFc09c00 />
-    <bluedk       = 0xFF0037db />
-    <magentadk    = 0xFF871798 />
-    <cyandk       = 0xFF3b96dd />
-    <whitedk      = 0xFFbbbbbb />
-    <blacklt      = 0xFF757575 />
-    <redlt        = 0xFFe64856 />
-    <greenlt      = 0xFF15c60c />
-    <yellowlt     = 0xFFf8f1a5 />
-    <bluelt       = 0xFF3a78ff />
-    <magentalt    = 0xFFb3009e />
-    <cyanlt       = 0xFF60d6d6 />
-    <whitelt      = 0xFFf3f3f3 />
-    <pureblack    = 0xFF000000 />
-    <purewhite    = 0xFFffffff />
-    <purered      = 0xFFff0000 />
-    <puregreen    = 0xFF00ff00 />
-    <pureblue     = 0xFF0000ff />
-    <puremagenta  = 0xFFff00ff />
-    <purecyan     = 0xFF00ffff />
-    <pureyellow   = 0xFFff00ff />
+    <blackdk      = #101010 />
+    <reddk        = #c40f1f />
+    <greendk      = #12a10e />
+    <yellowdk     = #c09c00 />
+    <bluedk       = #0037db />
+    <magentadk    = #871798 />
+    <cyandk       = #3b96dd />
+    <whitedk      = #bbbbbb />
+    <blacklt      = #757575 />
+    <redlt        = #e64856 />
+    <greenlt      = #15c60c />
+    <yellowlt     = #f8f1a5 />
+    <bluelt       = #3a78ff />
+    <magentalt    = #b3009e />
+    <cyanlt       = #60d6d6 />
+    <whitelt      = #f3f3f3 />
+    <pureblack    = #000000 />
+    <purewhite    = #ffffff />
+    <purered      = #ff0000 />
+    <puregreen    = #00ff00 />
+    <pureblue     = #0000ff />
+    <puremagenta  = #ff00ff />
+    <purecyan     = #00ffff />
+    <pureyellow   = #ff00ff />
 </Colors>
+
+<X11ColorNames name*>  <!-- Source: https://en.wikipedia.org/wiki/X11_color_names#Color_name_chart -->
+    <name = "Black"               rgb = #000000 />
+    <name = "Brown"               rgb = #A52A2A />
+    <name = "Firebrick"           rgb = #B22222 />
+    <name = "Web Maroon"          rgb = #800000 />
+    <name = "Dark Red"            rgb = #8B0000 />
+    <name = "Saddle brown"        rgb = #8B4513 />
+    <name = "Dark Olive Green"    rgb = #556B2F />
+    <name = "Forest Green"        rgb = #228B22 />
+    <name = "Web Green"           rgb = #008000 />
+    <name = "Dark Green"          rgb = #006400 />
+    <name = "Dark Slate Gray"     rgb = #2F4F4F />
+    <name = "Midnight Blue"       rgb = #191970 />
+    <name = "Navy Blue"           rgb = #000080 />
+    <name = "Dark Blue"           rgb = #00008B />
+    <name = "Medium Blue"         rgb = #0000CD />
+    <name = "Indigo"              rgb = #4B0082 />
+    <name = "Indian Red"          rgb = #CD5C5C />
+    <name = "Red"                 rgb = #FF0000 />
+    <name = "Orange Red"          rgb = #FF4500 />
+    <name = "Sienna"              rgb = #A0522D />
+    <name = "Chocolate"           rgb = #D2691E />
+    <name = "Peru"                rgb = #CD853F />
+    <name = "Dark Orange"         rgb = #FF8C00 />
+    <name = "Orange"              rgb = #FFA500 />
+    <name = "Dark Goldenrod"      rgb = #B8860B />
+    <name = "Goldenrod"           rgb = #DAA520 />
+    <name = "Olive"               rgb = #808000 />
+    <name = "Dim Gray"            rgb = #696969 />
+    <name = "Web Gray"            rgb = #808080 />
+    <name = "Olive Drab"          rgb = #6B8E23 />
+    <name = "Yellow Green"        rgb = #9ACD32 />
+    <name = "Chartreuse"          rgb = #7FFF00 />
+    <name = "Lawn Green"          rgb = #7CFC00 />
+    <name = "Lime Green"          rgb = #32CD32 />
+    <name = "Green"               rgb = #00FF00 />
+    <name = "Lime"                rgb = #00FF00 />
+    <name = "Sea Green"           rgb = #2E8B57 />
+    <name = "Medium Sea Green"    rgb = #3CB371 />
+    <name = "Spring Green"        rgb = #00FF7F />
+    <name = "Medium Spring Green" rgb = #00FA9A />
+    <name = "Dark Turquoise"      rgb = #00CED1 />
+    <name = "Light Sea Green"     rgb = #20B2AA />
+    <name = "Teal"                rgb = #008080 />
+    <name = "Dark Cyan"           rgb = #008B8B />
+    <name = "Steel Blue"          rgb = #4682B4 />
+    <name = "Cadet Blue"          rgb = #5F9EA0 />
+    <name = "Slate Gray"          rgb = #708090 />
+    <name = "Light Slate Gray"    rgb = #778899 />
+    <name = "Royal Blue"          rgb = #4169E1 />
+    <name = "Blue"                rgb = #0000FF />
+    <name = "Slate Blue"          rgb = #6A5ACD />
+    <name = "Dark Slate Blue"     rgb = #483D8B />
+    <name = "Rebecca Purple"      rgb = #663399 />
+    <name = "Blue Violet"         rgb = #8A2BE2 />
+    <name = "Dark Orchid"         rgb = #9932CC />
+    <name = "Dark Violet"         rgb = #9400D3 />
+    <name = "Web Purple"          rgb = #800080 />
+    <name = "Dark Magenta"        rgb = #8B008B />
+    <name = "Medium Violet Red"   rgb = #C71585 />
+    <name = "Deep Pink"           rgb = #FF1493 />
+    <name = "Maroon"              rgb = #B03060 />
+    <name = "Crimson"             rgb = #DC143C />
+    <name = "Rosy Brown"          rgb = #BC8F8F />
+    <name = "Light Coral"         rgb = #F08080 />
+    <name = "Salmon"              rgb = #FA8072 />
+    <name = "Tomato"              rgb = #FF6347 />
+    <name = "Coral"               rgb = #FF7F50 />
+    <name = "Dark Salmon"         rgb = #E9967A />
+    <name = "Light Salmon"        rgb = #FFA07A />
+    <name = "Sandy Brown"         rgb = #F4A460 />
+    <name = "Burlywood"           rgb = #DEB887 />
+    <name = "Tan"                 rgb = #D2B48C />
+    <name = "Dark Khaki"          rgb = #BDB76B />
+    <name = "Gold"                rgb = #FFD700 />
+    <name = "Yellow"              rgb = #FFFF00 />
+    <name = "Green Yellow"        rgb = #ADFF2F />
+    <name = "Dark Gray"           rgb = #A9A9A9 />
+    <name = "Gray"                rgb = #BEBEBE />
+    <name = "Silver"              rgb = #C0C0C0 />
+    <name = "Dark Sea Green"      rgb = #8FBC8F />
+    <name = "Pale Green"          rgb = #98FB98 />
+    <name = "Light Green"         rgb = #90EE90 />
+    <name = "Medium Aquamarine"   rgb = #66CDAA />
+    <name = "Aquamarine"          rgb = #7FFFD4 />
+    <name = "Turquoise"           rgb = #40E0D0 />
+    <name = "Medium Turquoise"    rgb = #48D1CC />
+    <name = "Aqua"                rgb = #00FFFF />
+    <name = "Cyan"                rgb = #00FFFF />
+    <name = "Sky Blue"            rgb = #87CEEB />
+    <name = "Light Steel Blue"    rgb = #B0C4DE />
+    <name = "Light Sky Blue"      rgb = #87CEFA />
+    <name = "Deep Sky Blue"       rgb = #00BFFF />
+    <name = "Dodger Blue"         rgb = #1E90FF />
+    <name = "Cornflower Blue"     rgb = #6495ED />
+    <name = "Medium Slate Blue"   rgb = #7B68EE />
+    <name = "Medium Purple"       rgb = #9370DB />
+    <name = "Purple"              rgb = #A020F0 />
+    <name = "Medium Orchid"       rgb = #BA55D3 />
+    <name = "Fuchsia"             rgb = #FF00FF />
+    <name = "Magenta"             rgb = #FF00FF />
+    <name = "Orchid"              rgb = #DA70D6 />
+    <name = "Hot Pink"            rgb = #FF69B4 />
+    <name = "Pale Violet Red"     rgb = #DB7093 />
+    <name = "Snow"                rgb = #FFFAFA />
+    <name = "Seashell"            rgb = #FFF5EE />
+    <name = "Misty Rose"          rgb = #FFE4E1 />
+    <name = "Peach Puff"          rgb = #FFDAB9 />
+    <name = "Linen"               rgb = #FAF0E6 />
+    <name = "Bisque"              rgb = #FFE4C4 />
+    <name = "Antique White"       rgb = #FAEBD7 />
+    <name = "Navajo White"        rgb = #FFDEAD />
+    <name = "Blanched Almond"     rgb = #FFEBCD />
+    <name = "Papaya Whip"         rgb = #FFEFD5 />
+    <name = "Moccasin"            rgb = #FFE4B5 />
+    <name = "Wheat"               rgb = #F5DEB3 />
+    <name = "Old Lace"            rgb = #FDF5E6 />
+    <name = "Floral White"        rgb = #FFFAF0 />
+    <name = "Cornsilk"            rgb = #FFF8DC />
+    <name = "Lemon Chiffon"       rgb = #FFFACD />
+    <name = "Khaki"               rgb = #F0E68C />
+    <name = "Pale Goldenrod"      rgb = #EEE8AA />
+    <name = "Ivory"               rgb = #FFFFF0 />
+    <name = "Beige"               rgb = #F5F5DC />
+    <name = "Light Yellow"        rgb = #FFFFE0 />
+    <name = "Light Goldenrod"     rgb = #FAFAD2 />
+    <name = "Light Gray"          rgb = #D3D3D3 />
+    <name = "Gainsboro"           rgb = #DCDCDC />
+    <name = "Gainsbora"           rgb = #DCDCDC />
+    <name = "White Smoke"         rgb = #F5F5F5 />
+    <name = "Honeydew"            rgb = #F0FFF0 />
+    <name = "Mint Cream"          rgb = #F5FFFA />
+    <name = "Azure"               rgb = #F0FFFF />
+    <name = "Light Cyan"          rgb = #E0FFFF />
+    <name = "Pale Turquoise"      rgb = #AFEEEE />
+    <name = "Powder Blue"         rgb = #B0E0E6 />
+    <name = "Light Blue"          rgb = #ADD8E6 />
+    <name = "Alice Blue"          rgb = #F0F8FF />
+    <name = "Ghost White"         rgb = #F8F8FF />
+    <name = "Lavender"            rgb = #E6E6FA />
+    <name = "Thistle"             rgb = #D8BFD8 />
+    <name = "Plum"                rgb = #DDA0DD />
+    <name = "Violet"              rgb = #EE82EE />
+    <name = "Pink"                rgb = #FFC0CB />
+    <name = "Light Pink"          rgb = #FFB6C1 />
+    <name = "Lavender Blush"      rgb = #FFF0F5 />
+    <name = "White"               rgb = #FFFFFF />
+</X11ColorNames>
 
 <Terminal>
     <selection>

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -523,7 +523,7 @@ R"==(
     <pureblue     = #0000ff />
     <puremagenta  = #ff00ff />
     <purecyan     = #00ffff />
-    <pureyellow   = #ff00ff />
+    <pureyellow   = #ffff00 />
 </Colors>
 
 <X11ColorNames name*>  <!-- Source: https://en.wikipedia.org/wiki/X11_color_names#Color_name_chart -->
@@ -560,9 +560,9 @@ R"==(
     <name = "Yellow Green"        rgb = #9ACD32 />
     <name = "Chartreuse"          rgb = #7FFF00 />
     <name = "Lawn Green"          rgb = #7CFC00 />
-    <name = "Lime Green"          rgb = #32CD32 />
     <name = "Green"               rgb = #00FF00 />
     <name = "Lime"                rgb = #00FF00 />
+    <name = "Lime Green"          rgb = #32CD32 />
     <name = "Sea Green"           rgb = #2E8B57 />
     <name = "Medium Sea Green"    rgb = #3CB371 />
     <name = "Spring Green"        rgb = #00FF7F />
@@ -578,11 +578,11 @@ R"==(
     <name = "Royal Blue"          rgb = #4169E1 />
     <name = "Blue"                rgb = #0000FF />
     <name = "Slate Blue"          rgb = #6A5ACD />
-    <name = "Dark Slate Blue"     rgb = #483D8B />
-    <name = "Rebecca Purple"      rgb = #663399 />
     <name = "Blue Violet"         rgb = #8A2BE2 />
     <name = "Dark Orchid"         rgb = #9932CC />
     <name = "Dark Violet"         rgb = #9400D3 />
+    <name = "Rebecca Purple"      rgb = #663399 />
+    <name = "Dark Slate Blue"     rgb = #483D8B />
     <name = "Web Purple"          rgb = #800080 />
     <name = "Dark Magenta"        rgb = #8B008B />
     <name = "Medium Violet Red"   rgb = #C71585 />
@@ -609,8 +609,8 @@ R"==(
     <name = "Dark Sea Green"      rgb = #8FBC8F />
     <name = "Pale Green"          rgb = #98FB98 />
     <name = "Light Green"         rgb = #90EE90 />
-    <name = "Medium Aquamarine"   rgb = #66CDAA />
     <name = "Aquamarine"          rgb = #7FFFD4 />
+    <name = "Medium Aquamarine"   rgb = #66CDAA />
     <name = "Turquoise"           rgb = #40E0D0 />
     <name = "Medium Turquoise"    rgb = #48D1CC />
     <name = "Aqua"                rgb = #00FFFF />


### PR DESCRIPTION
### Changes

- Add support for X11 Color Names in OSC4,10-12 commands.
- Highlight #rrggbb[aa] color values in config preview (`vtm -l`).
- Fix SGR 2 attribute (faint).
- Don't interrupt CSI execution on an unsupported SGR attribute.
- Add support for SGR 8/28 (hidden/visible) attribute.
- Fix cursor visibility in win32 conhost (in TUI mode).