### PR TITLE
Fix tooltips and footer size (GUI mode)

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -284,7 +284,7 @@
           "type": "STRING"
         },
         {
-          "name": "DCMAKE_EXE_LINKER_FLAGS_RELEASE",
+          "name": "CMAKE_EXE_LINKER_FLAGS_RELEASE",
           "value": "/DEBUG /OPT:REF /OPT:ICF",
           "type": "STRING"
         },

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -349,7 +349,7 @@ Tiling Window Manager is a window container that organizes the workspace into mu
                 <script>  <!-- A binding to update the menu item label at runtime. -->
                     <on="release: e2::form::prop::zorder" source="applet"/>
                     local is_topmost=vtm()                   -- Use event arguments to get the current state.
-                    -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object iteslf for the current state.
+                    -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object itself for the current state.
                     vtm.item.Label(is_topmost==1 and "\\x1b[38:2:0:255:0m▀ \\x1b[m" or "  ")
                     vtm.item.Tooltip(is_topmost==1 and " AlwaysOnTop on " or " AlwaysOnTop off ")
                     vtm.item.Deface()

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -1118,7 +1118,7 @@ Notes
             <script>  <!-- A binding to update the menu item label at runtime. -->
                 <on="release: e2::form::prop::zorder" source="applet"/>
                 local is_topmost=vtm()                   -- Use event arguments to get the current state.
-                -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object iteslf for the current state.
+                -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object itself for the current state.
                 vtm.item.Label(is_topmost==1 and "\e[2:247;38:2:0:255:0m▀\e[2:239m \e[m" or "  ")
                 vtm.item.Tooltip(is_topmost==1 and " AlwaysOnTop on " or " AlwaysOnTop off ")
                 vtm.item.Deface()
@@ -1147,7 +1147,7 @@ Notes
             <script>
                 <on="release: terminal::events::rawkbd" source="terminal"/>
                 local m=vtm()                                    -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.ExclusiveKeyboardMode()  -- or ask the terminal instance iteslf for the current state.
