### PR TITLE
Fix tile's keybindings (regression from v2025.05.27)

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -887,7 +887,7 @@ Notes
         </panel>
         <background>  <!-- Desktop background. -->
             <color fgc=whitedk bgc= #00007f80/>  <!-- Desktop background color. -->
-            <tile=""/>                           <!-- Truecolor ANSI-art with gradients can be used here. -->
+            <tile=""/>                           <!-- Truecolor ANSI-art can be used here. -->
         </background>
     </desktop>
     <terminal>  <!-- Base settings for the built-in terminal. It can be partially overridden by the menu item's config subarg. -->
@@ -1129,7 +1129,7 @@ Notes
                 <on="release: e2::form::prop::zorder" source="applet"/>
                 local is_topmost=vtm()                   -- Use event arguments to get the current state.
                 -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object iteslf for the current state.
-                vtm.item.Label(is_topmost==1 and "\\x1b[38:2:0:255:0m▀ \\x1b[m" or "  ")
+                vtm.item.Label(is_topmost==1 and "\e[2:247;38:2:0:255:0m▀\e[2:239m \e[m" or "  ")
                 vtm.item.Tooltip(is_topmost==1 and " AlwaysOnTop on " or " AlwaysOnTop off ")
                 vtm.item.Deface()
             </script>
@@ -1148,7 +1148,7 @@ Notes
                 "   Match clipboard data if no selection  "
             </tooltip>
         </FindNext>
-        <ExclusiveKeyboard label="   Desktop   " script=OnLeftClick|ExclusiveKeyboardMode>
+        <ExclusiveKeyboard label="  Exclusive  " script=OnLeftClick|ExclusiveKeyboardMode>
             <tooltip>
                 " \e[1mToggle exclusive keyboard mode\e[m              \n"
                 "   Exclusive keyboard mode allows keystrokes \n"
@@ -1158,12 +1158,12 @@ Notes
                 <on="release: terminal::events::rawkbd" source="terminal"/>
                 local m=vtm()                                    -- Use event arguments to get the current state.
                 -- local m=vtm.terminal.ExclusiveKeyboardMode()  -- or ask the terminal instance iteslf for the current state.
