### PR TITLE
Add mouse support in KMSCON environment

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -55,13 +55,13 @@
         },
         {
           "name": "CMAKE_CXX_COMPILER",
-          "value": "/bin/g++",
+          "value": "/usr/bin/g++-12",
           "_comment": "/bin/clang++",
           "type": "STRING"
         },
         {
           "name": "CMAKE_C_COMPILER",
-          "value": "/bin/gcc",
+          "value": "/usr/bin/gcc-12",
           "_comment": "/bin/clang",
           "type": "STRING"
         }

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -26,6 +26,7 @@ Option                  | Description
 `-u`, `--uninstall`     | Perform system-wide deinstallation.
 `-0`, `--session0`      | Use Session 0 to run Desktop Server in background. For Windows only.
 `--SetMouseAccess`      | Set mouse device access for all users in Linux VGA Console. Elevated privileges required.
+`--mouse`               | Force polling of mouse devices.
 `-q`, `--quiet`         | Disable logging.
 `-x`, `--script <cmds>` | Specifies script commands to be run by the desktop when ready.
 `-c`, `--config <file>` | Specifies a settings file to load or plain xml-data to merge.

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.06.17";
+    static const auto version = "v2025.06.17a";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -528,8 +528,10 @@ namespace netxs::ui
             auto& gear = *gear_ptr;
             gear.set_multihome();
             gear.hids::take(device);
-            //todo should we set default gear here?
-            base::strike();
+            if (props.legacy_mode & ui::console::mouse)
+            {
+                base::deface(); // Unconditional viewport update to redraw mouse cursor.
+            }
         }
         void fire(hint event_id)
         {

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2992,13 +2992,10 @@ namespace netxs::ui
                         state = m_buttons[i] ? "pressed" : "idle   ";
                     }
 
-                    if constexpr (debugmode)
-                    {
-                        status[prop::k] = utf::concat(netxs::_k0, " ",
-                                                      netxs::_k1, " ",
-                                                      netxs::_k2, " ",
-                                                      netxs::_k3);
-                    }
+                    status[prop::k] = utf::concat(netxs::_k0, " ",
+                                                  netxs::_k1, " ",
+                                                  netxs::_k2, " ",
+                                                  netxs::_k3);
                     status[prop::mouse_wheeldt] = m.wheelfp ? (m.wheelfp < 0 ? ""s : " "s) + std::to_string(m.wheelfp) : " -- "s;
                     status[prop::mouse_wheelsi] = m.wheelsi ? (m.wheelsi < 0 ? ""s : " "s) + std::to_string(m.wheelsi) : m.wheelfp ? " 0 "s : " -- "s;
                     status[prop::mouse_hzwheel] = m.hzwheel ? "active" : "idle  ";

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4007,7 +4007,13 @@ namespace netxs::os
                     dtvt::vtmode |= nt16 ? ui::console::nt | ui::console::nt16
                                          : ui::console::nt;
                 }
-                #elif defined(__linux__)
+                #endif
+                auto colorterm = os::env::get("COLORTERM");
+                term = text{ dtvt::vtmode & ui::console::nt16 ? "Windows Console" : "" };
+                if (term.empty()) term = os::env::get("TERM");
+                if (term.empty()) term = os::env::get("TERM_PROGRAM");
+                if (term.empty()) term = "xterm-compatible";
+                #if defined(__linux__)
                     auto buffer = text(os::pipebuf, '\0');
                     ok(::ttyname_r(os::stdout_fd, buffer.data(), buffer.size()), "::ttyname_r(os::stdout_fd)", os::unexpected);
                     dtvt::tty_name = buffer.data();
@@ -4027,16 +4033,11 @@ namespace netxs::os
                     {
                         log("%%Pseudoterminal %pts%", prompt::tty, dtvt::tty_name);
                     }
+                    if (term == "linux" || os::linux_console)
+                    {
+                        dtvt::vtmode |= ui::console::mouse;
+                    }
                 #endif