+                -- local m=vtm.terminal.ExclusiveKeyboardMode()  -- or ask the terminal instance itself for the current state.
                 vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Exclusive \e[2:239m \e[m" or "  Exclusive  ")
                 vtm.item.Tooltip(m==1 and " ExclusiveKeyboardMode on " or " ExclusiveKeyboardMode off ")
                 vtm.item.Deface()
@@ -1161,7 +1161,7 @@ Notes
             <script>
                 <on="release: terminal::events::layout::wrapln" source="terminal"/>
                 local m=vtm()                           -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance iteslf for the current state.
+                -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance itself for the current state.
                 vtm.item.Label(m~=1 and "\e[2:247m \e[2:231;38:2:0:255:0mNoWrap\e[2:239m \e[m" or " NoWrap ")
                 vtm.item.Tooltip(m~=1 and " \e[1mText line wrapping mode\e[m  \\n Text wrapping off        " or " \e[1mText line wrapping mode\e[m  \\n Text wrapping on         ")
                 vtm.item.Deface()
@@ -1171,7 +1171,7 @@ Notes
             <script>
                 <on="release: terminal::events::selmod" source="terminal"/>
                 local m=vtm()                              -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.ClipboardFormat()  -- or ask the terminal instance iteslf for the current state.
+                -- local m=vtm.terminal.ClipboardFormat()  -- or ask the terminal instance itself for the current state.
                 vtm.item.Label(m==1 and "\e[38:2:0:255:0m  Plaintext  \e[m"     -- "textonly"
                             or m==2 and "\e[38:2:255:255:0m  ANSI-text  \e[m"   -- "ansitext"
                             or m==3 and "\e[38:2:109:231:237m  ".."R"..
@@ -1193,7 +1193,7 @@ Notes
             <script>
                 <on="release: terminal::events::io_log" source="terminal"/>
                 local m=vtm()                      -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.LogMode()  -- or ask the terminal instance iteslf for the current state.
+                -- local m=vtm.terminal.LogMode()  -- or ask the terminal instance itself for the current state.
                 vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Log \e[2:239m \e[m" or "  Log  ")
                 vtm.item.Deface()
             </script>

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -1114,11 +1114,11 @@ Notes
         <slim=true/>       <!-- Make the window menu one cell high (slim=true) or three cells high (slim=false). -->
     </Defaults>
     <Buttons>
-        <AlwaysOnTop label="  " tooltip=" AlwaysOnTop off " script=OnLeftClick|AlwaysOnTopApplet> <!-- The default event source is the parent object, i.e. source="item" (aka vtm.item). -->
+        <AlwaysOnTop script=OnLeftClick|AlwaysOnTopApplet> <!-- The default event source is the parent object, i.e. source="item" (aka vtm.item). -->
             <script>  <!-- A binding to update the menu item label at runtime. -->
-                <on="release: e2::form::prop::zorder" source="applet"/>
-                local is_topmost=vtm()                   -- Use event arguments to get the current state.
-                -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object itself for the current state.
+                <on="release: e2::form::upon::started" source="applet"/>
+                <on="release: e2::form::prop::zorder"  source="applet"/>
+                local is_topmost=vtm.applet.ZOrder()
                 vtm.item.Label(is_topmost==1 and "\e[2:247;38:2:0:255:0m▀\e[2:239m \e[m" or "  ")
                 vtm.item.Tooltip(is_topmost==1 and " AlwaysOnTop on " or " AlwaysOnTop off ")
                 vtm.item.Deface()
@@ -1138,40 +1138,36 @@ Notes
                 "   Match clipboard data if no selection  "
             </tooltip>
         </FindNext>
-        <ExclusiveKeyboard label="  Exclusive  " script=OnLeftClick|ExclusiveKeyboardMode>
+        <ExclusiveKeyboard script=OnLeftClick|ExclusiveKeyboardMode>
             <tooltip>
                 " \e[1mToggle exclusive keyboard mode\e[m              \n"
                 "   Exclusive keyboard mode allows keystrokes \n"
                 "   to be passed through without processing   "
             </tooltip>
             <script>
+                <on="release: e2::form::upon::started"  source="applet"/>
                 <on="release: terminal::events::rawkbd" source="terminal"/>
-                local m=vtm()                                    -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.ExclusiveKeyboardMode()  -- or ask the terminal instance itself for the current state.
+                local m=vtm.terminal.ExclusiveKeyboardMode()
                 vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Exclusive \e[2:239m \e[m" or "  Exclusive  ")
                 vtm.item.Tooltip(m==1 and " ExclusiveKeyboardMode on " or " ExclusiveKeyboardMode off ")
                 vtm.item.Deface()
             </script>
         </ExclusiveKeyboard>
-        <WrapMode label=" NoWrap " script=OnLeftClick|TerminalWrapMode>
-            <tooltip>
-                " \e[1mText line wrapping mode\e[m  \n"
-                " Text wrapping on         "
-            </tooltip>
+        <WrapMode script=OnLeftClick|TerminalWrapMode>
             <script>
+                <on="release: e2::form::upon::started"          source="applet"/>
                 <on="release: terminal::events::layout::wrapln" source="terminal"/>
-                local m=vtm()                           -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance itself for the current state.
+                local m=vtm.terminal.LineWrapMode()
                 vtm.item.Label(m~=1 and "\e[2:247m \e[2:231;38:2:0:255:0mNoWrap\e[2:239m \e[m" or " NoWrap ")
                 vtm.item.Tooltip(m~=1 and " \e[1mText line wrapping mode\e[m  \\n Text wrapping off        " or " \e[1mText line wrapping mode\e[m  \\n Text wrapping on         ")
                 vtm.item.Deface()
             </script>
         </WrapMode>
-        <ClipboardFormat label="  Clipboard  " tooltip=" Clipboard format " script=OnLeftClick|TerminalClipboardFormat>
+        <ClipboardFormat tooltip=" Clipboard format " script=OnLeftClick|TerminalClipboardFormat>
             <script>
+                <on="release: e2::form::upon::started"  source="applet"/>
                 <on="release: terminal::events::selmod" source="terminal"/>
-                local m=vtm()                              -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.ClipboardFormat()  -- or ask the terminal instance itself for the current state.
+                local m=vtm.terminal.ClipboardFormat()
                 vtm.item.Label(m==1 and "\e[38:2:0:255:0m  Plaintext  \e[m"     -- "textonly"
                             or m==2 and "\e[38:2:255:255:0m  ANSI-text  \e[m"   -- "ansitext"
                             or m==3 and "\e[38:2:109:231:237m  ".."R"..
@@ -1189,11 +1185,11 @@ Notes
                 vtm.item.Deface()
             </script>
         </ClipboardFormat>
-        <StdioLog label="  Log  " tooltip=" \e[1mConsole logging\e[m        \n Use Logs to see output " script=OnLeftClick|TerminalStdioLog>
+        <StdioLog tooltip=" \e[1mConsole logging\e[m        \n Use Logs to see output " script=OnLeftClick|TerminalStdioLog>
             <script>
+                <on="release: e2::form::upon::started"  source="applet"/>
                 <on="release: terminal::events::io_log" source="terminal"/>
-                local m=vtm()                      -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.LogMode()  -- or ask the terminal instance itself for the current state.
+                local m=vtm.terminal.LogMode()
                 vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Log \e[2:239m \e[m" or "  Log  ")
                 vtm.item.Deface()
             </script>

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -835,12 +835,54 @@ namespace netxs::app::shared
             layers->attach(app::shared::scroll_bars(scroll));
             return window_ptr;
         };
-
+        auto build_invalid = [](eccc, settings&)
+        {
+            auto window = ui::cake::ctor()
+                ->plugin<pro::focus>()
+                //->plugin<pro::track>()
+                ->plugin<pro::acryl>()
+                ->invoke([&](auto& boss)
+                {
+                    closing_on_quit(boss);
+                    closing_by_gesture(boss);
+                    boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent)
+                    {
+                        auto title = "error"s;
+                        boss.base::riseup(tier::preview, e2::form::prop::ui::header, title);
+                    };
+                });
+            auto msg = ui::post::ctor()
+                ->colors(whitelt, argb{ 0x7F404040 })
+                ->upload(ansi::fgc(yellowlt).mgl(4).mgr(4).wrp(wrap::off) +
+                    "\n"
+                    "\nUnsupported application type"
+                    "\n" + ansi::nil().wrp(wrap::on) +
+                    "\nOnly the following application types are supported:"
+                    "\n" + ansi::nil().wrp(wrap::off).fgc(whitedk) +
+                    "\n   type = vtty"
+                    "\n   type = term"
+                    "\n   type = dtvt"
+                    "\n   type = dtty"
+                    "\n   type = tile"
+                    "\n   type = site"
+                    "\n   type = info"
+                    "\n"
+                    "\n" + ansi::nil().wrp(wrap::on).fgc(whitelt)
+                    .add(prompt::apps, "See logs for details."));
+            auto placeholder = ui::cake::ctor()
+                ->colors(whitelt, argb{ 0x7F404040 })
+                ->attach(msg->alignment({ snap::head, snap::head }));
+            window->attach(ui::rail::ctor())
+                ->attach(placeholder)
+                ->active();
+            return window;
+        };
         app::shared::initialize site_builder{ app::site::id, build_site };
         app::shared::initialize vtty_builder{ app::vtty::id, build_vtty };
         app::shared::initialize term_builder{ app::term::id, build_term };
         app::shared::initialize dtvt_builder{ app::dtvt::id, build_dtvt };
         app::shared::initialize dtty_builder{ app::dtty::id, build_dtty };
         app::shared::initialize info_builder{ app::info::id, build_info };
+        app::shared::initialize invalid_builder{ "invalid", build_invalid };
     }
 }

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.07.15";
+    static const auto version = "v2025.07.17";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -773,7 +773,7 @@ namespace netxs::ui
             }
             return parent_ptr;
         }
-        // base: Fire an event for all nested objects (except those with base::master == true).
+        // base: Fire an event for the owner and then for all nested objects (except those with base::master == true).
         void broadcast(si32 Tier, hint event, auto&& param, bool forced = true)
         {
             auto lock = bell::sync();
@@ -806,7 +806,10 @@ namespace netxs::ui
                 auto root_ptr = gettop();
                 root_ptr->broadcast(Tier, event, param, faux);
             }
-            else bell::_signal(Tier, event, param);
+            else
+            {
+                bell::_signal(Tier, event, param);
+            }
         }
         // base: Fire an event.
         // Usage example:

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1156,7 +1156,7 @@ namespace netxs
                 }
                 return crop;
             }
-            bool is_space() const //todo VS2019 complains on auto
+            auto is_space() const
             {
                 return (token & netxs::letoh((ui64)0xFF00)) <= netxs::letoh((ui64)whitespace << 8); // (byte)(bytes[1]) <= whitespace;
             }

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1557,6 +1557,10 @@ namespace netxs
 
         operator bool () const { return st.xy(); } // cell: Return true if cell contains printable character.
 
+        auto is_empty() const // cell: Return true if cell is absolutely empty.
+        {
+            return uv.bg.token == 0 && uv.fg.token == 0 && gc.token == 0 && st.token == 0 && id == 0 && px.token == 0;
+        }
         auto same_txt(cell const& c) const // cell: Compare clusters.
         {
             return gc == c.gc;

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -993,7 +993,7 @@ namespace netxs::ui
             LISTEN(tier::preview, e2::form::proceed::create, dest_region)
             {
                 dest_region.coor += base::coor();
-                this->base::riseup(tier::release, e2::form::proceed::create, dest_region);
+                base::riseup(tier::release, e2::form::proceed::create, dest_region);
             };
             LISTEN(tier::release, e2::conio::pointer, pointer)
             {
@@ -1001,7 +1001,7 @@ namespace netxs::ui
             };
             LISTEN(tier::release, e2::form::upon::stopped, fast) // Reading loop ends.
             {
-                this->base::signal(tier::anycast, e2::form::proceed::quit::one, fast);
+                base::signal(tier::anycast, e2::form::proceed::quit::one, fast);
                 disconnect();
                 paint.stop();
                 bell::sensors.clear();
@@ -1018,11 +1018,11 @@ namespace netxs::ui
             {
                 base::update_scripting_context(); // Gate has no parents.
                 if (props.debug_overlay) debug.start();
-                this->base::signal(tier::release, e2::form::prop::name, props.title);
+                base::signal(tier::release, e2::form::prop::name, props.title);
                 //todo revise
                 if (props.title.length())
                 {
-                    this->base::riseup(tier::preview, e2::form::prop::ui::header, props.title);
+                    base::riseup(tier::preview, e2::form::prop::ui::header, props.title);
                 }
             };
             LISTEN(tier::request, e2::form::prop::ui::footer, f)
@@ -1161,7 +1161,10 @@ namespace netxs::ui
                 });
                 LISTEN(tier::release, e2::config::fps, fps)
                 {
-                    if (fps > 0) this->base::signal(tier::general, e2::config::fps, fps);
+                    if (fps > 0)
+                    {
+                        base::signal(tier::general, e2::config::fps, fps);
+                    }
                 };
                 LISTEN(tier::preview, e2::form::prop::cwd, path)
                 {

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -608,7 +608,7 @@ namespace netxs::ui
             {
                 auto& gear = *gear_ptr;
                 if (gear.mouse_disabled) continue;
-                auto [tooltip_page_sptr, tooltip_offset] = gear.tooltip.get_render_sptr_and_offset();
+                auto [tooltip_page_sptr, tooltip_offset] = gear.tooltip.get_render_sptr_and_offset(props.tooltip_colors);
                 if (tooltip_page_sptr)
                 {
                     auto& tooltip_page = *tooltip_page_sptr;
@@ -621,7 +621,7 @@ namespace netxs::ui
                     page_area.size.x = dot_mx.x; // Prevent line wrapping.
                     canvas.full(page_area);
                     canvas.cup(dot_00);
-                    canvas.output(tooltip_page, cell::shaders::color(props.tooltip_colors));
+                    canvas.output(tooltip_page, cell::shaders::fuse);
                 }
             }
             canvas.area(area);

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -3417,7 +3417,7 @@ namespace netxs::ui
             LISTEN(tier::preview, e2::form::layout::swarp, warp)
             {
                 adaptive = true; // Adjust the grip ratio on coming resize.
-                this->bell::passover();
+                bell::passover();
             };
             LISTEN(tier::release, e2::render::any, parent_canvas)
             {
@@ -3533,7 +3533,7 @@ namespace netxs::ui
                     auto split = xpose(griparea.coor + delta).x;
                     auto limit = xpose(base::size() - griparea.size).x;
                     fraction = netxs::divround(max_ratio * split, limit);
-                    this->base::reflow();
+                    base::reflow();
                 };
             }
             item_ptr->base::signal(tier::release, e2::form::upon::vtree::attached, This());
@@ -4058,7 +4058,7 @@ namespace netxs::ui
             }
             base::resize(twod{ initial_width, 0 });
             base::reflow();