-                vtm.item.Label(m==1 and "\e[48:2:0:128:128;38:2:0:255:0m  Exclusive  \e[m" or "   Desktop   ")
+                vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Exclusive \e[2:239m \e[m" or "  Exclusive  ")
                 vtm.item.Tooltip(m==1 and " ExclusiveKeyboardMode on " or " ExclusiveKeyboardMode off ")
                 vtm.item.Deface()
             </script>
         </ExclusiveKeyboard>
-        <WrapMode label="  Wrap  " script=OnLeftClick|TerminalWrapMode>
+        <WrapMode label=" NoWrap " script=OnLeftClick|TerminalWrapMode>
             <tooltip>
                 " Wrapping text lines on/off      \n"
                 "   Applied to selection if it is "
@@ -1172,7 +1172,7 @@ Notes
                 <on="release: terminal::events::layout::wrapln" source="terminal"/>
                 local m=vtm()                           -- Use event arguments to get the current state.
                 -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance iteslf for the current state.
-                vtm.item.Label(m==1 and "\e[38:2:0:255:0m  Wrap  \e[m" or "  Wrap  ")
+                vtm.item.Label(m~=1 and "\e[2:247m \e[2:231;38:2:0:255:0mNoWrap\e[2:239m \e[m" or " NoWrap ")
                 vtm.item.Deface()
             </script>
         </WrapMode>
@@ -1203,7 +1203,7 @@ Notes
                 <on="release: terminal::events::io_log" source="terminal"/>
                 local m=vtm()                      -- Use event arguments to get the current state.
                 -- local m=vtm.terminal.LogMode()  -- or ask the terminal instance iteslf for the current state.
-                vtm.item.Label(m==1 and "\e[38:2:0:255:0m  Log  \e[m" or "  Log  ")
+                vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Log \e[2:239m \e[m" or "  Log  ")
                 vtm.item.Deface()
             </script>
         </StdioLog>

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -1165,14 +1165,15 @@ Notes
         </ExclusiveKeyboard>
         <WrapMode label=" NoWrap " script=OnLeftClick|TerminalWrapMode>
             <tooltip>
-                " Wrapping text lines on/off      \n"
-                "   Applied to selection if it is "
+                " \e[1mText line wrapping mode\e[m  \n"
+                " Text wrapping on         "
             </tooltip>
             <script>
                 <on="release: terminal::events::layout::wrapln" source="terminal"/>
                 local m=vtm()                           -- Use event arguments to get the current state.
                 -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance iteslf for the current state.
                 vtm.item.Label(m~=1 and "\e[2:247m \e[2:231;38:2:0:255:0mNoWrap\e[2:239m \e[m" or " NoWrap ")
+                vtm.item.Tooltip(m~=1 and " \e[1mText line wrapping mode\e[m  \\n Text wrapping off        " or " \e[1mText line wrapping mode\e[m  \\n Text wrapping on         ")
                 vtm.item.Deface()
             </script>
         </WrapMode>

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -72,64 +72,26 @@ namespace netxs::app::terminal
     };
     auto build_terminal = [](eccc appcfg, settings& config)
     {
-        //log(prompt::resultant_settings, "\n", config);
-        auto window_clr = skin::color(tone::window_clr);
         auto border = std::max(0, config.settings::take(attr::borders, 0));
         auto borders = dent{ border, border, 0, 0 };
-        auto menu_height = ptr::shared(0);
-        auto gradient = [menu_height, borders, bground = core{}](face& parent_canvas, si32 /*param*/, base& /*boss*/) mutable
-        {
-            static constexpr auto grad_vsize = 32;
-            auto full = parent_canvas.full();
-            auto clip = parent_canvas.clip();
-            auto region = full;
-            if (region.size.x != bground.size().x)
-            {
-                auto spline = netxs::spline01{ -0.30f };
-                auto mx = std::max(2, region.size.x);
-                auto my = std::min(3, region.size.y);
-                bground.size({ mx, my }, skin::color(tone::winfocus));
-                auto it = bground.begin();
-                for (auto y = 0.f; y < my; y++)
-                {
-                    auto y0 = (y + 1) / grad_vsize;
-                    auto sy = spline(y0);
-                    for (auto x = 0.f; x < mx; x++)
-                    {
-                        auto& c = it++->bgc();
-                        auto mirror = x < mx / 2.f ? x : mx - x;
-                        auto x0 = (mirror + 2) / (mx - 1.f);
-                        auto sx = spline(x0);
-                        auto xy = sy * sx;
-                        c.chan.a = (byte)std::round(255.0 * (1.f - xy));
-                    }
-                }
-            }
-            auto menu_size = twod{ region.size.x, std::min(bground.size().y, *menu_height) };
-            auto stat_size = twod{ region.size.x, 1 };
-            // Menu background.
-            auto dest = clip.trim({ region.coor, menu_size });
-            parent_canvas.clip(dest);
-            bground.move(region.coor);
-            parent_canvas.plot(bground, cell::shaders::blend);
-            // Hz scrollbar background.
-            bground.step({ 0, region.size.y - 1 });
-            parent_canvas.clip(clip);
-            parent_canvas.plot(bground, cell::shaders::blend);
-            // Left/right border background.
-            auto color = bground[dot_00];
-            full -= dent{ 0, 0, menu_size.y, stat_size.y };
-            parent_canvas.cage(full, borders, cell::shaders::blend(color));
-            // Restore clipping area.
-            parent_canvas.clip(clip);
-        };
-
         auto window = ui::cake::ctor();
+        auto& window_clr = window->base::field(skin::color(tone::window_clr));
+        auto& is_focused = window->base::field(faux);
         window->plugin<pro::focus>()
             //->plugin<pro::track>()
             //->plugin<pro::acryl>()
             ->plugin<pro::cache>()
-            ->shader(gradient, e2::form::state::focus::count);
+            ->invoke([&](auto& boss)
+            {
+                boss.LISTEN(tier::release, e2::form::state::focus::count, count)
+                {
+                    if (std::exchange(is_focused, !!count) != is_focused)
+                    {
+                        window_clr = is_focused ? skin::color(tone::winfocus)
+                                                : skin::color(tone::window_clr);
+                    }
+                };
+            });
 
         auto object = window->attach(ui::fork::ctor(axis::Y));
         auto term_stat_area = object->attach(slot::_2, ui::fork::ctor(axis::Y))
@@ -137,7 +99,7 @@ namespace netxs::app::terminal
             ->invoke([&](auto& boss)
             {
                 if (borders)
-                boss.LISTEN(tier::release, e2::render::background::any, parent_canvas, -, (borders, window_clr)) // Shade left/right borders.
+                boss.LISTEN(tier::release, e2::render::background::any, parent_canvas, -, (borders)) // Shade left/right borders.
                 {
                     auto full = parent_canvas.full();
                     parent_canvas.cage(full, borders, [&](cell& c){ c.fuse(window_clr); });
@@ -244,7 +206,6 @@ namespace netxs::app::terminal
         {
             static auto box1 = "▄"sv;
             static auto box2 = ' ';
-            auto window_clr = skin::color(tone::window_clr);
             if (handle_len != region_len) // Show only if it is oversized.
             {
                 if (wide) // Draw full scrollbar on mouse hover.
@@ -265,14 +226,8 @@ namespace netxs::app::terminal
 
         auto [slot1, cover, menu_data] = app::shared::menu::load(config);
         auto menu = object->attach(slot::_1, slot1)
-            ->shader(cell::shaders::fuse(window_clr))
-            ->invoke([&](auto& boss)
-            {
-                boss.LISTEN(tier::release, e2::area, new_area, -, (menu_height))
-                {
-                    *menu_height = new_area.size.y;
-                };
-            });
+            ->shader(window_clr);
+
         cover->invoke([&, &slot1 = slot1](auto& boss) //todo clang 15.0.0 still disallows capturing structured bindings (wait for clang 16.0.0)
         {
             auto& bar = boss.base::field(cell{ "▀"sv }.link(slot1->id));

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -287,7 +287,7 @@ namespace netxs::app::tile
         auto build_node = [](auto tag, auto slot1, auto slot2, auto grip_width, auto grip_bindings_ptr)
         {
             auto highlight_color = skin::color(tone::winfocus);
-            auto c3 = highlight_color.bga(0x40);
+            auto c3 = highlight_color;
 
             auto node = tag == 'h' ? ui::fork::ctor(axis::X, grip_width == -1 ? 2 : grip_width, slot1, slot2)
                                    : ui::fork::ctor(axis::Y, grip_width == -1 ? 1 : grip_width, slot1, slot2);
@@ -385,6 +385,7 @@ namespace netxs::app::tile
         auto empty_slot = []
         {
             auto window_clr = skin::color(tone::window_clr);
+            window_clr.bga(0x60);
             auto highlight_color = skin::color(tone::winfocus);
             auto danger_color    = skin::color(tone::danger);
             auto c3 = highlight_color.bga(0x40);

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -1011,6 +1011,7 @@ namespace netxs::app::tile
                         boss.base::riseup(tier::release, e2::form::proceed::quit::one, true);
                     };
                     auto& luafx = boss.bell::indexer.luafx;
+                    tile_context = config.settings::push_context("/config/events/tile/");
                     auto script_list = config.settings::take_ptr_list_for_name("script");
                     auto bindings = input::bindings::load(config, script_list);
                     input::bindings::keybind(boss, bindings);
@@ -1505,7 +1506,6 @@ namespace netxs::app::tile
                         });
                     };
                 });
-            //config.settings::pop_context();
             return object;
         };
     }

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -441,7 +441,28 @@ namespace netxs::app::shared
             }
             auto scrlarea = menufork->attach(menuslot, ui::cake::ctor());
             auto scrlrail = scrlarea->attach(ui::rail::ctor(axes::X_only, axes::all));
-            auto scrllist = scrlrail->attach(ui::list::ctor(axis::X));
+            auto scrllist = scrlrail->attach(ui::list::ctor(axis::X))
+                ->invoke([&](auto& boss)
+                {
+                    boss.LISTEN(tier::release, e2::postrender, parent_canvas) // Draw a shadow to split button groups.
+                    {
+                        auto clip = parent_canvas.clip();
+                        auto full = parent_canvas.full();
+                        if (clip.coor.x + clip.size.x < full.coor.x + full.size.x)
+                        {
+                            auto vert_line = clip;
+                            vert_line.coor.x += vert_line.size.x - 1;
+                            vert_line.size.x = 1;
+                            parent_canvas.fill(vert_line, cell::shaders::shadow(ui::pro::ghost::x3y1_x3y2_x3y3));
+                        }
+                        if (clip.coor.x > full.coor.x)
+                        {
+                            auto vert_line = clip;
+                            vert_line.size.x = 1;
+                            parent_canvas.fill(vert_line, cell::shaders::shadow(ui::pro::ghost::x1y1_x1y2_x1y3));
+                        }
+                    };
+                });
 
             auto scrlcake = ui::cake::ctor();
             auto scrlhint = scrlcake->attach(underlined_hz_scrollbar(scrlrail));

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.06.09";
+    static const auto version = "v2025.06.11";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -153,7 +153,7 @@ R"==(
         </panel>
         <background>  <!-- Desktop background. -->
             <color fgc=whitedk bgc= #00007f80/>  <!-- Desktop background color. -->
-            <tile=""/>                           <!-- Truecolor ANSI-art with gradients can be used here. -->
+            <tile=""/>                           <!-- Truecolor ANSI-art can be used here. -->
         </background>
     </desktop>
 )==" // MSVC2022: C2026 String too big, trailing characters truncated.
@@ -408,7 +408,7 @@ R"==(
                 <on="release: e2::form::prop::zorder" source="applet"/>
                 local is_topmost=vtm()                   -- Use event arguments to get the current state.
                 -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object iteslf for the current state.
-                vtm.item.Label(is_topmost==1 and "\\x1b[38:2:0:255:0m▀ \\x1b[m" or "  ")
+                vtm.item.Label(is_topmost==1 and "\e[2:247;38:2:0:255:0m▀\e[2:239m \e[m" or "  ")
                 vtm.item.Tooltip(is_topmost==1 and " AlwaysOnTop on " or " AlwaysOnTop off ")
                 vtm.item.Deface()
             </script>
@@ -427,7 +427,7 @@ R"==(
                 "   Match clipboard data if no selection  "
             </tooltip>
         </FindNext>
-        <ExclusiveKeyboard label="   Desktop   " script=OnLeftClick|ExclusiveKeyboardMode>
+        <ExclusiveKeyboard label="  Exclusive  " script=OnLeftClick|ExclusiveKeyboardMode>
             <tooltip>
                 " \e[1mToggle exclusive keyboard mode\e[m              \n"
                 "   Exclusive keyboard mode allows keystrokes \n"
@@ -437,12 +437,12 @@ R"==(
                 <on="release: terminal::events::rawkbd" source="terminal"/>
                 local m=vtm()                                    -- Use event arguments to get the current state.
                 -- local m=vtm.terminal.ExclusiveKeyboardMode()  -- or ask the terminal instance iteslf for the current state.
-                vtm.item.Label(m==1 and "\e[48:2:0:128:128;38:2:0:255:0m  Exclusive  \e[m" or "   Desktop   ")
+                vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Exclusive \e[2:239m \e[m" or "  Exclusive  ")
                 vtm.item.Tooltip(m==1 and " ExclusiveKeyboardMode on " or " ExclusiveKeyboardMode off ")
                 vtm.item.Deface()
             </script>
         </ExclusiveKeyboard>
-        <WrapMode label="  Wrap  " script=OnLeftClick|TerminalWrapMode>
+        <WrapMode label=" NoWrap " script=OnLeftClick|TerminalWrapMode>
             <tooltip>
                 " Wrapping text lines on/off      \n"
                 "   Applied to selection if it is "
@@ -451,7 +451,7 @@ R"==(
                 <on="release: terminal::events::layout::wrapln" source="terminal"/>
                 local m=vtm()                           -- Use event arguments to get the current state.
                 -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance iteslf for the current state.
-                vtm.item.Label(m==1 and "\e[38:2:0:255:0m  Wrap  \e[m" or "  Wrap  ")
+                vtm.item.Label(m~=1 and "\e[2:247m \e[2:231;38:2:0:255:0mNoWrap\e[2:239m \e[m" or " NoWrap ")
                 vtm.item.Deface()
             </script>
         </WrapMode>
@@ -482,7 +482,7 @@ R"==(
                 <on="release: terminal::events::io_log" source="terminal"/>
                 local m=vtm()                      -- Use event arguments to get the current state.
                 -- local m=vtm.terminal.LogMode()  -- or ask the terminal instance iteslf for the current state.
-                vtm.item.Label(m==1 and "\e[38:2:0:255:0m  Log  \e[m" or "  Log  ")
+                vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Log \e[2:239m \e[m" or "  Log  ")
                 vtm.item.Deface()
             </script>
         </StdioLog>

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -45,8 +45,8 @@ R"==(<include*/>  <!-- Ordered list of <include="/path/to/settings.xml"/>. The s
         <format="html"/>  <!-- Default clipboard format for screenshots: "text" | "ansi" | "rich" | "html" | "protected" . -->
     </clipboard>
     <colors>  <!-- Along with fgc, bgc and txt, other SGR attributes (boolean) are allowed here: itc: italic, bld: bold, und: underline, inv: reverse, ovr: overline, blk: blink. -->
-        <window   fgc=whitelt   bgc= #40404080        />  <!-- Base desktop window color. -->
-        <focus    fgc=purewhite bgc=bluelt            />  <!-- Focused item tinting. -->
+        <window   fgc=whitelt   bgc= #404040          />  <!-- Color of the unfocused desktop window. -->
+        <focus    fgc=purewhite bgc= #3A528E          />  <!-- Color of the focused window. -->
         <brighter fgc=purewhite bgc=purewhite alpha=60/>  <!-- Brighter. -->
         <shadower               bgc= #202020B4        />  <!-- Dimmer. -->
         <warning  fgc=whitelt   bgc=yellowdk          />  <!-- "Warning" color. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -444,14 +444,15 @@ R"==(
         </ExclusiveKeyboard>
         <WrapMode label=" NoWrap " script=OnLeftClick|TerminalWrapMode>
             <tooltip>
-                " Wrapping text lines on/off      \n"
-                "   Applied to selection if it is "
+                " \e[1mText line wrapping mode\e[m  \n"
+                " Text wrapping on         "
             </tooltip>
             <script>
                 <on="release: terminal::events::layout::wrapln" source="terminal"/>
                 local m=vtm()                           -- Use event arguments to get the current state.
                 -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance iteslf for the current state.
                 vtm.item.Label(m~=1 and "\e[2:247m \e[2:231;38:2:0:255:0mNoWrap\e[2:239m \e[m" or " NoWrap ")
+                vtm.item.Tooltip(m~=1 and " \e[1mText line wrapping mode\e[m  \\n Text wrapping off        " or " \e[1mText line wrapping mode\e[m  \\n Text wrapping on         ")
                 vtm.item.Deface()
             </script>
         </WrapMode>


### PR DESCRIPTION
### Changes

- Fix tile's keybindings (regression from v2025.05.27).
- Add shadows to menu buttons.
- Make the terminal window opaque by default.