### PR TITLE
Fix mouse in linux vga console

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -806,6 +806,7 @@ Notes
         <repeat_delay  = 500ms/>  <!-- Repeat delay. -->
         <repeat_rate   = 30ms />  <!-- Repeat rate. -->
         <dblclick      = 500ms/>  <!-- Mouse double click threshold. -->
+        <wheelrate     = 3    />  <!-- Lines per mouse wheel step (for Unix-like platforms). -->
     </timings>
     <desktop>  <!-- Desktop client settings. -->
         <viewport coor=0,0/>  <!-- Viewport position for the first connected user. At runtime, this value is temporarily replaced with the next disconnecting user's viewport coordinates to restore the viewport position on reconnection. -->
@@ -825,17 +826,6 @@ Notes
                     "   LeftClick to launch instance \n"
                     "   RightClick to set as default "
                 </tooltip>
-                <config>  <!-- The following config partially overrides the base configuration. It is valid for DirectVT apps only. -->
-                    <terminal>
-                        <scrollback>
-                            <size=100000/>  <!-- Scrollback buffer length. -->
-                            <wrap=true/>    <!-- Lines wrapping mode. -->
-                        </scrollback>
-                        <selection>
-                            <mode=/Terminal/selection/mode/>  <!-- Clipboard copy format: "text" | "ansi" | "rich" | "html" | "protected" | "none" . -->
-                        </selection>
-                    </terminal>
-                </config>
             </item>
             <item id="Tile" label="Window Manager"  type="tile" title="Window Manager" cmd="h1:1(Term, Term)"      tooltip=" \e[1mTiling Window Manager\e[m           \n   LeftClick to launch instance  \n   RightClick to set as default  "/>
             <item id="Site" label="Viewport Marker" type="site" title="Site "          cmd="@" winform="maximized" tooltip=" \e[1mDesktop Viewport Marker\e[m         \n   LeftClick to launch instance  \n   RightClick to set as default  "/>  <!-- cmd="@" is a directive for numbering instances. -->

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -844,6 +844,7 @@ namespace netxs::app::shared
 
     auto get_gui_config(settings& config)
     {
+        os::dtvt::wheelrate = config.settings::take("/config/timings/wheelrate", 3);
         auto gui_config = gui_config_t{ .winstate = config.settings::take("/config/gui/winstate", winstate::normal, app::shared::win::options),
                                         .aliasing = config.settings::take("/config/gui/antialiasing", faux),
                                         .blinking = config.settings::take("/config/gui/blinkrate", span{ 400ms }),
@@ -865,6 +866,7 @@ namespace netxs::app::shared
     auto get_tui_config(settings& config, ui::skin& g)
     {
         using namespace std::chrono;
+        os::dtvt::wheelrate = config.settings::take("/config/timings/wheelrate", 3);
         g.window_clr     = config.settings::take("/config/colors/window"     , cell{ whitespace });
         g.winfocus       = config.settings::take("/config/colors/focus"      , cell{ whitespace });
         g.brighter       = config.settings::take("/config/colors/brighter"   , cell{ whitespace });

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.06.11a";
+    static const auto version = "v2025.06.12";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -567,7 +567,7 @@ namespace netxs::ui
             static const auto busy = cell{}.bgc(reddk).fgc(0xFFffffff);
             auto brush = gear.m_sys.buttons ? cell{ busy }.txt(64 + (char)gear.m_sys.buttons/*A-Z...*/)
                                             : idle;
-            auto area = rect{ gear.owner.coor() + gear.coord, dot_11 };
+            auto area = rect{ gear.coord, dot_11 };
             parent_canvas.fill(area, cell::shaders::fuse(brush));
         }
         void draw_mouse_pointer(face& parent_canvas)

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -70,6 +70,7 @@ R"==(<include*/>  <!-- Ordered list of <include="/path/to/settings.xml"/>. The s
         <repeat_delay  = 500ms/>  <!-- Repeat delay. -->
         <repeat_rate   = 30ms />  <!-- Repeat rate. -->
         <dblclick      = 500ms/>  <!-- Mouse double click threshold. -->
+        <wheelrate     = 3    />  <!-- Lines per mouse wheel step (for Unix-like platforms). -->
     </timings>
 )=="
 R"==(
@@ -91,17 +92,6 @@ R"==(
                     "   LeftClick to launch instance \n"
                     "   RightClick to set as default "
                 </tooltip>
-                <config>  <!-- The following config partially overrides the base configuration. It is valid for DirectVT apps only. -->
-                    <terminal>
-                        <scrollback>
-                            <size=100000/>  <!-- Scrollback buffer length. -->
-                            <wrap=true/>    <!-- Lines wrapping mode. -->
-                        </scrollback>
-                        <selection>
-                            <mode=/Terminal/selection/mode/>  <!-- Clipboard copy format: "text" | "ansi" | "rich" | "html" | "protected" | "none" . -->
-                        </selection>
-                    </terminal>
-                </config>
             </item>
             <item id="Tile" label="Window Manager"  type="tile" title="Window Manager" cmd="h1:1(Term, Term)"      tooltip=" \e[1mTiling Window Manager\e[m           \n   LeftClick to launch instance  \n   RightClick to set as default  "/>
             <item id="Site" label="Viewport Marker" type="site" title="Site "          cmd="@" winform="maximized" tooltip=" \e[1mDesktop Viewport Marker\e[m         \n   LeftClick to launch instance  \n   RightClick to set as default  "/>  <!-- cmd="@" is a directive for numbering instances. -->


### PR DESCRIPTION
### Changes

- Fix PS/2 mouse handling in Linux VGA Console. #742
- Make mouse wheel rate configurable via settings (for Unix-like platforms).
  ```xml
  vtm -c "<config/timings/wheelrate=3/>"
  ```