-            return this->This();
+            return postfx::This();
         }
         // post: .
         auto& get_source() const
@@ -4115,7 +4115,7 @@ namespace netxs::ui
             return twod{ !!(Axes & axes::X_only), !!(Axes & axes::Y_only) };
         }
         // rail: .
-        bool empty() //todo VS2019 requires bool
+        auto empty()
         {
             return base::subset.empty() || !base::subset.back();
         }
@@ -4149,7 +4149,7 @@ namespace netxs::ui
             LISTEN(tier::preview, e2::form::upon::scroll::any, info) // Receive scroll parameters from external sources.
             {
                 auto delta = dot_00;
-                switch (this->bell::protos())
+                switch (bell::protos())
                 {
                     case e2::form::upon::scroll::bycoor::v.id: delta = { scinfo.window.coor - info.window.coor };        break;
                     case e2::form::upon::scroll::bycoor::x.id: delta = { scinfo.window.coor.x - info.window.coor.x, 0 }; break;
@@ -4300,7 +4300,7 @@ namespace netxs::ui
                 master->LISTEN(tier::release, e2::form::upon::scroll::bycoor::any, master_scinfo, fasten)
                 {
                     auto backup_scinfo = master_scinfo;
-                    this->base::signal(tier::preview, e2::form::upon::scroll::bycoor::_<Axis>, backup_scinfo);
+                    base::signal(tier::preview, e2::form::upon::scroll::bycoor::_<Axis>, backup_scinfo);
                 };
             }
             else fasten.clear();
@@ -4467,7 +4467,7 @@ namespace netxs::ui
                 scinfo.region = block;
                 scinfo.window.coor =-coord; // Viewport.
                 scinfo.window.size = frame; //
-                this->base::signal(tier::release, e2::form::upon::scroll::bycoor::any, scinfo);
+                base::signal(tier::release, e2::form::upon::scroll::bycoor::any, scinfo);
             };
             return object;
         }
@@ -4480,7 +4480,7 @@ namespace netxs::ui
                 base::remove(object);
                 scinfo.region = {};
                 scinfo.window.coor = {};
-                this->base::signal(tier::release, e2::form::upon::scroll::bycoor::any, scinfo); // Reset dependent scrollbars.
+                base::signal(tier::release, e2::form::upon::scroll::bycoor::any, scinfo); // Reset dependent scrollbars.
                 fasten.clear();
             }
             else base::clear();
