### PR TITLE
Fix mutexes not surviving process fork

### DIFF
--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -400,8 +400,8 @@ namespace netxs::app::desk
 
             auto menu_bg_color = config.settings::take("/config/desktop/taskbar/colors/bground", cell{}.fgc(whitedk).bgc(0x60202020));
             auto menu_min_conf = config.settings::take("/config/desktop/taskbar/width/folded",   si32{ 5  });
-            auto menu_max_conf = config.settings::take("/config/desktop/taskbar/width/expanded", si32{ 32 });
-            auto bttn_min_size = twod{ 35, 1 + tall * 2 };
+            auto menu_max_conf = config.settings::take("/config/desktop/taskbar/width/expanded", si32{ 40 });
+            auto bttn_min_size = twod{ 40, 1 + tall * 2 };
             auto bttn_max_size = twod{ -1, 1 + tall * 2 };
 
             auto window = ui::fork::ctor(axis::Y, 0, 0, 1);

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -893,7 +893,6 @@ namespace netxs::app::tile
             //            └─ maximized node_veer...
 
             auto param = view{ appcfg.cmd };
-            auto window_clr = skin::color(tone::window_clr);
             //auto highlight_color = skin::color(tone::highlight);
             //auto danger_color    = skin::color(tone::danger);
             //auto warning_color   = skin::color(tone::warning);
@@ -905,6 +904,20 @@ namespace netxs::app::tile
                 ->plugin<items>()
                 ->plugin<pro::focus>()
                 ->plugin<pro::keybd>();
+            auto& window_clr = object->base::field(skin::color(tone::window_clr));
+            auto& is_focused = object->base::field(faux);
+            object ->invoke([&](auto& boss)
+            {
+                boss.LISTEN(tier::release, e2::form::state::focus::count, count)
+                {
+                    if (std::exchange(is_focused, !!count) != is_focused)
+                    {
+                        boss.base::deface(); // Trigger to update pro::cache.
+                        window_clr = is_focused ? skin::color(tone::winfocus)
+                                                : skin::color(tone::window_clr);
+                    }
+                };
+            });
             using namespace app::shared;
             auto tile_context = config.settings::push_context("/config/events/tile/grip/");
             auto script_list = config.settings::take_ptr_list_for_name("script");
@@ -919,16 +932,15 @@ namespace netxs::app::tile
                         boss.base::riseup(tier::release, e2::form::proceed::quit::one, fast);
                     };
                 });
-            menu_data->active(window_clr)
-                     //->plugin<pro::track>()
-                     ->plugin<pro::acryl>();
+            menu_data->active()
+                ->shader(window_clr)
+                ->plugin<pro::acryl>();
             auto menu_id = menu_block->id;
             cover->invoke([&](auto& boss)
             {
                 auto bar = cell{ "▀"sv }.link(menu_id);
                 boss.LISTEN(tier::release, e2::render::any, parent_canvas, -, (bar))
                 {
-                    auto window_clr = skin::color(tone::window_clr);
                     auto fgc = window_clr.bgc();
                     parent_canvas.fill([&](cell& c){ c.fgc(fgc).txt(bar).link(bar); });
                 };

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.07.26";
+    static const auto version = "v2025.07.27";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -1506,6 +1506,10 @@ namespace netxs::xml
             : document{ std::move(document) }
         { }
 
+        void swap(settings& s)
+        {
+            document.swap(s.document);
+        }
         sptr get_context()
         {
             auto context_path = context.size() ? context.back() : document.root_ptr;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -113,7 +113,7 @@ R"==(
             </autorun>
             <width>  <!-- Taskbar menu width. -->
                 <folded=18/>
-                <expanded=32/>
+                <expanded=40/>
             </width>
             <timeout=250ms/>  <!-- Taskbar collaplse timeout after mouse leave. -->
             <colors>


### PR DESCRIPTION
### Changes

- Fix mutexes not surviving process fork. #767
- Highlight tiling manager on focus.
- Fix 'Shutdown' button alignment.