-                auto colorterm = os::env::get("COLORTERM");
-                term = text{ dtvt::vtmode & ui::console::nt16 ? "Windows Console" : "" };
-                if (term.empty()) term = os::env::get("TERM");
-                if (term.empty()) term = os::env::get("TERM_PROGRAM");
-                if (term.empty()) term = "xterm-compatible";
-                if (term == "linux" || os::linux_console)
-                {
-                    dtvt::vtmode |= ui::console::mouse;
-                }
                 if (colorterm != "truecolor" && colorterm != "24bit")
                 {
                     auto vt16colors = { // https://github.com//termstandard/colors

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3761,6 +3761,8 @@ namespace netxs::os
         static auto gridsz = twod{}; // dtvt: Initial window grid size.
         static auto client = xipc{}; // dtvt: Internal IO link.
         static auto wheelrate = 3;   // dtvt: Lines per mouse wheel step (legacy mode).
+        static auto tty_name = text{}; // dtvt: TTY device name.
+        static auto ttynum = 0;        // dtvt: /dev/ttyX index (X).
 
         auto consize()
         {
@@ -4006,13 +4008,35 @@ namespace netxs::os
                                          : ui::console::nt;
                 }
                 #elif defined(__linux__)
-                    if (os::linux_console) dtvt::vtmode |= ui::console::mouse;
+                    auto buffer = text(os::pipebuf, '\0');
+                    ok(::ttyname_r(os::stdout_fd, buffer.data(), buffer.size()), "::ttyname_r(os::stdout_fd)", os::unexpected);
+                    dtvt::tty_name = buffer.data();
+                    if (dtvt::tty_name.starts_with("/dev/tty"))
+                    {
+                        log("%%Linux console %tty%", prompt::tty, dtvt::tty_name);
+                        dtvt::vtmode |= ui::console::mouse;
+                        auto tty_word = "tty"sv;
+                        auto tty_pos = dtvt::tty_name.find(tty_word, 0);
+                        if (tty_pos != text::npos)
+                        {
+                            auto tty_number = dtvt::tty_name.substr(tty_pos + tty_word.size());
+                            dtvt::ttynum = utf::to_int(tty_number, 0);
+                        }
+                    }
+                    else
+                    {
+                        log("%%Pseudoterminal %pts%", prompt::tty, dtvt::tty_name);
+                    }
                 #endif
                 auto colorterm = os::env::get("COLORTERM");
                 term = text{ dtvt::vtmode & ui::console::nt16 ? "Windows Console" : "" };
                 if (term.empty()) term = os::env::get("TERM");
                 if (term.empty()) term = os::env::get("TERM_PROGRAM");
                 if (term.empty()) term = "xterm-compatible";
+                if (term == "linux" || os::linux_console)
+                {
+                    dtvt::vtmode |= ui::console::mouse;
+                }
                 if (colorterm != "truecolor" && colorterm != "24bit")
                 {
                     auto vt16colors = { // https://github.com//termstandard/colors
@@ -4807,7 +4831,10 @@ namespace netxs::os
             }
             void enumerate_mouses(auto proc)
             {
-                for (auto& entry : fs::directory_iterator("/dev/input/"))
+                auto code = std::error_code{};
+                auto events = fs::directory_iterator("/dev/input/", code);
+                if (!code)
+                for (auto& entry : events)
                 {
                     if (entry.path().filename().string().starts_with("event"))
                     {
@@ -5179,63 +5206,62 @@ namespace netxs::os
                 auto micefd = os::invalid_fd;
                 auto buffer = text(os::pipebuf, '\0');
                 auto sig_fd = os::signals::fd{};
-                #if defined(__linux__)
-                auto ttynum = si32{ 0 };
-                #endif
                 auto get_kb_state = []
                 {
                     auto state = si32{ 0 };
                     #if defined(__linux__)
                         auto shift_state = si32{ 6 /*TIOCL_GETSHIFTSTATE*/ };
-                        ::ioctl(os::stdin_fd, TIOCLINUX, &shift_state);
-                        auto lalt   = shift_state & (1 << KG_ALT   );
-                        auto ralt   = shift_state & (1 << KG_ALTGR );
-                        auto ctrl   = shift_state & (1 << KG_CTRL  );
-                        auto rctrl  = shift_state & (1 << KG_CTRLR );
-                        auto lctrl  = shift_state & (1 << KG_CTRLL ) || (!rctrl && ctrl);
-                        auto shift  = shift_state & (1 << KG_SHIFT );
-                        auto rshift = shift_state & (1 << KG_SHIFTR);
-                        auto lshift = shift_state & (1 << KG_SHIFTL) || (!rshift && shift);
-                        if (lalt  ) state |= input::hids::LAlt;
-                        if (ralt  ) state |= input::hids::RAlt;
-                        if (lctrl ) state |= input::hids::LCtrl;
-                        if (rctrl ) state |= input::hids::RCtrl;
-                        if (lshift) state |= input::hids::LShift;
-                        if (rshift) state |= input::hids::RShift;
-                        auto led_state = si32{};
-                        ::ioctl(os::stdin_fd, KDGKBLED, &led_state);
-                        // CapsLock can always be 0 due to poorly coded drivers.
-                        if (led_state & LED_NUM) state |= input::hids::NumLock;
-                        if (led_state & LED_CAP) state |= input::hids::CapsLock;
-                        if (led_state & LED_SCR) state |= input::hids::ScrlLock;
+                        if (-1 != ::ioctl(os::stdin_fd, TIOCLINUX, &shift_state))
+                        {
+                            _k0 = shift_state;
+                            _k1 = 0;
+                            auto lalt   = shift_state & (1 << KG_ALT   );
+                            auto ralt   = shift_state & (1 << KG_ALTGR );
+                            auto ctrl   = shift_state & (1 << KG_CTRL  );
+                            auto rctrl  = shift_state & (1 << KG_CTRLR );
+                            auto lctrl  = shift_state & (1 << KG_CTRLL ) || (!rctrl && ctrl);
+                            auto shift  = shift_state & (1 << KG_SHIFT );
+                            auto rshift = shift_state & (1 << KG_SHIFTR);
+                            auto lshift = shift_state & (1 << KG_SHIFTL) || (!rshift && shift);
+                            if (lalt  ) state |= input::hids::LAlt;
+                            if (ralt  ) state |= input::hids::RAlt;
+                            if (lctrl ) state |= input::hids::LCtrl;
+                            if (rctrl ) state |= input::hids::RCtrl;
+                            if (lshift) state |= input::hids::LShift;
+                            if (rshift) state |= input::hids::RShift;
+                        }
+                        else
+                        {
+                            _k0 = -1;
+                            _k1 = errno;
+                        }
+                        auto led_state = si32{ 0 };
+                        if (-1 != ::ioctl(os::stdin_fd, KDGKBLED, &led_state))
+                        {
+                            _k2 = led_state;
+                            _k3 = 0;
+                            // CapsLock can always be 0 due to poorly coded drivers.
+                            if (led_state & LED_NUM) state |= input::hids::NumLock;
+                            if (led_state & LED_CAP) state |= input::hids::CapsLock;
+                            if (led_state & LED_SCR) state |= input::hids::ScrlLock;
+                        }
+                        else
+                        {
+                            _k2 = -1;
+                            _k3 = errno;
+                        }
                     #endif
                     return state;
                 };
-                ok(::ttyname_r(os::stdout_fd, buffer.data(), buffer.size()), "::ttyname_r(os::stdout_fd)", os::unexpected);
-                auto tty_name = view(buffer.data());
-                if (!os::linux_console)
-                {
-                    log(prompt::tty, "Pseudoterminal ", tty_name);
-                }
                 #if defined(__linux__)
-                else // Trying to get direct access to mouse devices.
+                if (dtvt::vtmode & ui::console::mouse) // Trying to get direct mouse access.
                 {
-                    log("%%Linux console %tty%", prompt::tty, tty_name);
                     if (auto li = os::tty::libinput::initialize())
                     {
                         auto dev_count = os::tty::libinput::attach_mouse();
                         if (dev_count)
                         {
                             micefd = libinput::get_fd(li);
-                            auto tty_word = tty_name.find("tty", 0);
-                            if (tty_word != text::npos)
-                            {
-                                auto tty_number = tty_name.substr(tty_word + 3/*skip tty letters*/);
-                                if (auto cur_tty = utf::to_int(tty_number))
-                                {
-                                    ttynum = cur_tty.value();
-                                }
-                            }
                         }
                         else
                         {
@@ -5879,9 +5905,14 @@ namespace netxs::os
                             }
                             auto vt_state = ::vt_stat{};
                             ::ioctl(os::stdout_fd, VT_GETSTATE, &vt_state);
-                            if (vt_state.v_active == ttynum) // Proceed only if the current tty is active.
+                            if (vt_state.v_active == dtvt::ttynum) // Proceed only if the current tty is active.
                             {
-                                k.ctlstat = get_kb_state();
+                                auto kbmod = get_kb_state();
+                                if (k.ctlstat != kbmod)
+                                {
+                                    k.ctlstat = kbmod;
+                                    m.ctlstat = kbmod;
+                                }
                                 m.coordxy = mcoord / scale;
                                 m.buttons = bttns;
                                 m.ctlstat = k.ctlstat;

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -134,6 +134,10 @@ int main(int argc, char* argv[])
             auto ok = os::tty::libinput::set_mouse_access();
             return ok;
         }
+        else if (getopt.match("--mouse"))
+        {
+            os::dtvt::vtmode |= ui::console::mouse;
+        }
         #endif
         else if (getopt.match("-?", "-h", "--help"))
         {
@@ -171,6 +175,7 @@ int main(int argc, char* argv[])
                 #endif
                 #if defined(__linux__)
                 "\n    --SetMouseAccess     Set mouse device access for all users in Linux VGA Console. Elevated privileges required."
+                "\n    --mouse              Force polling of mouse devices."
                 #endif
                 "\n    -q, --quiet          Disable logging."
                 "\n    -x, --script <cmds>  Specifies script commands."


### PR DESCRIPTION
### Changes

- Add mouse support in KMSCON environment. #749
  KMSCON is essentially a full-fledged terminal emulator and vtm expects a stream of keyboard and mouse events from it. Although KMSCON may support mouse reporting in the future, I added an option to vtm to allow mouse reporting in the same way as the Linux kernel console (Linux VGA Console).
  ```
  sudo ./vtm --SetMouseAccess
  ./vtm --mouse
  ```