@@ -4654,7 +4654,7 @@ namespace netxs::ui
         template<auto Event>
         void send()
         {
-            if (auto master = this->boss.lock())
+            if (auto master = boss.lock())
             {
                 master->base::signal(tier::preview, Event, calc.master_inf);
             }

--- a/src/netxs/desktopio/generics.hpp
+++ b/src/netxs/desktopio/generics.hpp
@@ -842,9 +842,9 @@ namespace netxs::generics
         void execute(size_t alonecmd, Out& story) const
         {
             auto& queue = In::fake();
-            if (alonecmd < this->size())
+            if (alonecmd < bulk::size())
             {
-                if (auto const& next = this->at(alonecmd))
+                if (auto const& next = bulk::at(alonecmd))
                 {
                     if (next.proc)
                     {

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3536,7 +3536,7 @@ namespace netxs::gui
                 });
                 LISTEN(tier::release, input::events::focus::set::any, seed, -, (treeid = datetime::uniqueid(), digest = ui64{}))
                 {
-                    auto deed = this->bell::protos();
+                    auto deed = bell::protos();
                     auto state = deed == input::events::focus::set::on.id;
                     stream.sysfocus.send(stream.intio, seed.gear_id, state, seed.focus_type, treeid, ++digest);
                 };

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2298,13 +2298,13 @@ namespace netxs::gui
         }
         void update_header()
         {
-            page_to_grid(faux, h_grid, titles.head_page, cell::shaders::contrast);
+            page_to_grid(faux, h_grid, titles.head_page, cell::shaders::contrast, { gridsz.x, dot_mx.y });
             sync_pixel_layout();
             netxs::set_flag<task::header>(reload);
         }
         void update_footer()
         {
-            page_to_grid(faux, f_grid, titles.foot_page, cell::shaders::contrast);
+            page_to_grid(faux, f_grid, titles.foot_page, cell::shaders::contrast, { gridsz.x, dot_mx.y });
             sync_pixel_layout();
             netxs::set_flag<task::footer>(reload);
         }
@@ -2317,7 +2317,7 @@ namespace netxs::gui
                 auto& tooltip_page = *render_sptr;
                 auto  tooltip_clrs = cell{}.bgc(tooltip.default_bgc).fgc(tooltip.default_fgc);
                 auto margins = dent{ dot_11 }; // Shadow around tooltip.
-                page_to_grid(true, tooltip_grid, tooltip_page, cell::shaders::color(tooltip_clrs), margins);
+                page_to_grid(true, tooltip_grid, tooltip_page, cell::shaders::color(tooltip_clrs), dot_mx, margins);
                 tooltip_layer.area.coor = mcoord + (tooltip_offset - margins.corner()) * cellsz;
                 tooltip_layer.area.size = tooltip_grid.size() * cellsz;
                 tooltip_layer.show();
@@ -2495,9 +2495,8 @@ namespace netxs::gui
                 update_gui();
             });
         }
-        void page_to_grid(bool update_all, ui::face& target_grid, ui::page& source_page, auto fuse, dent margins = {})
+        void page_to_grid(bool update_all, ui::face& target_grid, ui::page& source_page, auto fuse, twod grid_size, dent margins = {})
         {
-            auto grid_size = gridsz;
             target_grid.get_page_size(source_page, grid_size, update_all);
             target_grid.size(grid_size + margins);
             target_grid.wipe();
@@ -2516,8 +2515,8 @@ namespace netxs::gui
             master.area = blinky.area + border;
             if (fsmode != winstate::maximized)
             {
-                page_to_grid(faux, h_grid, titles.head_page, cell::shaders::contrast);
-                page_to_grid(faux, f_grid, titles.foot_page, cell::shaders::contrast);
+                page_to_grid(faux, h_grid, titles.head_page, cell::shaders::contrast, { gridsz.x, dot_mx.y });
+                page_to_grid(faux, f_grid, titles.foot_page, cell::shaders::contrast, { gridsz.x, dot_mx.y });
                 sync_pixel_layout();
             }
             if (sizechanged)

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2311,13 +2311,13 @@ namespace netxs::gui
         void update_tooltip()
         {
             auto& tooltip = stream.gears->tooltip;
-            auto [render_sptr, tooltip_offset] = tooltip.get_render_sptr_and_offset();
+            auto  tooltip_clrs = cell{}.bgc(tooltip.default_bgc).fgc(tooltip.default_fgc);
+            auto [render_sptr, tooltip_offset] = tooltip.get_render_sptr_and_offset(tooltip_clrs);
             if (render_sptr)
             {
                 auto& tooltip_page = *render_sptr;
-                auto  tooltip_clrs = cell{}.bgc(tooltip.default_bgc).fgc(tooltip.default_fgc);
                 auto margins = dent{ dot_11 }; // Shadow around tooltip.
-                page_to_grid(true, tooltip_grid, tooltip_page, cell::shaders::color(tooltip_clrs), dot_mx, margins);
+                page_to_grid(true, tooltip_grid, tooltip_page, cell::shaders::fuse, dot_mx, margins);
                 tooltip_layer.area.coor = mcoord + (tooltip_offset - margins.corner()) * cellsz;
                 tooltip_layer.area.size = tooltip_grid.size() * cellsz;
                 tooltip_layer.show();

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -2245,7 +2245,8 @@ namespace netxs::input
             auto bindings = input::bindings::vector{};
             for (auto script_ptr : script_list)
             {
-                auto script_context = config.settings::push_context(script_ptr);
+                //todo revise
+                //auto script_context = config.settings::push_context(script_ptr);
                 auto script_body_ptr = ptr::shared(config.settings::take_value(script_ptr));
                 auto on_ptr_list = config.settings::take_ptr_list_of(script_ptr, "on");
                 for (auto event_ptr : on_ptr_list)

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -508,7 +508,7 @@ namespace netxs::input
                 auto crop = std::vector<text>{};
                 //todo reimplement chord_list
                 if (auto anytest = utf::to_lower(chord);
-                    anytest.starts_with("any") ||
+                   (anytest.starts_with("any") && !anytest.starts_with(tier::str[tier::anycast])) ||
                    (anytest.starts_with(tier::str[tier::preview])
                        && utf::get_trimmed((view{ anytest }.substr(tier::str[tier::preview].size())), ": ").starts_with("any")))
                 {
@@ -2259,7 +2259,7 @@ namespace netxs::input
                     //         log("chord='%%' \tpreview=%% source='%%' script=%%", on_rec, (si32)preview, source, ansi::hi(*script_body_ptr));
                     //    }
                     //}
-                    bindings.push_back({ .chord = on_rec, .sources = std::move(sources), .script_ptr = script_body_ptr });
+                    bindings.push_back({ .chord = std::move(on_rec), .sources = std::move(sources), .script_ptr = script_body_ptr });
                 }
                 //config.settings::pop_context();
             }

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1284,11 +1284,11 @@ namespace netxs::input
             string = utf8;
             page_sptr.reset();
         }
-        auto get_render_sptr()
+        auto get_render_sptr(cell const& tooltip_colors)
         {
             if (!page_sptr)
             {
-                page_sptr = ptr::shared(page{ string });
+                page_sptr = ptr::shared(page{ string, tooltip_colors });
             }
             return page_sptr;
         }
@@ -1471,11 +1471,11 @@ namespace netxs::input
                     changed_visibility = true;
                 }
             }
-            auto get_render_sptr_and_offset()
+            auto get_render_sptr_and_offset(cell const& tooltip_colors = {})
             {
                 if (visible && current_sptr)
                 {
-                    auto render_sptr = current_sptr->get_render_sptr();
+                    auto render_sptr = current_sptr->get_render_sptr(tooltip_colors);
                     auto page_offset = -twod{ 4, render_sptr->size() + 1 };
                     return std::pair{ render_sptr, page_offset };
                 }

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -2419,7 +2419,7 @@ namespace netxs::ui
         {
             auto publish = [&](auto& combo)
             {
-                combo.coord = this->flow::print<true, Split>(combo, *this, printfx);
+                combo.coord = flow::print<true, Split>(combo, *this, printfx);
             };
             textpage.stream(publish);
         }

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1793,6 +1793,13 @@ namespace netxs::ui
         auto& operator  = (view utf8) { clear(); ansi::parse(utf8, this); reindex(); return *this; }
         auto& operator += (view utf8) {          ansi::parse(utf8, this); reindex(); return *this; }
         page(view utf8)               {          ansi::parse(utf8, this); reindex();               }
+        page(view utf8, cell c)
+        {
+            parser::brush.reset(c);
+            batch.front()->parser::brush.reset(c);
+            ansi::parse(utf8, this);
+            reindex();
+        }
         page() = default;
         page(page&& p)
             : parser{        },

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7066,7 +7066,7 @@ namespace netxs::ui
                     auto path = text{ data.substr(delimpos) };
                     base::enqueue([&, path](auto& /*boss*/) mutable
                     {
-                        this->base::riseup(tier::preview, e2::form::prop::cwd, path); //todo VS2019 requires `this`
+                        base::riseup(tier::preview, e2::form::prop::cwd, path);
                     });
                 }
             }
@@ -7430,7 +7430,7 @@ namespace netxs::ui
         template<bool Forced = faux>
         auto ondata_direct(view data = {}, bufferbase* target_buffer = {})
         {
-            auto& console_ptr = target_buffer ? target_buffer : this->target;
+            auto& console_ptr = target_buffer ? target_buffer : target;
             if (data.size())
             {
                 if (io_log) log(prompt::cout, "\n\t", utf::replace_all(ansi::hi(utf::debase(data)), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));
@@ -7599,7 +7599,7 @@ namespace netxs::ui
             auto data = get_clipboard_text(gear);
             if (data.size())
             {
-                pro::focus::set(this->This(), gear.id, solo::off);
+                pro::focus::set(This(), gear.id, solo::off);
                 _paste(data);
                 return true;
             }
@@ -7608,7 +7608,7 @@ namespace netxs::ui
         auto _copy(hids& gear, text const& data)
         {
             auto form = selmod == mime::disabled ? mime::textonly : selmod;
-            pro::focus::set(this->This(), gear.id, solo::off);
+            pro::focus::set(This(), gear.id, solo::off);
             gear.set_clipboard(target->panel, data, form);
         }
         auto copy(hids& gear)
@@ -7675,7 +7675,7 @@ namespace netxs::ui
             }
             if (utf8.size())
             {
-                pro::focus::set(this->This(), gear.id, solo::off);
+                pro::focus::set(This(), gear.id, solo::off);
                 follow[axis::X] = true;
                 if (bpmode)
                 {
@@ -7802,7 +7802,7 @@ namespace netxs::ui
             {
                 if (gear.captured()) // Forward mouse wheel events to all parents. Wheeling while button pressed.
                 {
-                    auto& offset = this->base::coor();
+                    auto& offset = base::coor();
                     if (auto parent_ptr = base::parent())
                     {
                         auto& parent = *parent_ptr;
@@ -7998,7 +7998,7 @@ namespace netxs::ui
                     auto byemsg = error().add("Press Esc to close or press Enter to restart the session.\r\n")
                                          .add("\n");
                     ondata(byemsg);
-                    this->LISTEN(tier::release, input::events::keybd::post, gear, onerun) //todo VS2019 requires `this`
+                    LISTEN(tier::release, input::events::keybd::post, gear, onerun)
                     {
                         if (gear.keystat)
                         {
@@ -8010,7 +8010,7 @@ namespace netxs::ui
                             }
                         }
                     };
-                    this->base::riseup(tier::release, e2::form::global::sysstart, 0);
+                    base::riseup(tier::release, e2::form::global::sysstart, 0);
                 };
                 auto renew = [&]
                 {
@@ -8072,7 +8072,10 @@ namespace netxs::ui
         }
         void close(bool fast = true, bool notify = true)
         {
-            if (notify) this->base::signal(tier::request, e2::form::proceed::quit::one, fast);
+            if (notify)
+            {
+                base::signal(tier::request, e2::form::proceed::quit::one, fast);
+            }
             forced = fast;
             if (ipccon)
             {
@@ -8082,7 +8085,7 @@ namespace netxs::ui
                     {
                         ipccon.payoff(io_log); // Wait child process.
                         auto lock = bell::sync();
-                        this->base::riseup(tier::release, e2::form::proceed::quit::one, forced); //todo VS2019 requires `this`
+                        base::riseup(tier::release, e2::form::proceed::quit::one, forced);
                         backup.reset(); // Backup should dtored under the lock.
                     });
                 }
@@ -8093,7 +8096,7 @@ namespace netxs::ui
                 onerun.reset();
                 base::enqueue([&, backup = This()](auto& /*boss*/) mutable // The termlink trailer (calling ui::term::close()) should be joined before ui::term dtor.
                 {
-                    this->base::riseup(tier::release, e2::form::proceed::quit::one, forced); //todo VS2019 requires `this`
+                    base::riseup(tier::release, e2::form::proceed::quit::one, forced);
                     backup.reset(); // Backup should dtored under the lock.
                 });
             }
@@ -8595,7 +8598,7 @@ namespace netxs::ui
                      || adjust_pads)
                     {
                         auto new_area = rect{ scroll_coor, scroll_size };
-                        this->base::signal(tier::release, e2::area, new_area);
+                        base::signal(tier::release, e2::area, new_area);
                         base::region = new_area;
                     }
                     base::deface();
@@ -8639,7 +8642,7 @@ namespace netxs::ui
                 auto& console = *target;
                 if (status.update(console))
                 {
-                    this->base::riseup(tier::preview, e2::form::prop::ui::footer, status.data);
+                    base::riseup(tier::preview, e2::form::prop::ui::footer, status.data);
                 }
 
                 auto clip = parent_canvas.clip();
@@ -9093,7 +9096,10 @@ namespace netxs::ui
         // dtvt: Close dtvt-object.
         void stop(bool fast, bool notify = true)
         {
-            if (notify) this->base::signal(tier::request, e2::form::proceed::quit::one, fast);
+            if (notify)
+            {
+                base::signal(tier::request, e2::form::proceed::quit::one, fast);
+            }
             auto nodtvt = [&]
             {
                 auto lock = stream.bitmap_dtvt.freeze();
@@ -9117,7 +9123,7 @@ namespace netxs::ui
             {
                 ipccon.payoff();
                 auto lock = bell::sync();
-                this->base::riseup(tier::release, e2::form::proceed::quit::one, true); // MSVC2019
+                base::riseup(tier::release, e2::form::proceed::quit::one, true);
                 backup.reset(); // Backup should dtored under the lock.
             });
         }
@@ -9193,7 +9199,7 @@ namespace netxs::ui
             bell::dup_handler(tier::general, input::events::halt.id);
             LISTEN(tier::release, input::events::focus::set::any, seed)
             {
-                auto deed = this->bell::protos();
+                auto deed = bell::protos();
                 auto state = deed == input::events::focus::set::on.id;
                 stream.sysfocus.send(*this, seed.gear_id, state, seed.focus_type, seed.treeid, seed.digest);
             };

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -8046,19 +8046,14 @@ namespace netxs::ui
                 base::enqueue([&, backup = This()](auto& /*boss*/) mutable // We can't request the title before conio.run(), so we queue the request.
                 {
                     auto& title = wtrack.get(ansi::osc_title);
-                    if (title.empty()) wtrack.set(ansi::osc_title); // Set default title if it is empty.
-                    if (defcfg.send_input.size()) ipccon.write<faux>(defcfg.send_input);
-                    // Sync external listeners with terminal current state.
-                    base::signal(tier::release, terminal::events::io_log,         io_log);
-                    base::signal(tier::release, terminal::events::selmod,         selmod);
-                    base::signal(tier::release, terminal::events::onesht,         onesht);
-                    base::signal(tier::release, terminal::events::selalt,         selalt);
-                    base::signal(tier::release, terminal::events::rawkbd,         rawkbd);
-                    base::signal(tier::release, terminal::events::colors::bg,     target->brush.bgc());
-                    base::signal(tier::release, terminal::events::colors::fg,     target->brush.fgc());
-                    base::signal(tier::release, terminal::events::layout::wrapln, (si32)target->style.wrp());
-                    base::signal(tier::release, terminal::events::layout::align,  (si32)target->style.jet());
-                    base::signal(tier::release, terminal::events::search::status, target->selection_button());
+                    if (title.empty())
+                    {
+                        wtrack.set(ansi::osc_title); // Set default title if it is empty.
+                    }
+                    if (defcfg.send_input.size())
+                    {
+                        ipccon.write<faux>(defcfg.send_input);
+                    }
                     backup.reset(); // Backup should dtored under the lock.
                 });
                 appcfg.win = target->panel;

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1407,8 +1407,7 @@ namespace netxs::app::vtm
             LISTEN(tier::request, vtm::events::newapp, what)
             {
                 auto& setup = menu_list[what.menuid];
-                auto& maker = app::shared::builder(setup.type);
-                what.applet = maker(setup.appcfg, config);
+                what.applet = app::shared::builder(setup.type)(setup.appcfg, config);
                 what.applet->base::property("window.menuid") = what.menuid;
                 what.applet->base::bind_property<tier::preview>("window.header", *what.applet, e2::form::prop::ui::header) = setup.title;
                 what.applet->base::bind_property<tier::preview>("window.footer", *what.applet, e2::form::prop::ui::footer) = setup.footer;

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -903,7 +903,7 @@ namespace netxs::app::vtm
                 {
                     if (base::holder != std::prev(world.base::subset.end()))
                     {
-                        world.base::subset.push_back(this->This());
+                        world.base::subset.push_back(This());
                         world.base::subset.erase(base::holder);
                         base::holder = std::prev(world.base::subset.end());
                         if (base::hidden) // Restore if window minimized.
@@ -925,7 +925,7 @@ namespace netxs::app::vtm
                             world.base::subset.erase(base::holder);
                             while (++next != world.base::subset.end() && !area.trim((*next)->region))
                             { }
-                            base::holder = world.base::subset.insert(next, this->This());
+                            base::holder = world.base::subset.insert(next, This());
                             base::strike();
                         }
                     }
@@ -1586,7 +1586,7 @@ namespace netxs::app::vtm
             LISTEN(tier::request, e2::form::layout::focus::any, gear_id)
             {
                 auto& counter = switch_counter[gear_id];
-                auto deed = this->bell::protos();
+                auto deed = bell::protos();
                 auto forward = deed == e2::form::layout::focus::next.id;
                 if (forward != (counter > 0)) counter = {}; // Reset if direction has changed.
                 forward ? counter++ : counter--;
@@ -1850,7 +1850,7 @@ namespace netxs::app::vtm
                 robot.actify(usergate.id, func, [&](auto& x)
                 {
                     usergate.base::moveby(-x);
-                    this->base::deface();
+                    base::deface();
                 });
             };
             usergate.LISTEN(tier::release, e2::form::layout::jumpto, window_inst)
@@ -1873,11 +1873,11 @@ namespace netxs::app::vtm
             });
             usergate.LISTEN(tier::release, e2::conio::mouse, m) // Trigger to redraw all gates on mouse activity (to redraw foreign mouse cursor).
             {
-                this->base::deface();
+                base::deface();
             };
             usergate.LISTEN(tier::release, e2::conio::winsz, w) // Trigger to redraw all gates.
             {
-                this->base::deface();
+                base::deface();
             };
             auto& drag_origin = usergate.base::field<fp2d>();
             auto& user_mouse = usergate.base::plugin<pro::mouse>();
@@ -1901,7 +1901,7 @@ namespace netxs::app::vtm
                 {
                     drag_origin = gear.coord;
                     usergate.base::moveby(-delta);
-                    this->base::deface();
+                    base::deface();
                 }
             };
             usergate.LISTEN(tier::release, e2::form::drag::stop::any, gear)
@@ -1911,7 +1911,7 @@ namespace netxs::app::vtm
                 robot.actify(usergate.id, gear.fader<quadratic<twod>>(2s), [&](auto delta)
                 {
                     usergate.base::moveby(-delta);
-                    this->base::deface();
+                    base::deface();
                 });
             };
 

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -397,7 +397,7 @@ R"==(
             <script>  <!-- A binding to update the menu item label at runtime. -->
                 <on="release: e2::form::prop::zorder" source="applet"/>
                 local is_topmost=vtm()                   -- Use event arguments to get the current state.
-                -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object iteslf for the current state.
+                -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object itself for the current state.
                 vtm.item.Label(is_topmost==1 and "\e[2:247;38:2:0:255:0m▀\e[2:239m \e[m" or "  ")
                 vtm.item.Tooltip(is_topmost==1 and " AlwaysOnTop on " or " AlwaysOnTop off ")
                 vtm.item.Deface()
@@ -426,7 +426,7 @@ R"==(
             <script>
                 <on="release: terminal::events::rawkbd" source="terminal"/>
                 local m=vtm()                                    -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.ExclusiveKeyboardMode()  -- or ask the terminal instance iteslf for the current state.
+                -- local m=vtm.terminal.ExclusiveKeyboardMode()  -- or ask the terminal instance itself for the current state.
                 vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Exclusive \e[2:239m \e[m" or "  Exclusive  ")
                 vtm.item.Tooltip(m==1 and " ExclusiveKeyboardMode on " or " ExclusiveKeyboardMode off ")
                 vtm.item.Deface()
@@ -440,7 +440,7 @@ R"==(
             <script>
                 <on="release: terminal::events::layout::wrapln" source="terminal"/>
                 local m=vtm()                           -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance iteslf for the current state.
+                -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance itself for the current state.
                 vtm.item.Label(m~=1 and "\e[2:247m \e[2:231;38:2:0:255:0mNoWrap\e[2:239m \e[m" or " NoWrap ")
                 vtm.item.Tooltip(m~=1 and " \e[1mText line wrapping mode\e[m  \\n Text wrapping off        " or " \e[1mText line wrapping mode\e[m  \\n Text wrapping on         ")
                 vtm.item.Deface()
@@ -450,7 +450,7 @@ R"==(
             <script>
                 <on="release: terminal::events::selmod" source="terminal"/>
                 local m=vtm()                              -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.ClipboardFormat()  -- or ask the terminal instance iteslf for the current state.
+                -- local m=vtm.terminal.ClipboardFormat()  -- or ask the terminal instance itself for the current state.
                 vtm.item.Label(m==1 and "\e[38:2:0:255:0m  Plaintext  \e[m"     -- "textonly"
                             or m==2 and "\e[38:2:255:255:0m  ANSI-text  \e[m"   -- "ansitext"
                             or m==3 and "\e[38:2:109:231:237m  ".."R"..
@@ -472,7 +472,7 @@ R"==(
             <script>
                 <on="release: terminal::events::io_log" source="terminal"/>
                 local m=vtm()                      -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.LogMode()  -- or ask the terminal instance iteslf for the current state.
+                -- local m=vtm.terminal.LogMode()  -- or ask the terminal instance itself for the current state.
                 vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Log \e[2:239m \e[m" or "  Log  ")
                 vtm.item.Deface()
             </script>

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -393,11 +393,11 @@ R"==(
         <slim=true/>       <!-- Make the window menu one cell high (slim=true) or three cells high (slim=false). -->
     </Defaults>
     <Buttons>
-        <AlwaysOnTop label="  " tooltip=" AlwaysOnTop off " script=OnLeftClick|AlwaysOnTopApplet> <!-- The default event source is the parent object, i.e. source="item" (aka vtm.item). -->
+        <AlwaysOnTop script=OnLeftClick|AlwaysOnTopApplet> <!-- The default event source is the parent object, i.e. source="item" (aka vtm.item). -->
             <script>  <!-- A binding to update the menu item label at runtime. -->
-                <on="release: e2::form::prop::zorder" source="applet"/>
-                local is_topmost=vtm()                   -- Use event arguments to get the current state.
-                -- local is_topmost=vtm.applet.ZOrder()  -- or ask the object itself for the current state.
+                <on="release: e2::form::upon::started" source="applet"/>
+                <on="release: e2::form::prop::zorder"  source="applet"/>
+                local is_topmost=vtm.applet.ZOrder()
                 vtm.item.Label(is_topmost==1 and "\e[2:247;38:2:0:255:0m▀\e[2:239m \e[m" or "  ")
                 vtm.item.Tooltip(is_topmost==1 and " AlwaysOnTop on " or " AlwaysOnTop off ")
                 vtm.item.Deface()
@@ -417,40 +417,36 @@ R"==(
                 "   Match clipboard data if no selection  "
             </tooltip>
         </FindNext>
-        <ExclusiveKeyboard label="  Exclusive  " script=OnLeftClick|ExclusiveKeyboardMode>
+        <ExclusiveKeyboard script=OnLeftClick|ExclusiveKeyboardMode>
             <tooltip>
                 " \e[1mToggle exclusive keyboard mode\e[m              \n"
                 "   Exclusive keyboard mode allows keystrokes \n"
                 "   to be passed through without processing   "
             </tooltip>
             <script>
+                <on="release: e2::form::upon::started"  source="applet"/>
                 <on="release: terminal::events::rawkbd" source="terminal"/>
-                local m=vtm()                                    -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.ExclusiveKeyboardMode()  -- or ask the terminal instance itself for the current state.
+                local m=vtm.terminal.ExclusiveKeyboardMode()
                 vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Exclusive \e[2:239m \e[m" or "  Exclusive  ")
                 vtm.item.Tooltip(m==1 and " ExclusiveKeyboardMode on " or " ExclusiveKeyboardMode off ")
                 vtm.item.Deface()
             </script>
         </ExclusiveKeyboard>
-        <WrapMode label=" NoWrap " script=OnLeftClick|TerminalWrapMode>
-            <tooltip>
-                " \e[1mText line wrapping mode\e[m  \n"
-                " Text wrapping on         "
-            </tooltip>
+        <WrapMode script=OnLeftClick|TerminalWrapMode>
             <script>
+                <on="release: e2::form::upon::started"          source="applet"/>
                 <on="release: terminal::events::layout::wrapln" source="terminal"/>
-                local m=vtm()                           -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.LineWrapMode()  -- or ask the terminal instance itself for the current state.
+                local m=vtm.terminal.LineWrapMode()
                 vtm.item.Label(m~=1 and "\e[2:247m \e[2:231;38:2:0:255:0mNoWrap\e[2:239m \e[m" or " NoWrap ")
                 vtm.item.Tooltip(m~=1 and " \e[1mText line wrapping mode\e[m  \\n Text wrapping off        " or " \e[1mText line wrapping mode\e[m  \\n Text wrapping on         ")
                 vtm.item.Deface()
             </script>
         </WrapMode>
-        <ClipboardFormat label="  Clipboard  " tooltip=" Clipboard format " script=OnLeftClick|TerminalClipboardFormat>
+        <ClipboardFormat tooltip=" Clipboard format " script=OnLeftClick|TerminalClipboardFormat>
             <script>
+                <on="release: e2::form::upon::started"  source="applet"/>
                 <on="release: terminal::events::selmod" source="terminal"/>
-                local m=vtm()                              -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.ClipboardFormat()  -- or ask the terminal instance itself for the current state.
+                local m=vtm.terminal.ClipboardFormat()
                 vtm.item.Label(m==1 and "\e[38:2:0:255:0m  Plaintext  \e[m"     -- "textonly"
                             or m==2 and "\e[38:2:255:255:0m  ANSI-text  \e[m"   -- "ansitext"
                             or m==3 and "\e[38:2:109:231:237m  ".."R"..
@@ -468,11 +464,11 @@ R"==(
                 vtm.item.Deface()
             </script>
         </ClipboardFormat>
-        <StdioLog label="  Log  " tooltip=" \e[1mConsole logging\e[m        \n Use Logs to see output " script=OnLeftClick|TerminalStdioLog>
+        <StdioLog tooltip=" \e[1mConsole logging\e[m        \n Use Logs to see output " script=OnLeftClick|TerminalStdioLog>
             <script>
+                <on="release: e2::form::upon::started"  source="applet"/>
                 <on="release: terminal::events::io_log" source="terminal"/>
-                local m=vtm()                      -- Use event arguments to get the current state.
-                -- local m=vtm.terminal.LogMode()  -- or ask the terminal instance itself for the current state.
+                local m=vtm.terminal.LogMode()
                 vtm.item.Label(m==1 and "\e[2:247m \e[2:231;38:2:0:255:0m Log \e[2:239m \e[m" or "  Log  ")
                 vtm.item.Deface()
             </script>

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -3,7 +3,7 @@ R"==(<include*/>  <!-- Ordered list of <include="/path/to/settings.xml"/>. The s
 <include="~/.config/vtm/settings.xml"/>   <!-- Default user-wise settings source. -->
 
 <!-- App configuration. -->
-<config=/Colors | /Scripting | /Macro> <!-- Using additional namespaces: "/Colors", "/Scripting" and "/Macro" -->
+<config=/Colors | /Scripting | /Macro | /en-US> <!-- Using additional namespaces: "/Colors", "/Scripting" and "/Macro" -->
     <gui>  <!-- GUI mode related settings. (win32 platform only for now) -->
         <antialiasing=off/>   <!-- Antialiasing of rendered glyphs. Note: Multi-layered color glyphs such as emoji are always antialiased. -->
         <cellheight=22/>      <!-- Text cell height in physical pixels. Note: The width of the text cell depends on the primary font (the first one in the font list). -->
@@ -398,8 +398,14 @@ R"==(
                 <on="release: e2::form::upon::started" source="applet"/>
                 <on="release: e2::form::prop::zorder"  source="applet"/>
                 local is_topmost=vtm.applet.ZOrder()
-                vtm.item.Label(is_topmost==1 and "\e[2:247;38:2:0:255:0m▀\e[2:239m \e[m" or "  ")
-                vtm.item.Tooltip(is_topmost==1 and " AlwaysOnTop on " or " AlwaysOnTop off ")
+                --if (is_topmost==1) vtm.settings.cd("Ns/AlwaysOnTop/on/")
+                --else               vtm.settings.cd("Ns/AlwaysOnTop/off/")
+                --vtm.item.Label(vtm.settings.get("label"))
+                --vtm.item.Tooltip(vtm.settings.get("tooltip"))\n
+                <br/>
+                'vtm.item.Label(is_topmost==1 and "'   | Ns/AlwaysOnTop/on/label   | '" or "' | Ns/AlwaysOnTop/off/label   | '")\n'
+                'vtm.item.Tooltip(is_topmost==1 and "' | Ns/AlwaysOnTop/on/tooltip | '" or "' | Ns/AlwaysOnTop/off/tooltip | '")\n'
+                <br/>
                 vtm.item.Deface()
             </script>
         </AlwaysOnTop>
@@ -473,10 +479,33 @@ R"==(
                 vtm.item.Deface()
             </script>
         </StdioLog>
-        <ClearScrollback label="  Clear  "   tooltip=" Clear scrollback "                 script=OnLeftClick|TerminalClearScrollback/>
-        <Restart         label="  Restart  " tooltip=" Restart current terminal session " script=OnLeftClick|TerminalRestart/>
+        <ClearScrollback label=Ns/ClearScrollback/label tooltip=Ns/ClearScrollback/tooltip script=OnLeftClick|TerminalClearScrollback/>
+        <Restart         label=Ns/Restart/label         tooltip=Ns/Restart/tooltip         script=OnLeftClick|TerminalRestart/>
     </Buttons>
 </Menu>
+
+<!-- Localization. -->
+<Ns=/en-US/>  <!-- Fallback localization is en-US. -->
+<en-US>
+    <Ns>
+        <AlwaysOnTop>
+            <on  label="\e[2:247;38:2:0:255:0m▀\e[2:239m \e[m" tooltip=" AlwaysOnTop on "/>
+            <off label="  "                                    tooltip=" AlwaysOnTop off "/>
+        </AlwaysOnTop>
+        <ClearScrollback label="  Clear  "   tooltip=" Clear scrollback "/>
+        <Restart         label="  Restart  " tooltip=" Restart current terminal session "/>
+    </Ns>
+</en-US>
+<ru-RU>
+    <Ns>
+        <AlwaysOnTop>
+            <on  label=/en-US/Ns/AlwaysOnTop/on/label  tooltip=" Поверх всех окон вкл. "/>
+            <off label=/en-US/Ns/AlwaysOnTop/off/label tooltip=" Поверх всех окон выкл. "/>
+        </AlwaysOnTop>
+        <ClearScrollback label="  Очистить  " tooltip=" Очистить скроллбэк буфер "/>
+        <Restart         label="  Рестарт  "  tooltip=" Перезапустить текущую сессию терминала "/>
+    </Ns>
+</ru-RU>
 
 <Colors>
     <DefaultColor = 0x00ffffff />


### PR DESCRIPTION
### Changes

- Fix tooltips and footer size (GUI mode).
- Allow tooltips to be colored.
- Drop MSVC 2019 compiler support (due to internal compiler error).
- Unify window menu construction.