### PR TITLE
Fix `en-US` tooltips

### DIFF
--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -203,11 +203,11 @@ namespace netxs::app::terminal
         auto sb = layers->attach(ui::fork::ctor());
         auto vt = sb->attach(slot::_2, ui::grip<axis::Y>::ctor(scroll));
         auto& term_bgc = term->get_color().bgc();
-        auto& drawfx = term->base::field([&](auto& boss, auto& canvas, auto handle, auto /*object_len*/, auto handle_len, auto region_len, auto wide)
+        auto& drawfx = term->base::field([&](auto& boss, auto& canvas, auto handle, auto object_len, auto handle_len, auto region_len, auto wide, auto master_len)
         {
             static auto box1 = "▄"sv;
             static auto box2 = ' ';
-            if (handle_len != region_len) // Show only if it is oversized.
+            if (ui::drawfx::visible(object_len, handle_len, region_len, master_len))
             {
                 if (wide) // Draw full scrollbar on mouse hover.
                 {

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.07.28";
+    static const auto version = "v2025.08.03";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -123,6 +123,10 @@ namespace netxs
         template<class D, class = std::enable_if_t<std::is_arithmetic_v<D>>> constexpr auto operator *= (xy2d<D> f)       { x = cast(x * f.x); y = cast(y * f.y); return *this; }
         template<class D, class = std::enable_if_t<std::is_arithmetic_v<D>>> constexpr auto operator /= (xy2d<D> f)       { x = cast(x / f.x); y = cast(y / f.y); return *this; }
 
+        auto hypot() const
+        {
+            return std::hypot(x, y);
+        }
         xy2d   less(xy2d what, xy2d if_yes, xy2d if_no) const
         {
             return { x < what.x ? if_yes.x : if_no.x,

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -13,11 +13,20 @@ namespace netxs
 
     // geometry: Generic 2D point.
     template<class T>
+    struct limits
+    {
+        using type = T;
+        T min;
+        T max;
+    };
+    // geometry: Generic 2D point.
+    template<class T>
     struct xy2d
     {
         using type = T;
 
-        T x, y;
+        T x;
+        T y;
 
         template<class D>
         constexpr static auto cast(D x) requires(std::is_floating_point_v<T> || (std::is_integral_v<T> == std::is_integral_v<D>))

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -221,9 +221,14 @@ namespace std
 namespace netxs
 {
     // geometry: Rectangle.
-    struct rect
+    template<class T>
+    struct xysz
     {
-        twod coor, size;
+        using twod = xy2d<T>;
+        using rect = xysz<T>;
+
+        twod coor;
+        twod size;
 
         bool operator == (rect const&) const = default;
         explicit operator bool ()       const { return size.x != 0 && size.y != 0;            }
@@ -282,18 +287,33 @@ namespace netxs
             return test;
         }
         // rect: Return rect with specified orientation.
-        constexpr rect rotate(twod dir) const
+        constexpr rect rotate(twod dir) const requires(std::is_integral_v<T>)
         {
             auto sx = (dir.x ^ size.x) < 0;
             auto sy = (dir.y ^ size.y) < 0;
             return {{ sx ?  coor.x + size.x : coor.x, sy ?  coor.y + size.y : coor.y },
                     { sx ? -size.x          : size.x, sy ? -size.y          : size.y }};
         }
+        // rect: Return rect with specified orientation.
+        constexpr rect rotate(twod dir) const requires(std::is_floating_point_v<T>)
+        {
+            auto sx = std::signbit(dir.x) != std::signbit(size.x);
+            auto sy = std::signbit(dir.y) != std::signbit(size.y);
+            return {{ sx ?  coor.x + size.x : coor.x, sy ?  coor.y + size.y : coor.y },
+                    { sx ? -size.x          : size.x, sy ? -size.y          : size.y }};
+        }
         // rect: Change orientation.
-        constexpr auto& rotate_itself(twod dir)
+        constexpr auto& rotate_itself(twod dir) requires(std::is_integral_v<T>)
         {
             if ((dir.x ^ size.x) < 0) { coor.x += size.x; size.x = -size.x; }
             if ((dir.y ^ size.y) < 0) { coor.y += size.y; size.y = -size.y; }
+            return *this;
+        }
+        // rect: Change orientation.
+        constexpr auto& rotate_itself(twod dir) requires(std::is_floating_point_v<T>)
+        {
+            if (std::signbit(dir.x) != std::signbit(size.x)) { coor.x += size.x; size.x = -size.x; }
+            if (std::signbit(dir.y) != std::signbit(size.y)) { coor.y += size.y; size.y = -size.y; }
             return *this;
         }
         // rect: Return rect with top-left orientation.
@@ -315,7 +335,7 @@ namespace netxs
         constexpr rect trunc(twod edge) const
         {
             auto r = rect{};
-            r.coor = std::clamp(coor, dot_00, edge);
+            r.coor = std::clamp(coor, r.coor, edge);
             r.size = std::clamp(size, -coor, edge - coor) + coor - r.coor;
             return r;
         }
@@ -369,10 +389,11 @@ namespace netxs
         }
     };
 
+    using rect = xysz<si32>;
     using regs = std::vector<rect>;
 
-    static constexpr auto rect_00 = rect{ dot_00,dot_00 };
-    static constexpr auto rect_11 = rect{ dot_00,dot_11 };
+    static constexpr auto rect_00 = rect{ dot_00, dot_00 };
+    static constexpr auto rect_11 = rect{ dot_00, dot_11 };
 
     // geometry: Padding around the rect.
     struct dent

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -43,6 +43,7 @@
 #include <vector>
 #include <variant>
 #include <ranges>  // std::views::reverse
+#include <regex>
 
 #ifndef faux
     #define faux (false)

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -284,6 +284,12 @@ namespace netxs
         { }
     };
 
+    // intmath: Converting from radians to degrees.
+    template<class T>
+    T rad2deg(T rad)
+    {
+        return rad * (180.0 / M_PI);
+    }
     // intmath: Summ and return TRUE in case of unsigned integer overflow and store result in accum.
     template<class T1, class T2>
     constexpr bool sum_overflow(T1& accum, T2 delta)

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -20145,9 +20145,9 @@ namespace netxs::lixx // li++, libinput++.
                     li_device->tags = (libinput_device_tags)(li_device->tags | EVDEV_TAG_EXTERNAL_TOUCHPAD);
                     li_device->tags = (libinput_device_tags)(li_device->tags & ~EVDEV_TAG_INTERNAL_TOUCHPAD);
                 }
-            void evdev_tag_touchpad(libinput_device_sptr li_device, ud_device_sptr ud_device)
+            void evdev_tag_touchpad(libinput_device_sptr li_device)
             {
-                auto prop = ud_device->udev_device_get_property_value("ID_INPUT_TOUCHPAD_INTEGRATION");
+                auto prop = li_device->udev_device_get_property_value("ID_INPUT_TOUCHPAD_INTEGRATION");
                 if (prop)
                 {
                     if (prop == "internal")
@@ -20246,7 +20246,7 @@ namespace netxs::lixx // li++, libinput++.
             }
         evdev_dispatch_sptr evdev_mt_touchpad_create(libinput_device_sptr li_device)
         {
-            evdev_tag_touchpad(li_device, li_device->ud_device);
+            evdev_tag_touchpad(li_device);
             auto tp = ptr::shared<tp_dispatch>();
             if (!tp->tp_impl.tp_init(li_device))
             {
@@ -20264,7 +20264,7 @@ namespace netxs::lixx // li++, libinput++.
             }
             return tp;
         }
-        void evdev_tag_external_mouse(libinput_device_sptr li_device, [[maybe_unused]] ud_device_sptr ud_device)
+        void evdev_tag_external_mouse(libinput_device_sptr li_device)
         {
             auto bustype = li_device->libevdev_get_id_bustype();
             if (bustype == BUS_USB || bustype == BUS_BLUETOOTH)
@@ -20272,10 +20272,10 @@ namespace netxs::lixx // li++, libinput++.
                 li_device->tags = (libinput_device_tags)(li_device->tags | EVDEV_TAG_EXTERNAL_MOUSE);
             }
         }
-        void evdev_tag_trackpoint(libinput_device_sptr li_device, ud_device_sptr ud_device)
+        void evdev_tag_trackpoint(libinput_device_sptr li_device)
         {
             if (!li_device->libevdev_has_property(INPUT_PROP_POINTING_STICK)
-             && !ud_device->parse_udev_flag("ID_INPUT_POINTINGSTICK"))
+             && !li_device->parse_udev_flag("ID_INPUT_POINTINGSTICK"))
             {
                 return;
             }
@@ -20409,7 +20409,7 @@ namespace netxs::lixx // li++, libinput++.
                 li_device->tags = (libinput_device_tags)(li_device->tags | EVDEV_TAG_EXTERNAL_KEYBOARD);
                 li_device->tags = (libinput_device_tags)(li_device->tags & ~EVDEV_TAG_INTERNAL_KEYBOARD);
             }
-        void evdev_tag_keyboard(libinput_device_sptr li_device, [[maybe_unused]] ud_device_sptr ud_device)
+        void evdev_tag_keyboard(libinput_device_sptr li_device)
         {
             if (li_device->libevdev_has_event_type(EV_KEY))
             {
@@ -20574,8 +20574,8 @@ namespace netxs::lixx // li++, libinput++.
         }
         if (udev_tags & EVDEV_UDEV_TAG_MOUSE || udev_tags & EVDEV_UDEV_TAG_POINTINGSTICK)
         {
-            evdev_tag_external_mouse(li_device, li_device->ud_device);
-            evdev_tag_trackpoint(li_device, li_device->ud_device);
+            evdev_tag_external_mouse(li_device);
+            evdev_tag_trackpoint(li_device);
             if (li_device->tags & EVDEV_TAG_TRACKPOINT)
             {
                 li_device->trackpoint_multiplier = evdev_get_trackpoint_multiplier(li_device);
@@ -20603,7 +20603,7 @@ namespace netxs::lixx // li++, libinput++.
                 li_device->scroll.natural_scrolling_enabled = true;
                 li_device->device_caps = (libinput_device_caps)(li_device->device_caps | EVDEV_DEVICE_POINTER);
             }
-            evdev_tag_keyboard(li_device, li_device->ud_device);
+            evdev_tag_keyboard(li_device);
         }
         if (udev_tags & EVDEV_UDEV_TAG_TOUCHSCREEN)
         {

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -1335,54 +1335,6 @@ namespace netxs::lixx // li++, libinput++.
             libinput_device_config_3fg_drag*         drag_3fg;
         };
 
-    // Helpers
-    char const* event_type_to_str(libinput_event_type type)
-    {
-        switch(type)
-        {
-            CASE_RETURN_STRING(LIBINPUT_EVENT_DEVICE_ADDED);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_DEVICE_REMOVED);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_KEYBOARD_KEY);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_MOTION);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_BUTTON);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_AXIS);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_SCROLL_WHEEL);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_SCROLL_FINGER);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_DOWN);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_UP);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_MOTION);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_CANCEL);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_FRAME);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_TOOL_AXIS);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_TOOL_TIP);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_TOOL_BUTTON);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_BUTTON);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_RING);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_STRIP);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_KEY);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_DIAL);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_SWIPE_BEGIN);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_SWIPE_UPDATE);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_SWIPE_END);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_PINCH_BEGIN);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_PINCH_UPDATE);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_PINCH_END);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_HOLD_BEGIN);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_HOLD_END);
-            CASE_RETURN_STRING(LIBINPUT_EVENT_SWITCH_TOGGLE);
-            case LIBINPUT_EVENT_NONE:
-                ::abort();
-        }
-        return nullptr;
-    }
-    void bad_event_type([[maybe_unused]] view function_name, [[maybe_unused]] libinput_event_type type_in)
-    {
-        log("Invalid event type %s% (%d%) used to call %s%()", event_type_to_str(type_in), type_in, function_name);
-    }
-
         using libinput_tablet_tool_sptr = sptr<struct libinput_tablet_tool>;
         struct libinput_tablet_tool_config_pressure_range
         {
@@ -2847,22 +2799,69 @@ namespace netxs::lixx // li++, libinput++.
         {
             return li_device;
         }
-        virtual ui32                  libinput_event_keyboard_get_key()                                              { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual libinput_key_state    libinput_event_keyboard_get_key_state()                                        { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual libinput_switch       libinput_event_switch_get_switch()                                             { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual libinput_switch_state libinput_event_switch_get_switch_state()                                       { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual si32                  libinput_event_gesture_get_finger_count()                                      { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual si32                  libinput_event_gesture_get_cancelled()                                         { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual fp64_coor             libinput_event_gesture_get_ds()                                                { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual fp64_coor             libinput_event_gesture_get_ds_unaccelerated()                                  { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual fp64                  libinput_event_gesture_get_scale()                                             { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual fp64                  libinput_event_gesture_get_angle_delta()                                       { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual fp64_coor             libinput_event_pointer_get_absolute_xy_transformed(fp64_coor /*size*/)         { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual fp64_coor             libinput_event_pointer_get_ds()                                                { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual ui32                  libinput_event_pointer_get_button()                                            { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual libinput_button_state libinput_event_pointer_get_button_state()                                      { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual si32                  libinput_event_pointer_has_axis(libinput_pointer_axis /*axis*/)                { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
-        virtual fp64_coor             libinput_event_pointer_get_scroll_value()                                      { if constexpr (debugmode) bad_event_type(__func__, type); return {}; }
+        virtual ui32                  libinput_event_keyboard_get_key()                                              { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual libinput_key_state    libinput_event_keyboard_get_key_state()                                        { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual libinput_switch       libinput_event_switch_get_switch()                                             { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual libinput_switch_state libinput_event_switch_get_switch_state()                                       { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual si32                  libinput_event_gesture_get_finger_count()                                      { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual si32                  libinput_event_gesture_get_cancelled()                                         { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual fp64_coor             libinput_event_gesture_get_ds()                                                { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual fp64_coor             libinput_event_gesture_get_ds_unaccelerated()                                  { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual fp64                  libinput_event_gesture_get_scale()                                             { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual fp64                  libinput_event_gesture_get_angle_delta()                                       { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual fp64_coor             libinput_event_pointer_get_absolute_xy_transformed(fp64_coor /*size*/)         { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual fp64_coor             libinput_event_pointer_get_ds()                                                { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual ui32                  libinput_event_pointer_get_button()                                            { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual libinput_button_state libinput_event_pointer_get_button_state()                                      { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual si32                  libinput_event_pointer_has_axis(libinput_pointer_axis /*axis*/)                { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+        virtual fp64_coor             libinput_event_pointer_get_scroll_value()                                      { if constexpr (debugmode) bad_event_type(__func__); return {}; }
+
+        view event_type_to_str()
+        {
+            if constexpr (debugmode)
+            switch(type)
+            {
+                CASE_RETURN_STRING(LIBINPUT_EVENT_DEVICE_ADDED);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_DEVICE_REMOVED);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_KEYBOARD_KEY);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_MOTION);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_BUTTON);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_AXIS);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_SCROLL_WHEEL);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_SCROLL_FINGER);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_DOWN);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_UP);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_MOTION);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_CANCEL);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TOUCH_FRAME);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_TOOL_AXIS);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_TOOL_TIP);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_TOOL_BUTTON);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_BUTTON);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_RING);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_STRIP);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_KEY);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_TABLET_PAD_DIAL);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_SWIPE_BEGIN);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_SWIPE_UPDATE);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_SWIPE_END);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_PINCH_BEGIN);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_PINCH_UPDATE);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_PINCH_END);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_HOLD_BEGIN);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_GESTURE_HOLD_END);
+                CASE_RETURN_STRING(LIBINPUT_EVENT_SWITCH_TOGGLE);
+                default: ::abort();
+            }
+            return {};
+        }
+        void bad_event_type([[maybe_unused]] view function_name)
+        {
+            log("Invalid event type %s% (%d%) used to call %s%()", event_type_to_str(), type, function_name);
+        }
     };
 
     using notify_func_t = void(*)(time stamp, libinput_event& event, void* notify_func_data);

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -44,12 +44,6 @@ using WacomDevice = void*;
 
 namespace netxs::lixx // li++, libinput++.
 {
-    static constexpr auto long_bits = sizeof(ui64) * 8;
-    template<auto x>
-    static constexpr auto nchars = (ui64)((x + 7) / 8);
-    template<auto x>
-    static constexpr auto nlongs = (x + lixx::long_bits - 1) / lixx::long_bits;
-
     #if defined(DEBUG)
     template<class ...Args>
     void log(auto format, Args... args)
@@ -1252,42 +1246,6 @@ namespace netxs::lixx // li++, libinput++.
         else if (prop == "0") b = faux;
         else return faux;
         return true;
-    }
-    void set_bit(byte* array, si32 bit)
-    {
-        array[bit / 8] |= (1 << (bit % 8));
-    }
-    bool bit_is_set(byte const* array, si32 bit)
-    {
-        return !!(array[bit / 8] & (1 << (bit % 8)));
-    }
-    void clear_bit(byte* array, si32 bit)
-    {
-        array[bit / 8] &= ~(1 << (bit % 8));
-    }
-    void long_clear_bit(ui64* array, si32 bit)
-    {
-        array[bit / lixx::long_bits] &= ~(1ull << (bit % lixx::long_bits));
-    }
-    void long_set_bit(ui64* array, si32 bit)
-    {
-        array[bit / lixx::long_bits] |= (1ull << (bit % lixx::long_bits));
-    }
-    bool long_bit_is_set(ui64 const* array, si32 bit)
-    {
-        return !!(array[bit / lixx::long_bits] & (1ull << (bit % lixx::long_bits)));
-    }
-    bool long_any_bit_set(ui64* array, ui64 size)
-    {
-        assert(size > 0);
-        for (auto i = 0u; i < size; i++)
-        {
-            if (array[i] != 0)
-            {
-                return true;
-            }
-        }
-        return faux;
     }
     fp64_coor normalize_for_dpi(fp64_coor coor, si32 dpi)
     {
@@ -6821,6 +6779,7 @@ namespace netxs::lixx // li++, libinput++.
     void evdev_read_calibration_prop(libinput_device_sptr li_device);
 
     // Helpers
+    //todo move to libinput_device_t
         void tablet_notify_proximity(libinput_device_sptr li_device, time now, libinput_tablet_tool_sptr tool, libinput_tablet_tool_proximity_state proximity_state, tablet_axes_bitset& changed_axes, tablet_axes const& axes, ::input_absinfo const* x, ::input_absinfo const* y)
         {
             auto& proximity_event = li_device->seat->libinput->libinput_emplace_event<libinput_event_tablet_tool>();
@@ -17328,11 +17287,6 @@ namespace netxs::lixx // li++, libinput++.
                             auto code = evdev_usage_code(usage);
                             return fallback.next_hw_key_mask[code];
                         }
-                            void long_set_bit_state(ui64* array, si32 bit, si32 state)
-                            {
-                                if (state) long_set_bit(array, bit);
-                                else       long_clear_bit(array, bit);
-                            }
                             ui32 update_seat_key_count(libinput_seat_sptr seat, keycode_t keycode, libinput_key_state state)
                             {
                                 assert(keycode <= KEY_MAX);

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -861,20 +861,9 @@ namespace netxs::lixx // li++, libinput++.
         BUTTON_STATE_IGNORE,
     };
 
-    constexpr ui32 evdev_usage_from_code(ui32 type, ui32 code)
-    {
-        return (type << 16) | code;
-    }
-    constexpr ui16 evdev_usage_type(ui32 usage)
-    {
-        return (ui16)(usage >> 16);
-    }
-    constexpr ui16 evdev_usage_code(ui32 usage)
-    {
-        return (ui16)usage & 0xFFFF;
-    }
-    //template<ui32 t, ui32 c>
-    //static constexpr auto _evbit = (t << 16) | c;
+    constexpr ui32 evdev_usage_from_code(ui32 type, ui32 code) { return (type << 16) | code;  }
+    constexpr ui16 evdev_usage_type(ui32 usage)                { return (ui16)(usage >> 16);  }
+    constexpr ui16 evdev_usage_code(ui32 usage)                { return (ui16)usage & 0xFFFF; }
     struct evdev // The enum doesn't need to contain all event codes, only the ones we use in libinput - add to here as required.      * The order doesn't matter either since each enum value is just the type | code value anyway, keep it in somewhat logical groups where possible.
     {
         static constexpr auto syn_report          = evdev_usage_from_code(EV_SYN, SYN_REPORT);
@@ -926,7 +915,6 @@ namespace netxs::lixx // li++, libinput++.
         static constexpr auto rel_hwheel          = evdev_usage_from_code(EV_REL, REL_HWHEEL);
         static constexpr auto rel_hwheel_hi_res   = evdev_usage_from_code(EV_REL, REL_HWHEEL_HI_RES);
         static constexpr auto rel_dial            = evdev_usage_from_code(EV_REL, REL_DIAL);
-        static constexpr auto rel_max             = evdev_usage_from_code(EV_REL, REL_MAX); // not used
         static constexpr auto abs_x               = evdev_usage_from_code(EV_ABS, ABS_X);
         static constexpr auto abs_y               = evdev_usage_from_code(EV_ABS, ABS_Y);
         static constexpr auto abs_z               = evdev_usage_from_code(EV_ABS, ABS_Z);
@@ -936,7 +924,6 @@ namespace netxs::lixx // li++, libinput++.
         static constexpr auto abs_pressure        = evdev_usage_from_code(EV_ABS, ABS_PRESSURE);
         static constexpr auto abs_distance        = evdev_usage_from_code(EV_ABS, ABS_DISTANCE);
         static constexpr auto abs_throttle        = evdev_usage_from_code(EV_ABS, ABS_THROTTLE);
-        static constexpr auto abs_rudder          = evdev_usage_from_code(EV_ABS, ABS_RUDDER); // not used
         static constexpr auto abs_wheel           = evdev_usage_from_code(EV_ABS, ABS_WHEEL);
         static constexpr auto abs_misc            = evdev_usage_from_code(EV_ABS, ABS_MISC);
         static constexpr auto abs_tilt_x          = evdev_usage_from_code(EV_ABS, ABS_TILT_X);
@@ -950,11 +937,8 @@ namespace netxs::lixx // li++, libinput++.
         static constexpr auto abs_mt_touch_minor  = evdev_usage_from_code(EV_ABS, ABS_MT_TOUCH_MINOR);
         static constexpr auto abs_mt_orientation  = evdev_usage_from_code(EV_ABS, ABS_MT_ORIENTATION);
         static constexpr auto abs_mt_pressure     = evdev_usage_from_code(EV_ABS, ABS_MT_PRESSURE);
-        static constexpr auto abs_mt_distance     = evdev_usage_from_code(EV_ABS, ABS_MT_DISTANCE); // not used
-        static constexpr auto abs_max             = evdev_usage_from_code(EV_ABS, ABS_MAX); // not used
         static constexpr auto sw_lid              = evdev_usage_from_code(EV_SW, SW_LID);
         static constexpr auto sw_tablet_mode      = evdev_usage_from_code(EV_SW, SW_TABLET_MODE);
-        static constexpr auto sw_max              = evdev_usage_from_code(EV_SW, SW_MAX); // not used
         static constexpr auto msc_scan            = evdev_usage_from_code(EV_MSC, MSC_SCAN);
         static constexpr auto msc_serial          = evdev_usage_from_code(EV_MSC, MSC_SERIAL);
         static constexpr auto msc_timestamp       = evdev_usage_from_code(EV_MSC, MSC_TIMESTAMP);

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -3096,12 +3096,6 @@ namespace netxs::lixx // li++, libinput++.
         };
     struct libinput_event_tablet_tool : libinput_event
     {
-        struct abs_t//todo unify
-        {
-            abs_info_t x;
-            abs_info_t y;
-        };
-
         ui32                                 button;
         libinput_button_state                state;
         ui32                                 seat_button_count;
@@ -3110,7 +3104,8 @@ namespace netxs::lixx // li++, libinput++.
         libinput_tablet_tool_sptr            tool;
         libinput_tablet_tool_proximity_state proximity_state;
         libinput_tablet_tool_tip_state       tip_state;
-        abs_t                                abs;
+        abs_info_t                           abs_info_x2; //todo not used?
+        abs_info_t                           abs_info_y2; //
 
         libinput_event_tablet_tool() = default;
     };
@@ -6711,7 +6706,8 @@ namespace netxs::lixx // li++, libinput++.
             proximity_event.tool              = tool;
             proximity_event.proximity_state   = proximity_state;
             proximity_event.tip_state         = LIBINPUT_TABLET_TOOL_TIP_UP;
-            proximity_event.abs               = { *x, *y };
+            proximity_event.abs_info_x2       = *x;
+            proximity_event.abs_info_y2       = *y;
             proximity_event.changed_axes_bits = changed_axes;
             post_device_event(now, LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY, proximity_event);
         }
@@ -6722,7 +6718,8 @@ namespace netxs::lixx // li++, libinput++.
             tip_event.tool              = tool;
             tip_event.proximity_state   = LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN;
             tip_event.tip_state         = tip_state;
-            tip_event.abs               = { *x, *y };
+            tip_event.abs_info_x2       = *x;
+            tip_event.abs_info_y2       = *y;
             tip_event.changed_axes_bits = changed_axes;
             post_device_event(now, LIBINPUT_EVENT_TABLET_TOOL_TIP, tip_event);
         }
@@ -6733,7 +6730,8 @@ namespace netxs::lixx // li++, libinput++.
             axis_event.tool              = tool;
             axis_event.proximity_state   = LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN;
             axis_event.tip_state         = tip_state;
-            axis_event.abs               = { *x, *y };
+            axis_event.abs_info_x2       = *x;
+            axis_event.abs_info_y2       = *y;
             axis_event.changed_axes_bits = changed_axes;
             post_device_event(now, LIBINPUT_EVENT_TABLET_TOOL_AXIS, axis_event);
         }
@@ -6747,7 +6745,8 @@ namespace netxs::lixx // li++, libinput++.
             button_event.tool              = tool;
             button_event.proximity_state   = LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN;
             button_event.tip_state         = tip_state;
-            button_event.abs               = { *x, *y };
+            button_event.abs_info_x2       = *x;
+            button_event.abs_info_y2       = *y;
             post_device_event(now, LIBINPUT_EVENT_TABLET_TOOL_BUTTON, button_event);
         }
     };

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -1343,13 +1343,12 @@ namespace netxs::lixx // li++, libinput++.
             void                  (*get)         (libinput_tablet_tool_sptr tool, fp64_range& range);
             void                  (*get_default) (libinput_tablet_tool_sptr tool, fp64_range& range);
         };
-        using pressure_offset_t = fp64;
         struct libinput_tablet_tool_pressure_threshold
         {
             ui32                     tablet_id;
             abs_info_t               abs_pressure; // The configured axis we actually work with.
             si32_range               threshold;   // In device coordinates.
-            pressure_offset_t        offset;
+            fp64                     offset;
             bool                     has_offset;
             pressure_heuristic_state heuristic_state; // This gives us per-tablet heuristic state which is arguably wrong but >99% of users have one tablet and it's easier to implement it this way.
         };
@@ -15162,7 +15161,7 @@ namespace netxs::lixx // li++, libinput++.
                                 {
                                     auto li_device = tablet.li_device;
                                     threshold->tablet_id     = tablet.tablet_id;
-                                    threshold->offset        = pressure_offset_t(0.0);
+                                    threshold->offset        = 0.0;
                                     threshold->has_offset    = faux;
                                     threshold->threshold.min = 0;
                                     threshold->threshold.max = 1;
@@ -15172,12 +15171,12 @@ namespace netxs::lixx // li++, libinput++.
                                     auto distance = li_device->libevdev_get_abs_info(ABS_DISTANCE);
                                     if (distance)
                                     {
-                                        threshold->offset = pressure_offset_t(0.0);
+                                        threshold->offset = 0.0;
                                         threshold->heuristic_state = PRESSURE_HEURISTIC_STATE_DONE;
                                     }
                                     else
                                     {
-                                        threshold->offset = pressure_offset_t(1.0);
+                                        threshold->offset = 1.0;
                                         threshold->heuristic_state = PRESSURE_HEURISTIC_STATE_PROXIN1;
                                     }
                                     apply_pressure_range_configuration(tool, true);
@@ -15428,11 +15427,11 @@ namespace netxs::lixx // li++, libinput++.
                         {
                             return &tool->pressure.threshold;
                         }
-                            si32 pressure_offset_to_absinfo(pressure_offset_t pressure_offset, abs_info_t const* abs)
+                            si32 pressure_offset_to_absinfo(fp64 pressure_offset, abs_info_t const* abs)
                             {
-                                return (abs->maximum - abs->minimum) * (fp64)pressure_offset + abs->minimum;
+                                return (abs->maximum - abs->minimum) * pressure_offset + abs->minimum;
                             }
-                        void set_pressure_offset(libinput_tablet_tool_pressure_threshold* threshold, pressure_offset_t offset_in_percent)
+                        void set_pressure_offset(libinput_tablet_tool_pressure_threshold* threshold, fp64 offset_in_percent)
                         {
                             threshold->offset = offset_in_percent;
                             threshold->has_offset = true;
@@ -15472,11 +15471,11 @@ namespace netxs::lixx // li++, libinput++.
                             threshold->heuristic_state = PRESSURE_HEURISTIC_STATE_DONE;
                         }
                     }
-                            pressure_offset_t pressure_offset_from_range(fp64 min, fp64 max, fp64 value)
+                            fp64 pressure_offset_from_range(fp64 min, fp64 max, fp64 value)
                             {
-                                return pressure_offset_t((value - min) / (max - min));
+                                return (value - min) / (max - min);
                             }
-                        pressure_offset_t pressure_offset_from_absinfo(abs_info_t const* abs, si32 value)
+                        fp64 pressure_offset_from_absinfo(abs_info_t const* abs, si32 value)
                         {
                             return pressure_offset_from_range(abs->minimum, abs->maximum, value);
                         }

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -12847,13 +12847,11 @@ namespace netxs::lixx // li++, libinput++.
                     bool tp_is_tpkb_combo_below(libinput_device_sptr li_device)
                     {
                         auto prop = (char*)nullptr;
-                        auto layout = TPKBCOMBO_LAYOUT_UNKNOWN;
                         auto rc = faux;
                         auto quirks = li_device->li_context()->quirks;
                         if (auto q = li_device->ud_device->quirks_fetch_for_device(quirks); q->quirks_get_string(QUIRK_ATTR_TPKBCOMBO_LAYOUT, &prop))
                         {
-                            rc = prop == "below";
-                            if (rc) layout = TPKBCOMBO_LAYOUT_BELOW;
+                            rc = prop == "below"sv;
                         }
                         return rc;
                     }

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -264,6 +264,16 @@ namespace netxs::lixx // li++, libinput++.
         EVDEV_DEVICE_TABLET_PAD      = 1ul << 5,
         EVDEV_DEVICE_TABLET          = 1ul << 6,
     };
+    enum ud_type_enum
+    {
+        UDEV_MOUSE         = 1ul << 1,
+        UDEV_POINTINGSTICK = 1ul << 2,
+        UDEV_TOUCHPAD      = 1ul << 3,
+        UDEV_TABLET        = 1ul << 4,
+        UDEV_TABLET_PAD    = 1ul << 5,
+        UDEV_JOYSTICK      = 1ul << 6,
+        UDEV_KEYBOARD      = 1ul << 7,
+    };
     enum libinput_device_tags
     {
         EVDEV_TAG_NONE               = 0ul,
@@ -278,6 +288,23 @@ namespace netxs::lixx // li++, libinput++.
         EVDEV_TAG_TABLET_MODE_SWITCH = 1ul << 8,
         EVDEV_TAG_TABLET_TOUCHPAD    = 1ul << 9,
         EVDEV_TAG_VIRTUAL            = 1ul << 10,
+    };
+    //todo unify, combine with ud_type_enum and rename to ID_INPUT_*
+    enum evdev_ud_device_tags
+    {
+        EVDEV_UDEV_TAG_NONE          = 0,
+        EVDEV_UDEV_TAG_INPUT         = 1ul << 0,
+        EVDEV_UDEV_TAG_KEYBOARD      = 1ul << 1,
+        EVDEV_UDEV_TAG_MOUSE         = 1ul << 2,
+        EVDEV_UDEV_TAG_TOUCHPAD      = 1ul << 3,
+        EVDEV_UDEV_TAG_TOUCHSCREEN   = 1ul << 4,
+        EVDEV_UDEV_TAG_TABLET        = 1ul << 5,
+        EVDEV_UDEV_TAG_JOYSTICK      = 1ul << 6,
+        EVDEV_UDEV_TAG_ACCELEROMETER = 1ul << 7,
+        EVDEV_UDEV_TAG_TABLET_PAD    = 1ul << 8,
+        EVDEV_UDEV_TAG_POINTINGSTICK = 1ul << 9,
+        EVDEV_UDEV_TAG_TRACKBALL     = 1ul << 10,
+        EVDEV_UDEV_TAG_SWITCH        = 1ul << 11,
     };
     enum evdev_button_scroll_state
     {
@@ -965,33 +992,6 @@ namespace netxs::lixx // li++, libinput++.
         PRESSURE_HEURISTIC_STATE_PROXIN2, // Second proximity in event.
         PRESSURE_HEURISTIC_STATE_DECIDE,  // Decide on offset now.
         PRESSURE_HEURISTIC_STATE_DONE,    // Decision's been made, live with it.
-    };
-    //todo unify, combine with ud_type_enum and rename to ID_INPUT_*
-    enum evdev_ud_device_tags
-    {
-        EVDEV_UDEV_TAG_NONE          = 0,
-        EVDEV_UDEV_TAG_INPUT         = 1ul << 0,
-        EVDEV_UDEV_TAG_KEYBOARD      = 1ul << 1,
-        EVDEV_UDEV_TAG_MOUSE         = 1ul << 2,
-        EVDEV_UDEV_TAG_TOUCHPAD      = 1ul << 3,
-        EVDEV_UDEV_TAG_TOUCHSCREEN   = 1ul << 4,
-        EVDEV_UDEV_TAG_TABLET        = 1ul << 5,
-        EVDEV_UDEV_TAG_JOYSTICK      = 1ul << 6,
-        EVDEV_UDEV_TAG_ACCELEROMETER = 1ul << 7,
-        EVDEV_UDEV_TAG_TABLET_PAD    = 1ul << 8,
-        EVDEV_UDEV_TAG_POINTINGSTICK = 1ul << 9,
-        EVDEV_UDEV_TAG_TRACKBALL     = 1ul << 10,
-        EVDEV_UDEV_TAG_SWITCH        = 1ul << 11,
-    };
-    enum ud_type_enum
-    {
-        UDEV_MOUSE         = 1ul << 1,
-        UDEV_POINTINGSTICK = 1ul << 2,
-        UDEV_TOUCHPAD      = 1ul << 3,
-        UDEV_TABLET        = 1ul << 4,
-        UDEV_TABLET_PAD    = 1ul << 5,
-        UDEV_JOYSTICK      = 1ul << 6,
-        UDEV_KEYBOARD      = 1ul << 7,
     };
     enum bustype
     {
@@ -5194,8 +5194,8 @@ namespace netxs::lixx // li++, libinput++.
         virtual                  void              device_suspended([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr suspended_li_device)                                                                                { } // A device was suspended.
         virtual                  void                device_resumed([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr resumed_li_device)                                                                                  { } // A device was resumed.
         virtual                  void                    post_added([[maybe_unused]] libinput_device_sptr li_device)                                                                                                                                           { } // Called immediately after the LIBINPUT_EVENT_DEVICE_ADDED event was sent.
-        virtual                  void      touch_arbitration_toggle([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_arbitration_state which, [[maybe_unused]] phys_rect const* rect/* may be nullptr */, [[maybe_unused]] time now) { } // For touch arbitration, called on the device that should enable/disable touch capabilities.
-        virtual                  void touch_arbitration_update_rect([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] phys_rect const*rect, [[maybe_unused]] time now)                                                                         { } // Called when touch arbitration is on, updates the area where touch arbitration should apply.
+        virtual                  void      touch_arbitration_toggle([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_arbitration_state which, [[maybe_unused]] phys_rect const* area/* may be nullptr */, [[maybe_unused]] time now) { } // For touch arbitration, called on the device that should enable/disable touch capabilities.
+        virtual                  void touch_arbitration_update_rect([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] phys_rect const* area, [[maybe_unused]] time now)                                                                        { } // Called when touch arbitration is on, updates the area where touch arbitration should apply.
         virtual libinput_switch_state              get_switch_state([[maybe_unused]] libinput_switch which)                                                                                                                                                    { return libinput_switch_state{}; } // Return the state of the given switch.
         virtual                  void            left_handed_toggle([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] bool left_handed_enabled)                                                                                                { }
     };
@@ -12556,7 +12556,7 @@ namespace netxs::lixx // li++, libinput++.
                     tp_change_rotation(li_device, DO_NOTIFY);
                 }
             }
-            void tp_interface_toggle_touch([[maybe_unused]] libinput_device_sptr li_device, libinput_arbitration_state which, [[maybe_unused]] phys_rect const* rect, time stamp)
+            void tp_interface_toggle_touch([[maybe_unused]] libinput_device_sptr li_device, libinput_arbitration_state which, [[maybe_unused]] phys_rect const* area, time stamp)
             {
                 if (which == tp.arbitration.state) return;
                 switch (which)
@@ -13859,7 +13859,7 @@ namespace netxs::lixx // li++, libinput++.
         void             device_added(libinput_device_sptr li_device, libinput_device_sptr added_li_device)                              { tp_impl.   tp_interface_device_added(li_device, added_li_device); }
         void           device_removed(libinput_device_sptr li_device, libinput_device_sptr removed_li_device)                            { tp_impl. tp_interface_device_removed(li_device, removed_li_device); }
         void       left_handed_toggle(libinput_device_sptr li_device, bool left_handed_enabled)                                          { tp_impl.touchpad_left_handed_toggled(li_device, left_handed_enabled); }
-        void touch_arbitration_toggle(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect const* rect, time now) { tp_impl.   tp_interface_toggle_touch(li_device, which, rect, now); }
+        void touch_arbitration_toggle(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect const* area, time now) { tp_impl.   tp_interface_toggle_touch(li_device, which, area, now); }
         void         device_suspended(libinput_device_sptr li_device, libinput_device_sptr suspended_li_device)                          { device_removed(li_device, suspended_li_device); }
         void           device_resumed(libinput_device_sptr li_device, libinput_device_sptr resumed_li_device)                            { device_added(li_device, resumed_li_device); }
     };
@@ -14867,7 +14867,6 @@ namespace netxs::lixx // li++, libinput++.
                 auto touch_device = totem.touch_li_device;
                 if (!touch_device) return;
                 auto r = phys_rect{};
-                auto rect = (phys_rect*)nullptr;
                 auto state = ARBITRATION_NOT_ACTIVE;
                 // We just pick the coordinates of the first touch we find. The totem only does one tool right now despite being nominally an MT device, so let's not go too hard on ourselves.
                 for (auto i = 0u; !enable_touch_device && i < totem.slots.size(); i++)
@@ -14880,7 +14879,6 @@ namespace netxs::lixx // li++, libinput++.
                         r.y = mm.y - 30;
                         r.w = 100;
                         r.h = 100;
-                        rect = &r;
                         state = ARBITRATION_IGNORE_RECT;
                         break;
                     }
@@ -14888,15 +14886,15 @@ namespace netxs::lixx // li++, libinput++.
                 auto dispatch = touch_device->dispatch;
                 if (enable_touch_device)
                 {
-                    dispatch->touch_arbitration_toggle(touch_device, state, rect, now);
+                    dispatch->touch_arbitration_toggle(touch_device, state, &r, now);
                 }
                 else
                 {
                     switch (totem.arbitration_state)
                     {
                         case ARBITRATION_IGNORE_ALL: ::abort();
-                        case ARBITRATION_NOT_ACTIVE:  dispatch->touch_arbitration_toggle(touch_device, state, rect, now); break;
-                        case ARBITRATION_IGNORE_RECT: dispatch->touch_arbitration_update_rect(touch_device, rect, now); break;
+                        case ARBITRATION_NOT_ACTIVE:  dispatch->touch_arbitration_toggle(touch_device, state, &r, now); break;
+                        case ARBITRATION_IGNORE_RECT: dispatch->touch_arbitration_update_rect(touch_device, &r, now); break;
                     }
                 }
                 totem.arbitration_state = state;
@@ -15100,8 +15098,8 @@ namespace netxs::lixx // li++, libinput++.
         struct area_t
         {
             libinput_device_config_area    config;
-            libinput_config_area_rectangle rect;
-            libinput_config_area_rectangle want_rect;
+            libinput_config_area_rectangle have_area;
+            libinput_config_area_rectangle want_area;
             ::input_absinfo                x;
             ::input_absinfo                y;
         };
@@ -15713,8 +15711,8 @@ namespace netxs::lixx // li++, libinput++.
                     }
                     bool is_inside_area(device_coords point, fp64 normalized_margin)
                     {
-                        if (tablet.area.rect.x1 == 0.0 && tablet.area.rect.x2 == 1.0
-                         && tablet.area.rect.y1 == 0.0 && tablet.area.rect.y2 == 1.0)
+                        if (tablet.area.have_area.x1 == 0.0 && tablet.area.have_area.x2 == 1.0
+                         && tablet.area.have_area.y1 == 0.0 && tablet.area.have_area.y2 == 1.0)
                         {
                             return true;
                         }
@@ -15931,8 +15929,8 @@ namespace netxs::lixx // li++, libinput++.
                     }
                                 void apply_tablet_area([[maybe_unused]] libinput_device_sptr li_device, device_coords& point)
                                 {
-                                    if (tablet.area.rect.x1 == 0.0 && tablet.area.rect.x2 == 1.0
-                                     && tablet.area.rect.y1 == 0.0 && tablet.area.rect.y2 == 1.0)
+                                    if (tablet.area.have_area.x1 == 0.0 && tablet.area.have_area.x2 == 1.0
+                                     && tablet.area.have_area.y1 == 0.0 && tablet.area.have_area.y2 == 1.0)
                                     {
                                         return;
                                     }
@@ -16478,19 +16476,19 @@ namespace netxs::lixx // li++, libinput++.
                     }
                     void tablet_change_area(libinput_device_sptr li_device)
                     {
-                        if (::memcmp(&tablet.area.rect, &tablet.area.want_rect, sizeof(tablet.area.rect)) == 0
+                        if (::memcmp(&tablet.area.have_area, &tablet.area.want_area, sizeof(tablet.area.have_area)) == 0
                          || !(tablet.status & TABLET_TOOL_OUT_OF_PROXIMITY))
                         {
                             return;
                         }
-                        tablet.area.rect = tablet.area.want_rect;
-                        log("tablet-area: area is %.2f%/%.2f% - %.2f%/%.2f%", tablet.area.rect.x1, tablet.area.rect.y1, tablet.area.rect.x2, tablet.area.rect.y2);
+                        tablet.area.have_area = tablet.area.want_area;
+                        log("tablet-area: area is %.2f%/%.2f% - %.2f%/%.2f%", tablet.area.have_area.x1, tablet.area.have_area.y1, tablet.area.have_area.x2, tablet.area.have_area.y2);
                         auto absx = li_device->abs.absinfo_x;
                         auto absy = li_device->abs.absinfo_y;
-                        tablet.area.x.minimum = axis_range_percentage(absx, tablet.area.rect.x1 * 100);
-                        tablet.area.x.maximum = axis_range_percentage(absx, tablet.area.rect.x2 * 100);
-                        tablet.area.y.minimum = axis_range_percentage(absy, tablet.area.rect.y1 * 100);
-                        tablet.area.y.maximum = axis_range_percentage(absy, tablet.area.rect.y2 * 100);
+                        tablet.area.x.minimum = axis_range_percentage(absx, tablet.area.have_area.x1 * 100);
+                        tablet.area.x.maximum = axis_range_percentage(absx, tablet.area.have_area.x2 * 100);
+                        tablet.area.y.minimum = axis_range_percentage(absy, tablet.area.have_area.y1 * 100);
+                        tablet.area.y.maximum = axis_range_percentage(absy, tablet.area.have_area.y2 * 100);
                     }
                 void tablet_flush(libinput_device_sptr li_device, time stamp)
                 {
@@ -16572,20 +16570,19 @@ namespace netxs::lixx // li++, libinput++.
                         if (!process_tool_twice) break;
                     }
                 }
-                    void tablet_set_touch_device_enabled(libinput_arbitration_state which, phys_rect const* rect, time stamp)
+                    void tablet_set_touch_device_enabled(libinput_arbitration_state which, phys_rect const* area, time stamp)
                     {
                         if (auto touch_li_device = tablet.touch_li_device)
                         {
                             tablet.arbitration = which;
                             auto dispatch = touch_li_device->dispatch;
-                            dispatch->touch_arbitration_toggle(touch_li_device, which, rect, stamp);
+                            dispatch->touch_arbitration_toggle(touch_li_device, which, area, stamp);
                         }
                     }
                 void tablet_toggle_touch_device([[maybe_unused]] libinput_device_sptr tablet_li_device, time stamp)
                 {
                     auto which = libinput_arbitration_state{};
                     auto r = phys_rect{};
-                    auto rect = (phys_rect*)nullptr;
                     if (tablet.status & (TABLET_TOOL_OUT_OF_RANGE | TABLET_NONE | TABLET_TOOL_LEAVING_PROXIMITY | TABLET_TOOL_OUT_OF_PROXIMITY))
                     {
                         which = ARBITRATION_NOT_ACTIVE;
@@ -16597,14 +16594,13 @@ namespace netxs::lixx // li++, libinput++.
                     else if (tablet.arbitration != ARBITRATION_IGNORE_RECT)
                     {
                         r = tablet_calculate_arbitration_rect(); // This enables rect-based arbitration, updates are sent elsewhere.
-                        rect = &r;
                         which = ARBITRATION_IGNORE_RECT;
                     }
                     else
                     {
                         return;
                     }
-                    tablet_set_touch_device_enabled(which, rect, stamp);
+                    tablet_set_touch_device_enabled(which, &r, stamp);
                 }
                 void tablet_reset_state()
                 {
@@ -16859,14 +16855,14 @@ namespace netxs::lixx // li++, libinput++.
                         {
                             return LIBINPUT_CONFIG_STATUS_INVALID;
                         }
-                        tablet.area.want_rect = *rectangle;
+                        tablet.area.want_area = *rectangle;
                         tablet.tablet_impl.tablet_change_area(li_device);
                         return LIBINPUT_CONFIG_STATUS_SUCCESS;
                     }
                     static libinput_config_area_rectangle tablet_area_get_rectangle(libinput_device_sptr li_device)
                     {
                         auto& tablet = *std::static_pointer_cast<tablet_dispatch>(li_device->dispatch);
-                        return tablet.area.rect;
+                        return tablet.area.have_area;
                     }
                     static libinput_config_area_rectangle tablet_area_get_default_rectangle([[maybe_unused]] libinput_device_sptr li_device)
                     {
@@ -16875,8 +16871,8 @@ namespace netxs::lixx // li++, libinput++.
                     }
                 void tablet_init_area(libinput_device_sptr li_device)
                 {
-                    tablet.area.rect = libinput_config_area_rectangle{ 0.0, 0.0, 1.0, 1.0, };
-                    tablet.area.want_rect = tablet.area.rect;
+                    tablet.area.have_area = libinput_config_area_rectangle{ 0.0, 0.0, 1.0, 1.0, };
+                    tablet.area.want_area = tablet.area.have_area;
                     tablet.area.x = *li_device->abs.absinfo_x;
                     tablet.area.y = *li_device->abs.absinfo_y;
                     if (!li_device->libevdev_has_property(INPUT_PROP_DIRECT))
@@ -17181,7 +17177,7 @@ namespace netxs::lixx // li++, libinput++.
         {
             libinput_arbitration_state state;
             bool                       in_arbitration;
-            device_coord_rect          rect;
+            device_coord_rect          area;
             libinput_timer_sptr        arbitration_timer;
         };
 
@@ -17875,17 +17871,17 @@ namespace netxs::lixx // li++, libinput++.
                                 touch_notify_touch_cancel(li_device, stamp, slot_idx, seat_slot);
                                 return true;
                             }
-                                bool point_in_rect(device_coords point, device_coord_rect const* rect)
+                                bool point_in_rect(device_coords point, device_coord_rect const* area)
                                 {
-                                    return (point.x >= rect->x && point.x < rect->x + rect->w
-                                         && point.y >= rect->y && point.y < rect->y + rect->h);
+                                    return (point.x >= area->x && point.x < area->x + area->w
+                                         && point.y >= area->y && point.y < area->y + area->h);
                                 }
                             bool fallback_arbitrate_touch(mt_slot& slot)
                             {
                                 auto discard = faux;
                                 auto point = slot.point;
                                 fallback.li_device->evdev_transform_absolute(point);
-                                if (fallback.arbitration.state == ARBITRATION_IGNORE_RECT && point_in_rect(point, &fallback.arbitration.rect))
+                                if (fallback.arbitration.state == ARBITRATION_IGNORE_RECT && point_in_rect(point, &fallback.arbitration.area))
                                 {
                                     slot.palm_state = MT_PALM_IS_PALM;
                                     discard = true;
@@ -18553,18 +18549,18 @@ namespace netxs::lixx // li++, libinput++.
                                 touch_notify_touch_cancel(li_device, stamp, -1, seat_slot);
                                 return true;
                             }
-                        void cancel_touches(libinput_device_sptr li_device, device_coord_rect const* rect, time stamp)
+                        void cancel_touches(libinput_device_sptr li_device, device_coord_rect const* area, time stamp)
                         {
                             auto need_frame = faux;
                             auto point = fallback.abs.point;
                             li_device->evdev_transform_absolute(point);
-                            if (!rect || point_in_rect(point, rect)) need_frame = fallback_flush_st_cancel(li_device, stamp);
+                            if (!area || point_in_rect(point, area)) need_frame = fallback_flush_st_cancel(li_device, stamp);
                             auto i = 0;
                             for (auto& slot : fallback.mt.slots)
                             {
                                 point = slot.point;
                                 li_device->evdev_transform_absolute(point);
-                                if (slot.seat_slot != -1 && (!rect || point_in_rect(point, rect)) && fallback_flush_mt_cancel(li_device, i, stamp))
+                                if (slot.seat_slot != -1 && (!area || point_in_rect(point, area)) && fallback_flush_mt_cancel(li_device, i, stamp))
                                 {
                                     need_frame = true;
                                 }
@@ -18669,16 +18665,16 @@ namespace netxs::lixx // li++, libinput++.
                         units.h = mm->h * absy->resolution;
                         return units;
                     }
-                void fallback_interface_update_rect(libinput_device_sptr li_device, phys_rect const* phys_rect, [[maybe_unused]] time now)
+                void fallback_interface_update_rect(libinput_device_sptr li_device, phys_rect const* phys_area, [[maybe_unused]] time now)
                 {
-                    assert(phys_rect);
+                    assert(phys_area);
                     // Existing touches do not change, we just update the rect and only new touches in these areas will be ignored. If you want to paint over your finger, be my guest.
-                    auto rect = evdev_phys_rect_to_units(li_device, phys_rect);
-                    fallback.arbitration.rect = rect;
+                    auto area = evdev_phys_rect_to_units(li_device, phys_area);
+                    fallback.arbitration.area = area;
                 }
-                void fallback_interface_toggle_touch(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect const* phys_rect, time stamp)
+                void fallback_interface_toggle_touch(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect const* phys_area, time stamp)
                 {
-                    auto rect = device_coord_rect{};
+                    auto area = device_coord_rect{};
                     [[maybe_unused]] auto state = (char const*)nullptr;
                     if (which == fallback.arbitration.state) return;
                     switch (which)
@@ -18689,10 +18685,10 @@ namespace netxs::lixx // li++, libinput++.
                             state = "not-active";
                             break;
                         case ARBITRATION_IGNORE_RECT:
-                            assert(phys_rect);
-                            rect = evdev_phys_rect_to_units(li_device, phys_rect);
-                            cancel_touches(li_device, &rect, stamp);
-                            fallback.arbitration.rect = rect;
+                            assert(phys_area);
+                            area = evdev_phys_rect_to_units(li_device, phys_area);
+                            cancel_touches(li_device, &area, stamp);
+                            fallback.arbitration.area = area;
                             state = "ignore-rect";
                             break;
                         case ARBITRATION_IGNORE_ALL:
@@ -19058,8 +19054,8 @@ namespace netxs::lixx // li++, libinput++.
         void                  device_suspended(libinput_device_sptr li_device, libinput_device_sptr suspended_li_device)                                              { fallback_impl.         fallback_interface_device_removed(li_device, suspended_li_device); }
         void                    device_resumed(libinput_device_sptr li_device, libinput_device_sptr resumed_li_device)                                                { fallback_impl.           fallback_interface_device_added(li_device, resumed_li_device); }
         void                        post_added(libinput_device_sptr li_device)                                                                                        { fallback_impl.     fallback_interface_sync_initial_state(li_device); }
-        void          touch_arbitration_toggle(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect const* rect/* may be nullptr */, time now) { fallback_impl.           fallback_interface_toggle_touch(li_device, which, rect, now) ; }
-        void     touch_arbitration_update_rect(libinput_device_sptr li_device, phys_rect const*rect, time now)                                                        { fallback_impl.            fallback_interface_update_rect(li_device, rect, now); }
+        void          touch_arbitration_toggle(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect const* area/* may be nullptr */, time now) { fallback_impl.           fallback_interface_toggle_touch(li_device, which, area, now) ; }
+        void     touch_arbitration_update_rect(libinput_device_sptr li_device, phys_rect const* area, time now)                                                       { fallback_impl.            fallback_interface_update_rect(li_device, area, now); }
         libinput_switch_state get_switch_state(libinput_switch which)                                                                                                 { return fallback_impl.fallback_interface_get_switch_state(which); }
     };
     using fallback_dispatch_sptr = sptr<fallback_dispatch>;

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -6181,8 +6181,7 @@ namespace netxs::lixx // li++, libinput++.
         }
         si32 evdev_need_mtdev()
         {
-            return (libevdev_has_event_code(EV_ABS, ABS_MT_POSITION_X)
-                 && libevdev_has_event_code(EV_ABS, ABS_MT_POSITION_Y)
+            return (libevdev_has_event_code(EV_ABS, ABS_MT_POSITION_X) && libevdev_has_event_code(EV_ABS, ABS_MT_POSITION_Y)
                 && !libevdev_has_event_code(EV_ABS, ABS_MT_SLOT));
         }
         void evdev_process_event(evdev_event& ev, time now)
@@ -19258,7 +19257,7 @@ namespace netxs::lixx // li++, libinput++.
                 if (auto li_device = libinput_device_create(seat, ud_device))
                 {
                     evdev_read_calibration_prop(li_device);
-                    li_device->output_name = ud_device->udev_device_get_property_value("WL_OUTPUT");
+                    li_device->output_name = li_device->udev_device_get_property_value("WL_OUTPUT");
                     return li_device;
                 }
             }
@@ -20673,7 +20672,7 @@ namespace netxs::lixx // li++, libinput++.
         {
             auto li = seat->libinput;
             li_device->source = li->timers.libinput_add_event_source(ud_device->fd, libinput_device_t::evdev_device_dispatch, li_device.get());
-            li_device->device_group = ud_device->udev_device_get_property_value("LIBINPUT_DEVICE_GROUP");
+            li_device->device_group = li_device->udev_device_get_property_value("LIBINPUT_DEVICE_GROUP");
             seat->devices_list.push_back(li_device);
             evdev_notify_added_device(li_device);
         }

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -1046,7 +1046,8 @@ namespace netxs::lixx // li++, libinput++.
     static constexpr auto zero_coor = fp64_coor{};
 
     using fd_t = os::fd_t;
-
+    template<class T>//todo simplify
+    struct libinput_timer_t;
     using libinput_sptr                       = sptr<struct libinput_t>;
     using libinput_seat_sptr                  = sptr<struct libinput_seat_t>;
     using libinput_timer_sptr                 = sptr<struct libinput_timer_t<struct libinput_timer_host>>;

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -3679,22 +3679,22 @@ namespace netxs::lixx // li++, libinput++.
 
         quirks_sptr quirks_fetch_for_device(quirks_context_sptr ctx)
         {
-            log("%s%: fetching quirks", devpath);
-            auto m = match_new(ctx->dmi2, ctx->dt2);
-            auto q = ptr::shared<quirks_t>();
-            for (auto s : ctx->sections)
+            if (ctx)
             {
-                q->quirk_match_section(s, m);
+                log("%s%: fetching quirks", devpath);
+                auto m = match_new(ctx->dmi2, ctx->dt2);
+                auto q = ptr::shared<quirks_t>();
+                for (auto s : ctx->sections)
+                {
+                    q->quirk_match_section(s, m);
+                }
+                if (q->properties.size())
+                {
+                    ctx->quirks.push_back(q);
+                    return q;
+                }
             }
-            if (q->properties.empty())
-            {
-                return {};
-            }
-            else
-            {
-                ctx->quirks.push_back(q);
-                return q;
-            }
+            return {};
         }
         bool libinput_ud_device_is_virtual()
         {

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -4894,8 +4894,6 @@ namespace netxs::lixx // li++, libinput++.
         void input_enable();
         void input_disable();
         bool libinput_add_devices();
-        si32 libinput_resume();
-        void libinput_suspend();
 
         bool current_tty_is_active()
         {
@@ -18987,22 +18985,6 @@ namespace netxs::lixx // li++, libinput++.
                 libinput_remove_devices();
             }
         }
-        void libinput_t::libinput_suspend()
-        {
-            if (ud_monitor)
-            {
-                ud_monitor.reset();
-                timers.libinput_remove_event_source(ud_monitor_source);
-                for (auto s : seat_list)
-                {
-                    for (auto d : s->devices_list)
-                    {
-                        disable_device(d);
-                    }
-                    s->devices_list.clear();
-                }
-            }
-        }
         void libinput_t::input_enable()
         {
             if (!ud_monitor && seat_id.size())
@@ -19020,33 +19002,6 @@ namespace netxs::lixx // li++, libinput++.
                     libinput_add_devices();
                 }
             }
-        }
-        si32 libinput_t::libinput_resume()
-        {
-            if (!ud_monitor && seat_id.size())
-            {
-                ud_monitor = ptr::shared<ud_monitor_t>(This());
-                if (!ud_monitor->udev_monitor_enable_receiving())
-                {
-                    log("Failed to bind the device monitor");
-                    ud_monitor.reset();
-                }
-                else
-                {
-                    auto fd = ud_monitor->udev_monitor_get_fd();
-                    auto ud_monitor_source = timers.libinput_add_event_source(fd, evdev_udev_handler, this);
-                    this->ud_monitor_source = ud_monitor_source;
-                    if (!libinput_add_devices())
-                    {
-                        libinput_suspend();
-                    }
-                    else
-                    {
-                        return 0;
-                    }
-                }
-            }
-            return -1;
         }
         libinput_device_sptr libinput_t::libinput_add_device(view path)
         {

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -1036,13 +1036,6 @@ namespace netxs::lixx // li++, libinput++.
     });
     static constexpr fp64 v_us2ms(fp64 units_per_us) { return units_per_us * 1000.0; }
     static constexpr fp64 v_us2s(fp64 units_per_us)  { return units_per_us * 1000000.0; }
-    static constexpr ::timeval time2tv(time t)
-    {
-        auto sec  = datetime::round<si64, std::chrono::seconds>(t);
-        auto usec = datetime::round<si64, std::chrono::microseconds>(t - std::chrono::seconds{ sec });
-        auto tv = ::timeval{ .tv_sec = (decltype(timeval::tv_sec))sec, .tv_usec = (decltype(timeval::tv_usec))usec };
-        return tv;
-    }
 
     using fp64_range = netxs::limits<fp64>;
     using si32_range = netxs::limits<si32>;
@@ -17226,7 +17219,9 @@ namespace netxs::lixx // li++, libinput++.
                     }
                                         input_event_t input_event_init(time stamp, ui32 type, ui32 code, si32 value)
                                         {
-                                            auto tval = time2tv(stamp);
+                                            auto sec  = datetime::round<si64, std::chrono::seconds>(stamp);
+                                            auto usec = datetime::round<si64, std::chrono::microseconds>(stamp - std::chrono::seconds{ sec });
+                                            auto tval = ::timeval{ .tv_sec = (decltype(timeval::tv_sec))sec, .tv_usec = (decltype(timeval::tv_usec))usec };
                                             auto event = input_event_t{};
                                             event.type             = (ui16)type;
                                             event.code             = (ui16)code;

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -714,93 +714,6 @@ namespace netxs::lixx // li++, libinput++.
         LIBINPUT_TABLET_TOOL_TIP_UP   = 0,
         LIBINPUT_TABLET_TOOL_TIP_DOWN = 1,
     };
-
-    template<auto t, auto c>
-    static constexpr auto _evbit = (t << 16) | c;
-    enum evdev_usage : ui32 // This is an enum to have the compiler help us a bit. The enum doesn't need to contain all event codes, only the ones we use in libinput - add to here as required.      * The order doesn't matter either since each enum value is just the type | code value anyway, keep it in somewhat logical groups where possible.
-    {
-        EVDEV_SYN_REPORT          = _evbit<EV_SYN, SYN_REPORT>,
-        EVDEV_KEY_RESERVED        = _evbit<EV_KEY, KEY_RESERVED>,
-        EVDEV_KEY_ESC             = _evbit<EV_KEY, KEY_ESC>,
-        EVDEV_KEY_MICMUTE         = _evbit<EV_KEY, KEY_MICMUTE>,
-        EVDEV_KEY_OK              = _evbit<EV_KEY, KEY_OK>,
-        EVDEV_KEY_LIGHTS_TOGGLE   = _evbit<EV_KEY, KEY_LIGHTS_TOGGLE>,
-        EVDEV_KEY_ALS_TOGGLE      = _evbit<EV_KEY, KEY_ALS_TOGGLE>,
-        EVDEV_KEY_MAX             = _evbit<EV_KEY, KEY_MAX>,
-        EVDEV_BTN_LEFT            = _evbit<EV_KEY, BTN_LEFT>,
-        EVDEV_BTN_RIGHT           = _evbit<EV_KEY, BTN_RIGHT>,
-        EVDEV_BTN_MIDDLE          = _evbit<EV_KEY, BTN_MIDDLE>,
-        EVDEV_BTN_SIDE            = _evbit<EV_KEY, BTN_SIDE>,
-        EVDEV_BTN_EXTRA           = _evbit<EV_KEY, BTN_EXTRA>,
-        EVDEV_BTN_FORWARD         = _evbit<EV_KEY, BTN_FORWARD>,
-        EVDEV_BTN_BACK            = _evbit<EV_KEY, BTN_BACK>,
-        EVDEV_BTN_TASK            = _evbit<EV_KEY, BTN_TASK>,
-        EVDEV_BTN_JOYSTICK        = _evbit<EV_KEY, BTN_JOYSTICK>,
-        EVDEV_BTN_0               = _evbit<EV_KEY, BTN_0>,
-        EVDEV_BTN_1               = _evbit<EV_KEY, BTN_1>,
-        EVDEV_BTN_2               = _evbit<EV_KEY, BTN_2>,
-        EVDEV_BTN_STYLUS          = _evbit<EV_KEY, BTN_STYLUS>,
-        EVDEV_BTN_STYLUS2         = _evbit<EV_KEY, BTN_STYLUS2>,
-        EVDEV_BTN_STYLUS3         = _evbit<EV_KEY, BTN_STYLUS3>,
-        EVDEV_BTN_TOUCH           = _evbit<EV_KEY, BTN_TOUCH>,
-        EVDEV_BTN_TOOL_PEN        = _evbit<EV_KEY, BTN_TOOL_PEN>,
-        EVDEV_BTN_TOOL_RUBBER     = _evbit<EV_KEY, BTN_TOOL_RUBBER>,
-        EVDEV_BTN_TOOL_BRUSH      = _evbit<EV_KEY, BTN_TOOL_BRUSH>,
-        EVDEV_BTN_TOOL_PENCIL     = _evbit<EV_KEY, BTN_TOOL_PENCIL>,
-        EVDEV_BTN_TOOL_AIRBRUSH   = _evbit<EV_KEY, BTN_TOOL_AIRBRUSH>,
-        EVDEV_BTN_TOOL_MOUSE      = _evbit<EV_KEY, BTN_TOOL_MOUSE>,
-        EVDEV_BTN_TOOL_LENS       = _evbit<EV_KEY, BTN_TOOL_LENS>,
-        EVDEV_BTN_TOOL_QUINTTAP   = _evbit<EV_KEY, BTN_TOOL_QUINTTAP>,
-        EVDEV_BTN_TOOL_DOUBLETAP  = _evbit<EV_KEY, BTN_TOOL_DOUBLETAP>,
-        EVDEV_BTN_TOOL_TRIPLETAP  = _evbit<EV_KEY, BTN_TOOL_TRIPLETAP>,
-        EVDEV_BTN_TOOL_QUADTAP    = _evbit<EV_KEY, BTN_TOOL_QUADTAP>,
-        EVDEV_BTN_TOOL_FINGER     = _evbit<EV_KEY, BTN_TOOL_FINGER>,
-        EVDEV_BTN_MISC            = _evbit<EV_KEY, BTN_MISC>,
-        EVDEV_BTN_GEAR_UP         = _evbit<EV_KEY, BTN_GEAR_UP>,
-        EVDEV_BTN_DPAD_UP         = _evbit<EV_KEY, BTN_DPAD_UP>,
-        EVDEV_BTN_DPAD_RIGHT      = _evbit<EV_KEY, BTN_DPAD_RIGHT>,
-        EVDEV_BTN_TRIGGER_HAPPY   = _evbit<EV_KEY, BTN_TRIGGER_HAPPY>,
-        EVDEV_BTN_TRIGGER_HAPPY40 = _evbit<EV_KEY, BTN_TRIGGER_HAPPY40>,
-        EVDEV_REL_X               = _evbit<EV_REL, REL_X>,
-        EVDEV_REL_Y               = _evbit<EV_REL, REL_Y>,
-        EVDEV_REL_WHEEL           = _evbit<EV_REL, REL_WHEEL>,
-        EVDEV_REL_WHEEL_HI_RES    = _evbit<EV_REL, REL_WHEEL_HI_RES>,
-        EVDEV_REL_HWHEEL          = _evbit<EV_REL, REL_HWHEEL>,
-        EVDEV_REL_HWHEEL_HI_RES   = _evbit<EV_REL, REL_HWHEEL_HI_RES>,
-        EVDEV_REL_DIAL            = _evbit<EV_REL, REL_DIAL>,
-        EVDEV_REL_MAX             = _evbit<EV_REL, REL_MAX>,
-        EVDEV_ABS_X               = _evbit<EV_ABS, ABS_X>,
-        EVDEV_ABS_Y               = _evbit<EV_ABS, ABS_Y>,
-        EVDEV_ABS_Z               = _evbit<EV_ABS, ABS_Z>,
-        EVDEV_ABS_RX              = _evbit<EV_ABS, ABS_RX>,
-        EVDEV_ABS_RY              = _evbit<EV_ABS, ABS_RY>,
-        EVDEV_ABS_RZ              = _evbit<EV_ABS, ABS_RZ>,
-        EVDEV_ABS_PRESSURE        = _evbit<EV_ABS, ABS_PRESSURE>,
-        EVDEV_ABS_DISTANCE        = _evbit<EV_ABS, ABS_DISTANCE>,
-        EVDEV_ABS_THROTTLE        = _evbit<EV_ABS, ABS_THROTTLE>,
-        EVDEV_ABS_RUDDER          = _evbit<EV_ABS, ABS_RUDDER>,
-        EVDEV_ABS_WHEEL           = _evbit<EV_ABS, ABS_WHEEL>,
-        EVDEV_ABS_MISC            = _evbit<EV_ABS, ABS_MISC>,
-        EVDEV_ABS_TILT_X          = _evbit<EV_ABS, ABS_TILT_X>,
-        EVDEV_ABS_TILT_Y          = _evbit<EV_ABS, ABS_TILT_Y>,
-        EVDEV_ABS_MT_SLOT         = _evbit<EV_ABS, ABS_MT_SLOT>,
-        EVDEV_ABS_MT_POSITION_X   = _evbit<EV_ABS, ABS_MT_POSITION_X>,
-        EVDEV_ABS_MT_POSITION_Y   = _evbit<EV_ABS, ABS_MT_POSITION_Y>,
-        EVDEV_ABS_MT_TOOL_TYPE    = _evbit<EV_ABS, ABS_MT_TOOL_TYPE>,
-        EVDEV_ABS_MT_TRACKING_ID  = _evbit<EV_ABS, ABS_MT_TRACKING_ID>,
-        EVDEV_ABS_MT_TOUCH_MAJOR  = _evbit<EV_ABS, ABS_MT_TOUCH_MAJOR>,
-        EVDEV_ABS_MT_TOUCH_MINOR  = _evbit<EV_ABS, ABS_MT_TOUCH_MINOR>,
-        EVDEV_ABS_MT_ORIENTATION  = _evbit<EV_ABS, ABS_MT_ORIENTATION>,
-        EVDEV_ABS_MT_PRESSURE     = _evbit<EV_ABS, ABS_MT_PRESSURE>,
-        EVDEV_ABS_MT_DISTANCE     = _evbit<EV_ABS, ABS_MT_DISTANCE>,
-        EVDEV_ABS_MAX             = _evbit<EV_ABS, ABS_MAX>,
-        EVDEV_SW_LID              = _evbit<EV_SW, SW_LID>,
-        EVDEV_SW_TABLET_MODE      = _evbit<EV_SW, SW_TABLET_MODE>,
-        EVDEV_SW_MAX              = _evbit<EV_SW, SW_MAX>,
-        EVDEV_MSC_SCAN            = _evbit<EV_MSC, MSC_SCAN>,
-        EVDEV_MSC_SERIAL          = _evbit<EV_MSC, MSC_SERIAL>,
-        EVDEV_MSC_TIMESTAMP       = _evbit<EV_MSC, MSC_TIMESTAMP>,
-    };
     enum libinput_tablet_tool_type
     {
         LIBINPUT_TABLET_TOOL_TYPE_NONE = 0,
@@ -948,6 +861,105 @@ namespace netxs::lixx // li++, libinput++.
         BUTTON_STATE_IGNORE,
     };
 
+    constexpr ui32 evdev_usage_from_code(ui32 type, ui32 code)
+    {
+        return (type << 16) | code;
+    }
+    constexpr ui16 evdev_usage_type(ui32 usage)
+    {
+        return (ui16)(usage >> 16);
+    }
+    constexpr ui16 evdev_usage_code(ui32 usage)
+    {
+        return (ui16)usage & 0xFFFF;
+    }
+    //template<ui32 t, ui32 c>
+    //static constexpr auto _evbit = (t << 16) | c;
+    struct evdev // The enum doesn't need to contain all event codes, only the ones we use in libinput - add to here as required.      * The order doesn't matter either since each enum value is just the type | code value anyway, keep it in somewhat logical groups where possible.
+    {
+        static constexpr auto syn_report          = evdev_usage_from_code(EV_SYN, SYN_REPORT);
+        static constexpr auto key_reserved        = evdev_usage_from_code(EV_KEY, KEY_RESERVED);
+        static constexpr auto key_esc             = evdev_usage_from_code(EV_KEY, KEY_ESC);
+        static constexpr auto key_micmute         = evdev_usage_from_code(EV_KEY, KEY_MICMUTE);
+        static constexpr auto key_ok              = evdev_usage_from_code(EV_KEY, KEY_OK);
+        static constexpr auto key_lights_toggle   = evdev_usage_from_code(EV_KEY, KEY_LIGHTS_TOGGLE);
+        static constexpr auto key_als_toggle      = evdev_usage_from_code(EV_KEY, KEY_ALS_TOGGLE);
+        static constexpr auto key_max             = evdev_usage_from_code(EV_KEY, KEY_MAX);
+        static constexpr auto btn_left            = evdev_usage_from_code(EV_KEY, BTN_LEFT);
+        static constexpr auto btn_right           = evdev_usage_from_code(EV_KEY, BTN_RIGHT);
+        static constexpr auto btn_middle          = evdev_usage_from_code(EV_KEY, BTN_MIDDLE);
+        static constexpr auto btn_side            = evdev_usage_from_code(EV_KEY, BTN_SIDE);
+        static constexpr auto btn_extra           = evdev_usage_from_code(EV_KEY, BTN_EXTRA);
+        static constexpr auto btn_forward         = evdev_usage_from_code(EV_KEY, BTN_FORWARD);
+        static constexpr auto btn_back            = evdev_usage_from_code(EV_KEY, BTN_BACK);
+        static constexpr auto btn_task            = evdev_usage_from_code(EV_KEY, BTN_TASK);
+        static constexpr auto btn_joystick        = evdev_usage_from_code(EV_KEY, BTN_JOYSTICK);
+        static constexpr auto btn_0               = evdev_usage_from_code(EV_KEY, BTN_0);
+        static constexpr auto btn_1               = evdev_usage_from_code(EV_KEY, BTN_1);
+        static constexpr auto btn_2               = evdev_usage_from_code(EV_KEY, BTN_2);
+        static constexpr auto btn_stylus          = evdev_usage_from_code(EV_KEY, BTN_STYLUS);
+        static constexpr auto btn_stylus2         = evdev_usage_from_code(EV_KEY, BTN_STYLUS2);
+        static constexpr auto btn_stylus3         = evdev_usage_from_code(EV_KEY, BTN_STYLUS3);
+        static constexpr auto btn_touch           = evdev_usage_from_code(EV_KEY, BTN_TOUCH);
+        static constexpr auto btn_tool_pen        = evdev_usage_from_code(EV_KEY, BTN_TOOL_PEN);
+        static constexpr auto btn_tool_rubber     = evdev_usage_from_code(EV_KEY, BTN_TOOL_RUBBER);
+        static constexpr auto btn_tool_brush      = evdev_usage_from_code(EV_KEY, BTN_TOOL_BRUSH);
+        static constexpr auto btn_tool_pencil     = evdev_usage_from_code(EV_KEY, BTN_TOOL_PENCIL);
+        static constexpr auto btn_tool_airbrush   = evdev_usage_from_code(EV_KEY, BTN_TOOL_AIRBRUSH);
+        static constexpr auto btn_tool_mouse      = evdev_usage_from_code(EV_KEY, BTN_TOOL_MOUSE);
+        static constexpr auto btn_tool_lens       = evdev_usage_from_code(EV_KEY, BTN_TOOL_LENS);
+        static constexpr auto btn_tool_quinttap   = evdev_usage_from_code(EV_KEY, BTN_TOOL_QUINTTAP);
+        static constexpr auto btn_tool_doubletap  = evdev_usage_from_code(EV_KEY, BTN_TOOL_DOUBLETAP);
+        static constexpr auto btn_tool_tripletap  = evdev_usage_from_code(EV_KEY, BTN_TOOL_TRIPLETAP);
+        static constexpr auto btn_tool_quadtap    = evdev_usage_from_code(EV_KEY, BTN_TOOL_QUADTAP);
+        static constexpr auto btn_tool_finger     = evdev_usage_from_code(EV_KEY, BTN_TOOL_FINGER);
+        static constexpr auto btn_misc            = evdev_usage_from_code(EV_KEY, BTN_MISC);
+        static constexpr auto btn_gear_up         = evdev_usage_from_code(EV_KEY, BTN_GEAR_UP);
+        static constexpr auto btn_dpad_up         = evdev_usage_from_code(EV_KEY, BTN_DPAD_UP);
+        static constexpr auto btn_dpad_right      = evdev_usage_from_code(EV_KEY, BTN_DPAD_RIGHT);
+        static constexpr auto btn_trigger_happy   = evdev_usage_from_code(EV_KEY, BTN_TRIGGER_HAPPY);
+        static constexpr auto btn_trigger_happy40 = evdev_usage_from_code(EV_KEY, BTN_TRIGGER_HAPPY40);
+        static constexpr auto rel_x               = evdev_usage_from_code(EV_REL, REL_X);
+        static constexpr auto rel_y               = evdev_usage_from_code(EV_REL, REL_Y);
+        static constexpr auto rel_wheel           = evdev_usage_from_code(EV_REL, REL_WHEEL);
+        static constexpr auto rel_wheel_hi_res    = evdev_usage_from_code(EV_REL, REL_WHEEL_HI_RES);
+        static constexpr auto rel_hwheel          = evdev_usage_from_code(EV_REL, REL_HWHEEL);
+        static constexpr auto rel_hwheel_hi_res   = evdev_usage_from_code(EV_REL, REL_HWHEEL_HI_RES);
+        static constexpr auto rel_dial            = evdev_usage_from_code(EV_REL, REL_DIAL);
+        static constexpr auto rel_max             = evdev_usage_from_code(EV_REL, REL_MAX); // not used
+        static constexpr auto abs_x               = evdev_usage_from_code(EV_ABS, ABS_X);
+        static constexpr auto abs_y               = evdev_usage_from_code(EV_ABS, ABS_Y);
+        static constexpr auto abs_z               = evdev_usage_from_code(EV_ABS, ABS_Z);
+        static constexpr auto abs_rx              = evdev_usage_from_code(EV_ABS, ABS_RX);
+        static constexpr auto abs_ry              = evdev_usage_from_code(EV_ABS, ABS_RY);
+        static constexpr auto abs_rz              = evdev_usage_from_code(EV_ABS, ABS_RZ);
+        static constexpr auto abs_pressure        = evdev_usage_from_code(EV_ABS, ABS_PRESSURE);
+        static constexpr auto abs_distance        = evdev_usage_from_code(EV_ABS, ABS_DISTANCE);
+        static constexpr auto abs_throttle        = evdev_usage_from_code(EV_ABS, ABS_THROTTLE);
+        static constexpr auto abs_rudder          = evdev_usage_from_code(EV_ABS, ABS_RUDDER); // not used
+        static constexpr auto abs_wheel           = evdev_usage_from_code(EV_ABS, ABS_WHEEL);
+        static constexpr auto abs_misc            = evdev_usage_from_code(EV_ABS, ABS_MISC);
+        static constexpr auto abs_tilt_x          = evdev_usage_from_code(EV_ABS, ABS_TILT_X);
+        static constexpr auto abs_tilt_y          = evdev_usage_from_code(EV_ABS, ABS_TILT_Y);
+        static constexpr auto abs_mt_slot         = evdev_usage_from_code(EV_ABS, ABS_MT_SLOT);
+        static constexpr auto abs_mt_position_x   = evdev_usage_from_code(EV_ABS, ABS_MT_POSITION_X);
+        static constexpr auto abs_mt_position_y   = evdev_usage_from_code(EV_ABS, ABS_MT_POSITION_Y);
+        static constexpr auto abs_mt_tool_type    = evdev_usage_from_code(EV_ABS, ABS_MT_TOOL_TYPE);
+        static constexpr auto abs_mt_tracking_id  = evdev_usage_from_code(EV_ABS, ABS_MT_TRACKING_ID);
+        static constexpr auto abs_mt_touch_major  = evdev_usage_from_code(EV_ABS, ABS_MT_TOUCH_MAJOR);
+        static constexpr auto abs_mt_touch_minor  = evdev_usage_from_code(EV_ABS, ABS_MT_TOUCH_MINOR);
+        static constexpr auto abs_mt_orientation  = evdev_usage_from_code(EV_ABS, ABS_MT_ORIENTATION);
+        static constexpr auto abs_mt_pressure     = evdev_usage_from_code(EV_ABS, ABS_MT_PRESSURE);
+        static constexpr auto abs_mt_distance     = evdev_usage_from_code(EV_ABS, ABS_MT_DISTANCE); // not used
+        static constexpr auto abs_max             = evdev_usage_from_code(EV_ABS, ABS_MAX); // not used
+        static constexpr auto sw_lid              = evdev_usage_from_code(EV_SW, SW_LID);
+        static constexpr auto sw_tablet_mode      = evdev_usage_from_code(EV_SW, SW_TABLET_MODE);
+        static constexpr auto sw_max              = evdev_usage_from_code(EV_SW, SW_MAX); // not used
+        static constexpr auto msc_scan            = evdev_usage_from_code(EV_MSC, MSC_SCAN);
+        static constexpr auto msc_serial          = evdev_usage_from_code(EV_MSC, MSC_SERIAL);
+        static constexpr auto msc_timestamp       = evdev_usage_from_code(EV_MSC, MSC_TIMESTAMP);
+    };
+
     static constexpr auto libinput_tablet_tool_type_min = LIBINPUT_TABLET_TOOL_TYPE_PEN;
     static constexpr auto libinput_tablet_tool_type_max = LIBINPUT_TABLET_TOOL_TYPE_LENS;
     static constexpr auto libinput_tablet_tool_axis_cnt = LIBINPUT_TABLET_TOOL_AXIS_SIZE_MINOR + 1;
@@ -1035,8 +1047,8 @@ namespace netxs::lixx // li++, libinput++.
     static constexpr auto valid_flags    = LIBEVDEV_READ_FLAG_NORMAL | LIBEVDEV_READ_FLAG_SYNC | LIBEVDEV_READ_FLAG_FORCE_SYNC | LIBEVDEV_READ_FLAG_BLOCKING;
     static constexpr auto tap_button_map = std::to_array<std::array<ui32, 3>>(
     {
-        { EVDEV_BTN_LEFT, EVDEV_BTN_RIGHT, EVDEV_BTN_MIDDLE },
-        { EVDEV_BTN_LEFT, EVDEV_BTN_MIDDLE, EVDEV_BTN_RIGHT },
+        { evdev::btn_left, evdev::btn_right, evdev::btn_middle },
+        { evdev::btn_left, evdev::btn_middle, evdev::btn_right },
     });
     static constexpr fp64 v_us2ms(fp64 units_per_us) { return units_per_us * 1000.0; }
     static constexpr fp64 v_us2s(fp64 units_per_us)  { return units_per_us * 1000000.0; }
@@ -1047,9 +1059,6 @@ namespace netxs::lixx // li++, libinput++.
         auto tv = ::timeval{ .tv_sec = (decltype(timeval::tv_sec))sec, .tv_usec = (decltype(timeval::tv_usec))usec };
         return tv;
     }
-
-    using button_code_t = ui32;
-    using keycode_t     = ui32;
 
     using fp64_range = netxs::limits<fp64>;
     using si32_range = netxs::limits<si32>;
@@ -1068,6 +1077,13 @@ namespace netxs::lixx // li++, libinput++.
     using button_state_t = std::bitset<KEY_CNT>;
     using tablet_axes_bitset = std::bitset<lixx::libinput_tablet_tool_axis_cnt>;
 
+    struct input_event_t : ::input_event
+    {
+        netxs::time input_event_time() const
+        {
+            return netxs::time{} + std::chrono::seconds{ input_event_sec } + std::chrono::microseconds{ input_event_usec };
+        }
+    };
     struct abs_info_t : ::input_absinfo
     {
         fp64 absinfo_range()                           const { return (fp64)(maximum - minimum + 1); }
@@ -3046,12 +3062,26 @@ namespace netxs::lixx // li++, libinput++.
             : stamp{}
         {
             ev_events.reserve(256);
-            ev_events.push_back(evdev_event{ .usage = EVDEV_SYN_REPORT }); // EVDEV_SYN_REPORT(0) should be always at the end.
+            ev_events.push_back(evdev_event{ .usage = evdev::syn_report }); // evdev::syn_report(0) should be always at the end.
         }
         void evdev_frame_reset()
         {
             ev_events.resize(1);
-            ev_events.front() = {}; // EVDEV_SYN_REPORT(0) should be always at the end.
+            ev_events.front() = {}; // evdev::syn_report(0) should be always at the end.
+        }
+        void evdev_frame_append_input_event(input_event_t& event)
+        {
+            auto ev = evdev_event{ .usage = evdev_usage_from_code(event.type, event.code), .value = event.value };
+            if (ev.usage == evdev::syn_report)
+            {
+                stamp = event.input_event_time();
+            }
+            else
+            {
+                ev_events.pop_back(); // Pop evdev::syn_report.
+                ev_events.push_back(ev);
+                ev_events.push_back({}); // evdev::syn_report(0) should be always at the end.
+            }
         }
     };
 
@@ -3180,7 +3210,7 @@ namespace netxs::lixx // li++, libinput++.
         si32                           current_slot{};
         std::vector<slot_change_state> slot_changes;
 
-        std::vector<::input_event> queue; //todo use std::deque
+        std::vector<input_event_t> queue; //todo use std::deque
         ui64                       queue_next{};  // Next event index.
         ui64                       queue_nsync{}; // Number of sync events.
         ::timeval                  last_event_time{};
@@ -3366,7 +3396,7 @@ namespace netxs::lixx // li++, libinput++.
         }
         static void evdev_drain_fd(si32 fd)
         {
-            auto events = std::array<::input_event, 24>{};
+            auto events = std::array<input_event_t, 24>{};
             while (::read(fd, events.data(), sizeof(events)) == sizeof(events)) // Discard all pending events.
             { }
         }
@@ -4033,7 +4063,7 @@ namespace netxs::lixx // li++, libinput++.
                 return -errno;
             }
         }
-                        void init_event(::input_event& ev, ui32 type, ui32 code, si32 value)
+                        void init_event(input_event_t& ev, ui32 type, ui32 code, si32 value)
                         {
                             ev.input_event_sec  = last_event_time.tv_sec;
                             ev.input_event_usec = last_event_time.tv_usec;
@@ -4096,13 +4126,19 @@ namespace netxs::lixx // li++, libinput++.
                     {
                         if (prev_ntouches > 0 && prev_ntouches <= (si32)map.size())
                         {
-                            auto ev = ::input_event{ .type = EV_KEY, .code = (ui16)map[prev_ntouches - 1], .value = 0 };
+                            auto ev = input_event_t{};
+                            ev.type = EV_KEY;
+                            ev.code = (ui16)map[prev_ntouches - 1];
+                            ev.value = 0;
                             queue_push_event(ev.type, ev.code, ev.value);
                             update_key_state(ev);
                         }
                         if (next_ntouches > 0 && next_ntouches <= (si32)map.size())
                         {
-                            auto ev = ::input_event{ .type = EV_KEY, .code = (ui16)map[next_ntouches - 1], .value = 1 };
+                            auto ev = input_event_t{};
+                            ev.type = EV_KEY;
+                            ev.code = (ui16)map[next_ntouches - 1];
+                            ev.value = 1;
                             queue_push_event(ev.type, ev.code, ev.value);
                             update_key_state(ev);
                         }
@@ -4247,12 +4283,12 @@ namespace netxs::lixx // li++, libinput++.
                     if (n)
                     {
                         remaining -= n;
-                        ::memmove(queue.data(), &queue[n], remaining * sizeof(::input_event));
+                        ::memmove(queue.data(), &queue[n], remaining * sizeof(input_event_t));
                         queue_next = remaining;
                     }
                     return n;
                 }
-                si32 queue_pop_front(::input_event& ev)
+                si32 queue_pop_front(input_event_t& ev)
                 {
                     auto remaining = queue_next;
                     auto n = std::min(ui64{ 1 }, remaining);
@@ -4265,17 +4301,17 @@ namespace netxs::lixx // li++, libinput++.
                     }
                     return n;
                 }
-            si32 queue_shift(::input_event& ev)
+            si32 queue_shift(input_event_t& ev)
             {
                 return queue_pop_front(ev) == 1 ? 0 : 1;
             }
                     template<ui32 Type>
-                    si32 libevdev_event_is_type(::input_event& ev)
+                    si32 libevdev_event_is_type(input_event_t& ev)
                     {
                         return ev.type == Type;
                     }
                 template<ui32 Type>
-                si32 libevdev_event_is_code(::input_event& ev, ui32 code)
+                si32 libevdev_event_is_code(input_event_t& ev, ui32 code)
                 {
                     if (!libevdev_event_is_type<Type>(ev))
                     {
@@ -4284,7 +4320,7 @@ namespace netxs::lixx // li++, libinput++.
                     auto& bits = select_bits<Type>();
                     return code < bits.size() && ev.code == code;
                 }
-            event_filter_status sanitize_event(::input_event& ev, sync_states sync_state)
+            event_filter_status sanitize_event(input_event_t& ev, sync_states sync_state)
             {
                 if (num_slots > -1 && libevdev_event_is_code<EV_ABS>(ev, ABS_MT_SLOT) && (ev.value < 0 || ev.value >= num_slots))
                 {
@@ -4299,7 +4335,7 @@ namespace netxs::lixx // li++, libinput++.
                 }
                 return EVENT_FILTER_NONE;
             }
-                si32 update_key_state(::input_event& e)
+                si32 update_key_state(input_event_t& e)
                 {
                     if (!libevdev_has_event_type<EV_KEY>() || e.code > KEY_MAX) return 1;
                     else
@@ -4308,7 +4344,7 @@ namespace netxs::lixx // li++, libinput++.
                         return 0;
                     }
                 }
-                    si32 update_mt_state(::input_event& e)
+                    si32 update_mt_state(input_event_t& e)
                     {
                         if (current_slot == -1) return 1;
                         else
@@ -4331,7 +4367,7 @@ namespace netxs::lixx // li++, libinput++.
                             return 0;
                         }
                     }
-                si32 update_abs_state(::input_event& e)
+                si32 update_abs_state(input_event_t& e)
                 {
                     if (!libevdev_has_event_type<EV_ABS>() || e.code > ABS_MAX) return 1;
                     else
@@ -4344,7 +4380,7 @@ namespace netxs::lixx // li++, libinput++.
                         return 0;
                     }
                 }
-                si32 update_led_state(::input_event& e)
+                si32 update_led_state(input_event_t& e)
                 {
                     if (!libevdev_has_event_type<EV_LED>() || e.code > LED_MAX) return 1;
                     else
@@ -4353,7 +4389,7 @@ namespace netxs::lixx // li++, libinput++.
                         return 0;
                     }
                 }
-                si32 update_sw_state(::input_event& e)
+                si32 update_sw_state(input_event_t& e)
                 {
                     if (!libevdev_has_event_type<EV_SW>() || e.code > SW_MAX) return 1;
                     else
@@ -4362,7 +4398,7 @@ namespace netxs::lixx // li++, libinput++.
                         return 0;
                     }
                 }
-            si32 update_state(::input_event& e)
+            si32 update_state(input_event_t& e)
             {
                 auto rc = 0;
                      if (e.type == EV_KEY) rc = update_key_state(e);
@@ -4378,12 +4414,12 @@ namespace netxs::lixx // li++, libinput++.
                 if (queue.size() && queue_next != queue.size())
                 {
                     auto free_elem = queue.size() - queue_next;
-                    auto len = ::read(fd, &queue[queue_next], free_elem * sizeof(::input_event));
+                    auto len = ::read(fd, &queue[queue_next], free_elem * sizeof(input_event_t));
                     if (len < 0) return -errno;
                     if (len > 0)
                     {
-                        if (len % sizeof(::input_event) != 0) return -EINVAL;
-                        auto nev = len / sizeof(::input_event);
+                        if (len % sizeof(input_event_t) != 0) return -EINVAL;
+                        auto nev = len / sizeof(input_event_t);
                         auto nelem = queue_next + nev;
                         if (nelem <= queue.size())
                         {
@@ -4393,7 +4429,7 @@ namespace netxs::lixx // li++, libinput++.
                 }
                 return 0;
             }
-        si32 libevdev_next_event(ui32 flags, ::input_event& ev)
+        si32 libevdev_next_event(ui32 flags, input_event_t& ev)
         {
             auto rc = (si32)LIBEVDEV_READ_STATUS_SUCCESS;
             if (!initialized || fd == os::invalid_fd)
@@ -4420,13 +4456,13 @@ namespace netxs::lixx // li++, libinput++.
             }
             else if (sync_state != SYNC_NONE)
             {
-                auto e = ::input_event{};
-                while (queue_shift(e) == 0) // Update state for all events.
+                auto ev = input_event_t{};
+                while (queue_shift(ev) == 0) // Update state for all events.
                 {
                     queue_nsync--;
-                    if (sanitize_event(e, sync_state) != EVENT_FILTER_DISCARD)
+                    if (sanitize_event(ev, sync_state) != EVENT_FILTER_DISCARD)
                     {
-                        update_state(e);
+                        update_state(ev);
                     }
                 }
                 sync_state = SYNC_NONE;
@@ -4791,10 +4827,6 @@ namespace netxs::lixx // li++, libinput++.
     using evdev_dispatch_sptr = sptr<struct evdev_dispatch_t>;
 
     // Helpers
-        evdev_usage evdev_usage_enum(ui32 usage)
-        {
-            return (evdev_usage)usage;
-        }
         bool parse_tpkbcombo_layout_property(qiew prop, tpkbcombo_layout& layout)
         {
             auto ok = prop == "below";
@@ -4835,88 +4867,13 @@ namespace netxs::lixx // li++, libinput++.
             }
             return view{};
         }
-        ui32 update_seat_button_count(libinput_seat_sptr seat, button_code_t button_code, libinput_button_state state)
+        ui32 update_seat_button_count(libinput_seat_sptr seat, ui32 button_code, libinput_button_state state)
         {
             assert(button_code <= KEY_MAX);
             auto& press_count = seat->button_count[button_code];
                  if (state == LIBINPUT_BUTTON_STATE_PRESSED) press_count++;
             else if (press_count)                            press_count--; // We might not have received the first PRESSED event.
             return press_count;
-        }
-        ui32 evdev_usage_from_code(ui32 type, ui32 code)
-        {
-            return (type << 16) | code;
-        }
-        ui16 evdev_usage_type(ui32 usage)
-        {
-            return (ui16)(usage >> 16);
-        }
-        ui16 evdev_event_type_f(evdev_event const& ev)
-        {
-            return evdev_usage_type(ev.usage);
-        }
-        ui32 evdev_usage_code(ui32 usage)
-        {
-            return (ui32)usage & 0xFFFF;
-        }
-        button_code_t button_code_from_usage(ui32 usage)
-        {
-            assert(evdev_usage_type(usage) == EV_KEY);
-            auto code = evdev_usage_code(usage);
-            return button_code_t(code);
-        }
-        ui16 evdev_event_code(evdev_event const& ev)
-        {
-            return (ui16)evdev_usage_code(ev.usage);
-        }
-        ::input_event evdev_event_to_input_event(evdev_event const& ev, time now)
-        {
-            auto tv = time2tv(now);
-            return ::input_event{ .time  = { tv.tv_sec, tv.tv_usec },
-                                  .type  = evdev_event_type_f(ev),
-                                  .code  = evdev_event_code(ev),
-                                  .value = ev.value };
-        }
-        qiew evdev_event_get_type_name(evdev_event const& ev)
-        {
-            return libevdev_event_type_get_name(evdev_usage_type(ev.usage));
-        }
-        time input_event_time(::input_event& event)
-        {
-            using namespace std::chrono;
-            return time{} + seconds{ event.input_event_sec } + microseconds{ event.input_event_usec };
-        }
-        evdev_event evdev_event_from_input_event(::input_event& event)
-        {
-            return evdev_event{ .usage = evdev_usage_from_code(event.type, event.code),
-                                .value = event.value };
-        }
-        evdev_event evdev_event_from_input_event(::input_event& event, time& event_time)
-        {
-            event_time = input_event_time(event);
-            return evdev_event_from_input_event(event);
-        }
-        void evdev_frame_append_input_event(evdev_frame& frame, ::input_event& event)
-        {
-            auto ev = evdev_event_from_input_event(event);
-            if (ev.usage == EVDEV_SYN_REPORT)
-            {
-                frame.stamp = input_event_time(event);
-            }
-            else
-            {
-                frame.ev_events.pop_back(); // Pop EVDEV_SYN_REPORT.
-                frame.ev_events.push_back(ev);
-                frame.ev_events.push_back({}); // EVDEV_SYN_REPORT(0) should be always at the end.
-            }
-        }
-        constexpr ui32 evdev_usage_from(evdev_usage usage)
-        {
-            return (ui32)usage;
-        }
-        ui32 evdev_usage_next(ui32 usage)
-        {
-            return evdev_usage_from_code(evdev_usage_type(usage), evdev_usage_code(usage) + 1);
         }
 
     struct evdev_dispatch_t : ptr::enable_shared_from_this<evdev_dispatch_t>
@@ -5466,15 +5423,15 @@ namespace netxs::lixx // li++, libinput++.
         {
             auto min = 0;
             auto max = 0;
-            switch (evdev_usage_enum(usage))
+            switch (usage)
             {
-                case EVDEV_ABS_X:
-                case EVDEV_ABS_MT_POSITION_X:
+                case evdev::abs_x:
+                case evdev::abs_mt_position_x:
                     min = abs.warning_range.min.x;
                     max = abs.warning_range.max.x;
                     break;
-                case EVDEV_ABS_Y:
-                case EVDEV_ABS_MT_POSITION_Y:
+                case evdev::abs_y:
+                case evdev::abs_mt_position_y:
                     min = abs.warning_range.min.y;
                     max = abs.warning_range.max.y;
                     break;
@@ -5483,12 +5440,12 @@ namespace netxs::lixx // li++, libinput++.
             }
             if (value < min || value > max)
             {
-                log("Axis %#x% value %d% is outside expected range [%d%, %d%]", evdev_usage_enum(usage), value, min, max);
+                log("Axis %#x% value %d% is outside expected range [%d%, %d%]", usage, value, min, max);
             }
         }
         si32 evdev_update_key_down_count(ui32 usage, si32 pressed)
         {
-            assert(usage >= EVDEV_KEY_RESERVED && usage <= EVDEV_KEY_MAX);
+            assert(usage >= evdev::key_reserved && usage <= evdev::key_max);
             auto code = evdev_usage_code(usage);
             auto& count = key_count[code];
                  if (pressed)   count++;
@@ -5606,8 +5563,8 @@ namespace netxs::lixx // li++, libinput++.
         {
             if (left_handed.enabled)
             {
-                     if (button == EVDEV_BTN_LEFT)  return evdev_usage_from(EVDEV_BTN_RIGHT);
-                else if (button == EVDEV_BTN_RIGHT) return evdev_usage_from(EVDEV_BTN_LEFT);
+                     if (button == evdev::btn_left)  return evdev::btn_right;
+                else if (button == evdev::btn_right) return evdev::btn_left;
             }
             return button;
         }
@@ -5659,11 +5616,11 @@ namespace netxs::lixx // li++, libinput++.
                         switch (event)
                         {
                             case MIDDLEBUTTON_EVENT_L_DOWN: middlebutton_state_error(event); break;
-                            case MIDDLEBUTTON_EVENT_R_DOWN: evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_MIDDLE), LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_MIDDLE, stamp); break;
-                            case MIDDLEBUTTON_EVENT_OTHER:  evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_PASSTHROUGH, stamp); return 0;
+                            case MIDDLEBUTTON_EVENT_R_DOWN: evdev_pointer_notify_button(stamp, evdev::btn_middle, LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_MIDDLE, stamp); break;
+                            case MIDDLEBUTTON_EVENT_OTHER:  evdev_pointer_notify_button(stamp, evdev::btn_left, LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_PASSTHROUGH, stamp); return 0;
                             case MIDDLEBUTTON_EVENT_R_UP:   middlebutton_state_error(event); break;
-                            case MIDDLEBUTTON_EVENT_L_UP:   evdev_pointer_notify_button(middlebutton.first_event_time, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_PRESSED); evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_IDLE, stamp); break;
-                            case MIDDLEBUTTON_EVENT_TIMEOUT:evdev_pointer_notify_button(middlebutton.first_event_time, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_PASSTHROUGH, stamp); break;
+                            case MIDDLEBUTTON_EVENT_L_UP:   evdev_pointer_notify_button(middlebutton.first_event_time, evdev::btn_left, LIBINPUT_BUTTON_STATE_PRESSED); evdev_pointer_notify_button(stamp, evdev::btn_left, LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_IDLE, stamp); break;
+                            case MIDDLEBUTTON_EVENT_TIMEOUT:evdev_pointer_notify_button(middlebutton.first_event_time, evdev::btn_left, LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_PASSTHROUGH, stamp); break;
                             case MIDDLEBUTTON_EVENT_ALL_UP: middlebutton_state_error(event); break;
                         }
                         return 1;
@@ -5672,12 +5629,12 @@ namespace netxs::lixx // li++, libinput++.
                     {
                         switch (event)
                         {
-                            case MIDDLEBUTTON_EVENT_L_DOWN:  evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_MIDDLE), LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_MIDDLE, stamp); break;
+                            case MIDDLEBUTTON_EVENT_L_DOWN:  evdev_pointer_notify_button(stamp, evdev::btn_middle, LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_MIDDLE, stamp); break;
                             case MIDDLEBUTTON_EVENT_R_DOWN:  middlebutton_state_error(event); break;
-                            case MIDDLEBUTTON_EVENT_OTHER:   evdev_pointer_notify_button(middlebutton.first_event_time, evdev_usage_from(EVDEV_BTN_RIGHT), LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_PASSTHROUGH, stamp); return 0;
-                            case MIDDLEBUTTON_EVENT_R_UP:    evdev_pointer_notify_button(middlebutton.first_event_time, evdev_usage_from(EVDEV_BTN_RIGHT), LIBINPUT_BUTTON_STATE_PRESSED); evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_RIGHT), LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_IDLE, stamp); break;
+                            case MIDDLEBUTTON_EVENT_OTHER:   evdev_pointer_notify_button(middlebutton.first_event_time, evdev::btn_right, LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_PASSTHROUGH, stamp); return 0;
+                            case MIDDLEBUTTON_EVENT_R_UP:    evdev_pointer_notify_button(middlebutton.first_event_time, evdev::btn_right, LIBINPUT_BUTTON_STATE_PRESSED); evdev_pointer_notify_button(stamp, evdev::btn_right, LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_IDLE, stamp); break;
                             case MIDDLEBUTTON_EVENT_L_UP:    middlebutton_state_error(event); break;
-                            case MIDDLEBUTTON_EVENT_TIMEOUT: evdev_pointer_notify_button(middlebutton.first_event_time, evdev_usage_from(EVDEV_BTN_RIGHT), LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_PASSTHROUGH, stamp); break;
+                            case MIDDLEBUTTON_EVENT_TIMEOUT: evdev_pointer_notify_button(middlebutton.first_event_time, evdev::btn_right, LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_PASSTHROUGH, stamp); break;
                             case MIDDLEBUTTON_EVENT_ALL_UP:  middlebutton_state_error(event); break;
                         }
                         return 1;
@@ -5688,9 +5645,9 @@ namespace netxs::lixx // li++, libinput++.
                         {
                             case MIDDLEBUTTON_EVENT_L_DOWN:
                             case MIDDLEBUTTON_EVENT_R_DOWN:  middlebutton_state_error(event); break;
-                            case MIDDLEBUTTON_EVENT_OTHER:   evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_MIDDLE), LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_IGNORE_LR, stamp);        return 0;
-                            case MIDDLEBUTTON_EVENT_R_UP:    evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_MIDDLE), LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_LEFT_UP_PENDING, stamp);  break;
-                            case MIDDLEBUTTON_EVENT_L_UP:    evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_MIDDLE), LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_RIGHT_UP_PENDING, stamp); break;
+                            case MIDDLEBUTTON_EVENT_OTHER:   evdev_pointer_notify_button(stamp, evdev::btn_middle, LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_IGNORE_LR, stamp);        return 0;
+                            case MIDDLEBUTTON_EVENT_R_UP:    evdev_pointer_notify_button(stamp, evdev::btn_middle, LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_LEFT_UP_PENDING, stamp);  break;
+                            case MIDDLEBUTTON_EVENT_L_UP:    evdev_pointer_notify_button(stamp, evdev::btn_middle, LIBINPUT_BUTTON_STATE_RELEASED); middlebutton_set_state(MIDDLEBUTTON_RIGHT_UP_PENDING, stamp); break;
                             case MIDDLEBUTTON_EVENT_TIMEOUT: middlebutton_state_error(event); break;
                             case MIDDLEBUTTON_EVENT_ALL_UP:  middlebutton_state_error(event); break;
                         }
@@ -5707,7 +5664,7 @@ namespace netxs::lixx // li++, libinput++.
                             case MIDDLEBUTTON_EVENT_ALL_UP:  middlebutton_state_error(event); break;
                             case MIDDLEBUTTON_EVENT_L_DOWN:  middlebutton_state_error(event); break;
                             case MIDDLEBUTTON_EVENT_R_DOWN:
-                                evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_MIDDLE), LIBINPUT_BUTTON_STATE_PRESSED);
+                                evdev_pointer_notify_button(stamp, evdev::btn_middle, LIBINPUT_BUTTON_STATE_PRESSED);
                                 middlebutton_set_state(MIDDLEBUTTON_MIDDLE, stamp);
                                 break;
                         }
@@ -5717,7 +5674,7 @@ namespace netxs::lixx // li++, libinput++.
                     {
                         switch (event)
                         {
-                            case MIDDLEBUTTON_EVENT_L_DOWN:  evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_MIDDLE), LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_MIDDLE, stamp); break;
+                            case MIDDLEBUTTON_EVENT_L_DOWN:  evdev_pointer_notify_button(stamp, evdev::btn_middle, LIBINPUT_BUTTON_STATE_PRESSED); middlebutton_set_state(MIDDLEBUTTON_MIDDLE, stamp); break;
                             case MIDDLEBUTTON_EVENT_R_DOWN:  middlebutton_state_error(event); break;
                             case MIDDLEBUTTON_EVENT_OTHER:   middlebutton_set_state(MIDDLEBUTTON_IGNORE_R, stamp); return 0;
                             case MIDDLEBUTTON_EVENT_R_UP:    middlebutton_set_state(MIDDLEBUTTON_IDLE, stamp); break;
@@ -5815,26 +5772,26 @@ namespace netxs::lixx // li++, libinput++.
                 auto event = evdev_middlebutton_event{};
                 auto is_press = state == LIBINPUT_BUTTON_STATE_PRESSED;
                 auto rc = 0;
-                auto btnbit = (evdev_usage_enum(button) - EVDEV_BTN_LEFT);
+                auto btnbit = (button - evdev::btn_left);
                 auto old_mask = 0u;
                 if (!middlebutton.enabled) return faux;
-                switch (evdev_usage_enum(button))
+                switch (button)
                 {
-                    case EVDEV_BTN_LEFT:
+                    case evdev::btn_left:
                         if (is_press) event = MIDDLEBUTTON_EVENT_L_DOWN;
                         else          event = MIDDLEBUTTON_EVENT_L_UP;
                         break;
-                    case EVDEV_BTN_RIGHT:
+                    case evdev::btn_right:
                         if (is_press) event = MIDDLEBUTTON_EVENT_R_DOWN;
                         else          event = MIDDLEBUTTON_EVENT_R_UP;
                         break;
                     // BTN_MIDDLE counts as "other" and resets middle button emulation.
-                    case EVDEV_BTN_MIDDLE:
+                    case evdev::btn_middle:
                     default:
                         event = MIDDLEBUTTON_EVENT_OTHER;
                         break;
                 }
-                if (button < EVDEV_BTN_LEFT || btnbit >= sizeof(middlebutton.button_mask) * 8)
+                if (button < evdev::btn_left || btnbit >= sizeof(middlebutton.button_mask) * 8)
                 {
                     log("Button mask too small for 'code=%%'", button);
                     return true;
@@ -5882,13 +5839,13 @@ namespace netxs::lixx // li++, libinput++.
                 }
                 if (is_press)
                 {
-                    if (scroll.button < EVDEV_BTN_LEFT + 5)
+                    if (scroll.button < evdev::btn_left + 5)
                     {
                         // For mouse buttons 1-5 (0x110 to 0x114) we apply a timeout before scrolling since the button could also be used for regular clicking.
                         auto flags = TIMER_FLAG_NONE;
                         scroll.button_scroll_state = BUTTONSCROLL_BUTTON_DOWN;
                         // Special case: if middle button emulation is enabled and our scroll button is the left or right button, we only get here *after* the middle button timeout has expired for that button press. The time passed is the button-down time though (which is in the past), so we have to allow for a negative timer to be set.
-                        if (middlebutton.enabled && (scroll.button == EVDEV_BTN_LEFT || scroll.button == EVDEV_BTN_RIGHT))
+                        if (middlebutton.enabled && (scroll.button == evdev::btn_left || scroll.button == evdev::btn_right))
                         {
                             flags = TIMER_FLAG_ALLOW_NEGATIVE;
                         }
@@ -5933,13 +5890,13 @@ namespace netxs::lixx // li++, libinput++.
                 evdev_pointer_post_button(stamp, button, state);
             }
         }
-            void pointer_notify_button(time stamp, button_code_t button, libinput_button_state state)
+            void pointer_notify_button(time stamp, ui32 button, libinput_button_state state)
             {
                 if (device_has_cap(LIBINPUT_DEVICE_CAP_POINTER))
                 {
                     auto seat_button_count = update_seat_button_count(seat, button, state);
                     auto& button_event = seat->libinput->libinput_emplace_event<libinput_event_pointer>();
-                    button_event.button            = ui32(button);
+                    button_event.button            = button;
                     button_event.seat_button_count = seat_button_count;
                     button_event.state             = state;
                     post_device_event(stamp, LIBINPUT_EVENT_POINTER_BUTTON, button_event);
@@ -5950,7 +5907,7 @@ namespace netxs::lixx // li++, libinput++.
             auto down_count = evdev_update_key_down_count(button, state);
             if ((state == LIBINPUT_BUTTON_STATE_PRESSED && down_count == 1) || (state == LIBINPUT_BUTTON_STATE_RELEASED && down_count == 0))
             {
-                pointer_notify_button(stamp, button_code_from_usage(button), state);
+                pointer_notify_button(stamp, evdev_usage_code(button), state);
                 if (state == LIBINPUT_BUTTON_STATE_RELEASED)
                 {
                     if (left_handed.change_to_enabled) left_handed.change_to_enabled(This());
@@ -6014,23 +5971,23 @@ namespace netxs::lixx // li++, libinput++.
         }
         si32 evdev_sync_device()
         {
-            auto event = ::input_event{};
+            auto ev = input_event_t{};
             auto rc = 0;
             frame.evdev_frame_reset();
             do
             {
-                rc = libevdev_next_event(LIBEVDEV_READ_FLAG_SYNC, event);
+                rc = libevdev_next_event(LIBEVDEV_READ_FLAG_SYNC, ev);
                 if (rc < 0) break;
-                evdev_frame_append_input_event(frame, event);
+                frame.evdev_frame_append_input_event(ev);
             }
             while (rc == LIBEVDEV_READ_STATUS_SYNC);
             evdev_device_dispatch_frame(frame);
             return rc == -EAGAIN ? LIBEVDEV_READ_STATUS_SUCCESS : rc;
         }
-        void evdev_note_time_delay(::input_event& ev)
+        void evdev_note_time_delay(input_event_t& ev)
         {
             auto li = seat->libinput;
-            auto event_time = input_event_time(ev);
+            auto event_time = ev.input_event_time();
             if (li->dispatch_time != time{} && event_time <= li->dispatch_time) // If we have a current libinput_dispatch() snapshot, compare our event time with the one from the snapshot. If we have more than 10ms delay, complain about it. This catches delays in processing where there is no steady event flow and thus SYN_DROPPED may not get hit by the kernel despite us being too slow.
             {
                 auto tdelta = li->dispatch_time - event_time;
@@ -6075,19 +6032,19 @@ namespace netxs::lixx // li++, libinput++.
         {
             auto li_device = (libinput_device_t*)data;
             auto li = li_device->li_context();
-            auto event = ::input_event{};
+            auto ev = input_event_t{};
             auto rc = (si32)LIBEVDEV_READ_STATUS_SUCCESS;
             auto once = faux;
             auto& frame = li_device->frame;
             frame.evdev_frame_reset();
             do // If the compositor is repainting, this function is called only once per frame and we have to process all the events available on the fd, otherwise there will be input lag.
             {
-                rc = li_device->libevdev_next_event(LIBEVDEV_READ_FLAG_NORMAL, event);
+                rc = li_device->libevdev_next_event(LIBEVDEV_READ_FLAG_NORMAL, ev);
                 if (rc == LIBEVDEV_READ_STATUS_SYNC)
                 {
                     log("SYN_DROPPED event - some input events have been lost.");
-                    event.code = SYN_REPORT; // Send one more sync event so we handle all currently pending events before we sync up to the current state.
-                    evdev_frame_append_input_event(frame, event);
+                    ev.code = SYN_REPORT; // Send one more sync event so we handle all currently pending events before we sync up to the current state.
+                    frame.evdev_frame_append_input_event(ev);
                     li_device->evdev_device_dispatch_frame(frame);
                     frame.evdev_frame_reset();
                     rc = li_device->evdev_sync_device();
@@ -6096,11 +6053,11 @@ namespace netxs::lixx // li++, libinput++.
                 {
                     if (!once)
                     {
-                        li_device->evdev_note_time_delay(event);
+                        li_device->evdev_note_time_delay(ev);
                         once = true;
                     }
-                    evdev_frame_append_input_event(frame, event);
-                    if (event.type == EV_SYN && event.code == SYN_REPORT)
+                    frame.evdev_frame_append_input_event(ev);
+                    if (ev.type == EV_SYN && ev.code == SYN_REPORT)
                     {
                         li_device->evdev_device_dispatch_frame(frame);
                         frame.evdev_frame_reset();
@@ -6136,12 +6093,12 @@ namespace netxs::lixx // li++, libinput++.
             fd = new_fd;
             ud_device->libevdev_change_fd(fd);
             // Re-sync libevdev's view of the device, but discard the actual events. Our device is in a neutral state already.
-            auto event = ::input_event{};
-            libevdev_next_event(LIBEVDEV_READ_FLAG_FORCE_SYNC, event);
+            auto ev = input_event_t{};
+            libevdev_next_event(LIBEVDEV_READ_FLAG_FORCE_SYNC, ev);
             auto status = 0;
             do
             {
-                status = libevdev_next_event(LIBEVDEV_READ_FLAG_SYNC, event);
+                status = libevdev_next_event(LIBEVDEV_READ_FLAG_SYNC, ev);
             }
             while (status == LIBEVDEV_READ_STATUS_SYNC);
             source = li->timers.libinput_add_event_source(fd, evdev_device_dispatch, this);
@@ -6242,7 +6199,7 @@ namespace netxs::lixx // li++, libinput++.
         {
             return ud_device->parse_udev_flag(property);
         }
-        si32 libevdev_next_event(ui32 flags, ::input_event& ev)
+        si32 libevdev_next_event(ui32 flags, input_event_t& ev)
         {
             return ud_device->libevdev_next_event(flags, ev);
         }
@@ -6614,7 +6571,7 @@ namespace netxs::lixx // li++, libinput++.
             }
             static ui32 evdev_scroll_get_button(libinput_device_sptr li_device)
             {
-                return evdev_usage_code(li_device->scroll.want_button); // Return the wanted configuration, even if it hasn't taken effect yet!.
+                return evdev_usage_code(li_device->scroll.want_button); // Return the wanted configuration, even if it hasn't taken effect yet!
             }
             static ui32 evdev_scroll_get_default_button(libinput_device_sptr li_device)
             {
@@ -6717,10 +6674,10 @@ namespace netxs::lixx // li++, libinput++.
             axis_event.changed_axes_bits = changed_axes;
             post_device_event(now, LIBINPUT_EVENT_TABLET_TOOL_AXIS, axis_event);
         }
-        void tablet_notify_button(time now, libinput_tablet_tool_sptr tool, libinput_tablet_tool_tip_state tip_state, tablet_axes const& axes, button_code_t button, libinput_button_state state, abs_info_t const* x, abs_info_t const* y)
+        void tablet_notify_button(time now, libinput_tablet_tool_sptr tool, libinput_tablet_tool_tip_state tip_state, tablet_axes const& axes, ui32 button, libinput_button_state state, abs_info_t const* x, abs_info_t const* y)
         {
             auto& button_event = seat->libinput->libinput_emplace_event<libinput_event_tablet_tool>();
-            button_event.button            = (ui32)button;
+            button_event.button            = button;
             button_event.state             = state;
             button_event.seat_button_count = update_seat_button_count(seat, button, state);
             button_event.axes              = axes;
@@ -7080,12 +7037,12 @@ namespace netxs::lixx // li++, libinput++.
                             {
                                 auto absinfo = (abs_info_t const*)nullptr;
                                 if (!tp.left_handed.rotate) return value;
-                                switch (evdev_usage_enum(usage))
+                                switch (usage)
                                 {
-                                    case EVDEV_ABS_X:
-                                    case EVDEV_ABS_MT_POSITION_X: absinfo = tp.li_device->abs.absinfo_x; break;
-                                    case EVDEV_ABS_Y:
-                                    case EVDEV_ABS_MT_POSITION_Y: absinfo = tp.li_device->abs.absinfo_y; break;
+                                    case evdev::abs_x:
+                                    case evdev::abs_mt_position_x: absinfo = tp.li_device->abs.absinfo_x; break;
+                                    case evdev::abs_y:
+                                    case evdev::abs_mt_position_y: absinfo = tp.li_device->abs.absinfo_y; break;
                                     default: ::abort();
                                 }
                                 return absinfo->maximum - (value - absinfo->minimum);
@@ -7155,24 +7112,24 @@ namespace netxs::lixx // li++, libinput++.
                         void tp_process_absolute(evdev_event const& ev, time stamp)
                         {
                             auto& t = tp_current_touch();
-                            switch (evdev_usage_enum(ev.usage))
+                            switch (ev.usage)
                             {
-                                case EVDEV_ABS_MT_POSITION_X:
+                                case evdev::abs_mt_position_x:
                                     tp.li_device->evdev_device_check_abs_axis_range(ev.usage, ev.value);
                                     t.point.x = rotated(ev.usage, ev.value);
                                     t.dirty = true;
                                     tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_MOTION);
                                     break;
-                                case EVDEV_ABS_MT_POSITION_Y:
+                                case evdev::abs_mt_position_y:
                                     tp.li_device->evdev_device_check_abs_axis_range(ev.usage, ev.value);
                                     t.point.y = rotated(ev.usage, ev.value);
                                     t.dirty = true;
                                     tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_MOTION);
                                     break;
-                                case EVDEV_ABS_MT_SLOT:
+                                case evdev::abs_mt_slot:
                                     tp.slot = ev.value;
                                     break;
-                                case EVDEV_ABS_MT_TRACKING_ID:
+                                case evdev::abs_mt_tracking_id:
                                     if (ev.value != -1)
                                     {
                                         tp.nactive_slots += 1;
@@ -7184,22 +7141,22 @@ namespace netxs::lixx // li++, libinput++.
                                         tp_end_sequence(t, stamp);
                                     }
                                     break;
-                                case EVDEV_ABS_MT_PRESSURE:
+                                case evdev::abs_mt_pressure:
                                     t.pressure = ev.value;
                                     t.dirty = true;
                                     tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_OTHERAXIS);
                                     break;
-                                case EVDEV_ABS_MT_TOOL_TYPE:
+                                case evdev::abs_mt_tool_type:
                                     t.is_tool_palm = ev.value == MT_TOOL_PALM;
                                     t.dirty = true;
                                     tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_OTHERAXIS);
                                     break;
-                                case EVDEV_ABS_MT_TOUCH_MAJOR:
+                                case evdev::abs_mt_touch_major:
                                     t.touch_limits.max = ev.value;
                                     t.dirty = true;
                                     tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_OTHERAXIS);
                                     break;
-                                case EVDEV_ABS_MT_TOUCH_MINOR:
+                                case evdev::abs_mt_touch_minor:
                                     t.touch_limits.min = ev.value;
                                     t.dirty = true;
                                     tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_OTHERAXIS);
@@ -7211,21 +7168,21 @@ namespace netxs::lixx // li++, libinput++.
                         void tp_process_absolute_st(evdev_event const& ev, [[maybe_unused]] time now)
                         {
                             auto& t = tp_current_touch();
-                            switch (evdev_usage_enum(ev.usage))
+                            switch (ev.usage)
                             {
-                                case EVDEV_ABS_X:
+                                case evdev::abs_x:
                                     tp.li_device->evdev_device_check_abs_axis_range(ev.usage, ev.value);
                                     t.point.x = rotated(ev.usage, ev.value);
                                     t.dirty = true;
                                     tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_MOTION);
                                     break;
-                                case EVDEV_ABS_Y:
+                                case evdev::abs_y:
                                     tp.li_device->evdev_device_check_abs_axis_range(ev.usage, ev.value);
                                     t.point.y = rotated(ev.usage, ev.value);
                                     t.dirty = true;
                                     tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_MOTION);
                                     break;
-                                case EVDEV_ABS_PRESSURE:
+                                case evdev::abs_pressure:
                                     t.pressure = ev.value;
                                     t.dirty = true;
                                     tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_OTHERAXIS);
@@ -7236,8 +7193,8 @@ namespace netxs::lixx // li++, libinput++.
                         }
                             void tp_process_button(evdev_event const& ev, [[maybe_unused]] time now)
                             {
-                                auto mask = 1ul << (evdev_usage_enum(ev.usage) - EVDEV_BTN_LEFT);
-                                if (tp.buttons.is_clickpad && ev.usage != EVDEV_BTN_LEFT) // Ignore other buttons on clickpads.
+                                auto mask = 1ul << (ev.usage - evdev::btn_left);
+                                if (tp.buttons.is_clickpad && ev.usage != evdev::btn_left) // Ignore other buttons on clickpads.
                                 {
                                     log("received 'type=%% code=%%' button event on a clickpad", evdev_usage_type(ev.usage), evdev_usage_code(ev.usage));
                                 }
@@ -7258,22 +7215,22 @@ namespace netxs::lixx // li++, libinput++.
                             void tp_fake_finger_set(ui32 usage, bool is_press)
                             {
                                 auto shift = 0;
-                                switch (evdev_usage_enum(usage))
+                                switch (usage)
                                 {
-                                    case EVDEV_BTN_TOUCH:
+                                    case evdev::btn_touch:
                                         if (!is_press) tp.fake_touches &= ~lixx::fake_finger_overflow;
                                         shift = 0;
                                         break;
-                                    case EVDEV_BTN_TOOL_FINGER:
+                                    case evdev::btn_tool_finger:
                                         shift = 1;
                                         break;
-                                    case EVDEV_BTN_TOOL_DOUBLETAP:
-                                    case EVDEV_BTN_TOOL_TRIPLETAP:
-                                    case EVDEV_BTN_TOOL_QUADTAP:
-                                        shift = evdev_usage_enum(usage) - EVDEV_BTN_TOOL_DOUBLETAP + 2;
+                                    case evdev::btn_tool_doubletap:
+                                    case evdev::btn_tool_tripletap:
+                                    case evdev::btn_tool_quadtap:
+                                        shift = usage - evdev::btn_tool_doubletap + 2;
                                         break;
                                     // When QUINTTAP is released we're either switching to 6 fingers (flag stays in place until BTN_TOUCH is released) or one of DOUBLE/TRIPLE/QUADTAP (will clear the flag on press).
-                                    case EVDEV_BTN_TOOL_QUINTTAP:
+                                    case evdev::btn_tool_quinttap:
                                         if (is_press) tp.fake_touches |= lixx::fake_finger_overflow;
                                         return;
                                     default:
@@ -7294,11 +7251,11 @@ namespace netxs::lixx // li++, libinput++.
                                 auto button = ui32{};
                                 if (!tp.buttons.trackpoint_li_device) return;
                                 auto dispatch = tp.buttons.trackpoint_li_device->dispatch;
-                                switch (evdev_usage_enum(ev.usage))
+                                switch (ev.usage)
                                 {
-                                    case EVDEV_BTN_0: button = evdev_usage_from(EVDEV_BTN_LEFT); break;
-                                    case EVDEV_BTN_1: button = evdev_usage_from(EVDEV_BTN_RIGHT); break;
-                                    case EVDEV_BTN_2: button = evdev_usage_from(EVDEV_BTN_MIDDLE); break;
+                                    case evdev::btn_0: button = evdev::btn_left; break;
+                                    case evdev::btn_1: button = evdev::btn_right; break;
+                                    case evdev::btn_2: button = evdev::btn_middle; break;
                                     default: return;
                                 }
                                 auto event = evdev_event
@@ -7308,7 +7265,7 @@ namespace netxs::lixx // li++, libinput++.
                                 };
                                 auto syn_report = evdev_event
                                 {
-                                    .usage = evdev_usage_from(EVDEV_SYN_REPORT),
+                                    .usage = evdev::syn_report,
                                     .value = 0
                                 };
                                 dispatch->process(tp.buttons.trackpoint_li_device, event, stamp);
@@ -7317,20 +7274,20 @@ namespace netxs::lixx // li++, libinput++.
                         void tp_process_key(evdev_event const& ev, time stamp)
                         {
                             if (ev.value == 2) return; // Ignore kernel key repeat.
-                            switch (evdev_usage_enum(ev.usage))
+                            switch (ev.usage)
                             {
-                                case EVDEV_BTN_LEFT:
-                                case EVDEV_BTN_MIDDLE:
-                                case EVDEV_BTN_RIGHT: tp_process_button(ev, stamp); break;
-                                case EVDEV_BTN_TOUCH:
-                                case EVDEV_BTN_TOOL_FINGER:
-                                case EVDEV_BTN_TOOL_DOUBLETAP:
-                                case EVDEV_BTN_TOOL_TRIPLETAP:
-                                case EVDEV_BTN_TOOL_QUADTAP:
-                                case EVDEV_BTN_TOOL_QUINTTAP: tp_fake_finger_set(ev.usage, !!ev.value); break;
-                                case EVDEV_BTN_0:
-                                case EVDEV_BTN_1:
-                                case EVDEV_BTN_2: tp_process_trackpoint_button(ev, stamp); break;
+                                case evdev::btn_left:
+                                case evdev::btn_middle:
+                                case evdev::btn_right: tp_process_button(ev, stamp); break;
+                                case evdev::btn_touch:
+                                case evdev::btn_tool_finger:
+                                case evdev::btn_tool_doubletap:
+                                case evdev::btn_tool_tripletap:
+                                case evdev::btn_tool_quadtap:
+                                case evdev::btn_tool_quinttap: tp_fake_finger_set(ev.usage, !!ev.value); break;
+                                case evdev::btn_0:
+                                case evdev::btn_1:
+                                case evdev::btn_2: tp_process_trackpoint_button(ev, stamp); break;
                                 default: break;
                             }
                         }
@@ -7356,7 +7313,7 @@ namespace netxs::lixx // li++, libinput++.
                             }
                         void tp_process_msc(evdev_event const& ev, [[maybe_unused]] time now)
                         {
-                            if (ev.usage != EVDEV_MSC_TIMESTAMP)
+                            if (ev.usage != evdev::msc_timestamp)
                             {
                                 tp.quirks.msc_timestamp.now = std::chrono::microseconds{ ev.value };
                                 tp.queued = (touchpad_event)(tp.queued | TOUCHPAD_EVENT_TIMESTAMP);
@@ -9438,7 +9395,7 @@ namespace netxs::lixx // li++, libinput++.
                                                         case GESTURE_EVENT_RESET: log("log_gesture_bug: tp", (ui32)event); break;
                                                         case GESTURE_EVENT_CANCEL:
                                                             // If the gesture is cancelled we release the button immediately.
-                                                            tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_RELEASED);
+                                                            tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev::btn_left, LIBINPUT_BUTTON_STATE_RELEASED);
                                                             tp.gesture.state = GESTURE_STATE_NONE;
                                                             break;
                                                         case GESTURE_EVENT_END:
@@ -9449,7 +9406,7 @@ namespace netxs::lixx // li++, libinput++.
                                                         case GESTURE_EVENT_FINGER_SWITCH_TIMEOUT:
                                                             if (tp.gesture.finger_count_pending < 2)
                                                             {
-                                                                tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_RELEASED);
+                                                                tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev::btn_left, LIBINPUT_BUTTON_STATE_RELEASED);
                                                                 tp.gesture.state = GESTURE_STATE_NONE;
                                                             }
                                                             break;
@@ -9480,7 +9437,7 @@ namespace netxs::lixx // li++, libinput++.
                                                             tp_gesture_stop_3fg_drag(stamp);
                                                             tp.gesture.drag_3fg_timer->cancel();
                                                             tp.gesture.finger_count_switch_timer->cancel();
-                                                            tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_RELEASED);
+                                                            tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev::btn_left, LIBINPUT_BUTTON_STATE_RELEASED);
                                                             tp.gesture.state = GESTURE_STATE_NONE;
                                                             break;
                                                         case GESTURE_EVENT_FINGER_SWITCH_TIMEOUT:
@@ -9495,7 +9452,7 @@ namespace netxs::lixx // li++, libinput++.
                                                         case GESTURE_EVENT_POINTER_MOTION_START:
                                                             tp_gesture_stop_3fg_drag(stamp);
                                                             tp.gesture.drag_3fg_timer->cancel();
-                                                            tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_RELEASED);
+                                                            tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev::btn_left, LIBINPUT_BUTTON_STATE_RELEASED);
                                                             tp.gesture.state = GESTURE_STATE_POINTER_MOTION;
                                                             break;
                                                         case GESTURE_EVENT_HOLD_AND_MOTION_START:
@@ -9503,7 +9460,7 @@ namespace netxs::lixx // li++, libinput++.
                                                         // Anything that's detected as gesture in this state will be continue the current 3fg drag gesture.
                                                         case GESTURE_EVENT_SCROLL_START:
                                                             tp.gesture.drag_3fg_timer->cancel();
-                                                            tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_RELEASED);
+                                                            tp.li_device->evdev_pointer_notify_button(tp.gesture.drag_3fg_release_time, evdev::btn_left, LIBINPUT_BUTTON_STATE_RELEASED);
                                                             tp.gesture.state = GESTURE_STATE_SCROLL_START;
                                                             break;
                                                         case GESTURE_EVENT_SWIPE_START:
@@ -9880,7 +9837,7 @@ namespace netxs::lixx // li++, libinput++.
                                                     auto value = (state == LIBINPUT_BUTTON_STATE_PRESSED) ? 1 : 0;
                                                     auto event = evdev_event{ .usage = button,
                                                                               .value = value };
-                                                    auto syn_report = evdev_event{ .usage = evdev_usage_from(EVDEV_SYN_REPORT),
+                                                    auto syn_report = evdev_event{ .usage = evdev::syn_report,
                                                                                    .value = 0 };
                                                     dispatch->process(tp.buttons.trackpoint_li_device, event, stamp);
                                                     dispatch->process(tp.buttons.trackpoint_li_device, syn_report, stamp);
@@ -9942,14 +9899,14 @@ namespace netxs::lixx // li++, libinput++.
                                             }
                                             if ((tp.li_device->middlebutton.enabled || is_top) && (area & LEFT) && (area & RIGHT))
                                             {
-                                                button = evdev_usage_from(EVDEV_BTN_MIDDLE);
+                                                button = evdev::btn_middle;
                                             }
-                                            else if (area & MIDDLE) button = evdev_usage_from(EVDEV_BTN_MIDDLE);
-                                            else if (area & RIGHT)  button = evdev_usage_from(EVDEV_BTN_RIGHT);
-                                            else if (area & LEFT)   button = evdev_usage_from(EVDEV_BTN_LEFT);
+                                            else if (area & MIDDLE) button = evdev::btn_middle;
+                                            else if (area & RIGHT)  button = evdev::btn_right;
+                                            else if (area & LEFT)   button = evdev::btn_left;
                                             else // Main or no area (for clickfinger) is always BTN_LEFT.
                                             {
-                                                button = evdev_usage_from(EVDEV_BTN_LEFT);
+                                                button = evdev::btn_left;
                                                 want_left_handed = faux;
                                             }
                                             if (is_top) want_left_handed = faux;
@@ -9973,17 +9930,17 @@ namespace netxs::lixx // li++, libinput++.
                                     {
                                         auto current = tp.buttons.state;
                                         auto old = tp.buttons.old_state;
-                                        auto button = EVDEV_BTN_LEFT;
+                                        auto button = evdev::btn_left;
                                         while (current || old)
                                         {
                                             auto state = libinput_button_state{};
                                             if ((current & 0x1) ^ (old & 0x1))
                                             {
                                                 state = (current & 0x1) ? LIBINPUT_BUTTON_STATE_PRESSED : LIBINPUT_BUTTON_STATE_RELEASED;
-                                                auto b = tp.li_device->evdev_to_left_handed((ui32)button);
+                                                auto b = tp.li_device->evdev_to_left_handed(button);
                                                 tp.li_device->evdev_pointer_notify_physical_button(stamp, b, state);
                                             }
-                                            button = (evdev_usage)(button + 1);
+                                            button++;
                                             current >>= 1;
                                             old >>= 1;
                                         }
@@ -11448,7 +11405,7 @@ namespace netxs::lixx // li++, libinput++.
                                         }
                                         void tp_gesture_handle_state_3fg_drag_start(time stamp)
                                         {
-                                            tp.li_device->evdev_pointer_notify_button(stamp, evdev_usage_from(EVDEV_BTN_LEFT), LIBINPUT_BUTTON_STATE_PRESSED);
+                                            tp.li_device->evdev_pointer_notify_button(stamp, evdev::btn_left, LIBINPUT_BUTTON_STATE_PRESSED);
                                             //todo FIXME: immediately send a motion event?.
                                             tp.gesture.state = GESTURE_STATE_3FG_DRAG;
                                         }
@@ -11692,7 +11649,7 @@ namespace netxs::lixx // li++, libinput++.
                         }
             void tp_interface_process([[maybe_unused]] libinput_device_sptr li_device, evdev_event& ev, time stamp)
             {
-                auto type = evdev_event_type_f(ev);
+                auto type = evdev_usage_type(ev.usage);
                 switch (type)
                 {
                     case EV_ABS:
@@ -12394,7 +12351,7 @@ namespace netxs::lixx // li++, libinput++.
                     // Some touchpads don't reset BTN_TOOL_FINGER on touch up and only change to/from it when BTN_TOOL_DOUBLETAP is set. This causes us to ignore the first touches events until a two-finger gesture is performed.
                     if (li_device->libevdev_get_event_value<EV_KEY>(BTN_TOOL_FINGER))
                     {
-                        tp_fake_finger_set(evdev_usage_from(EVDEV_BTN_TOOL_FINGER), true);
+                        tp_fake_finger_set(evdev::btn_tool_finger, true);
                     }
                     return true;
                 }
@@ -13668,14 +13625,14 @@ namespace netxs::lixx // li++, libinput++.
                         void pad_unset_status(byte s) { pad.status &= ~s; }
                         void pad_process_relative([[maybe_unused]] libinput_device_sptr li_device, evdev_event& ev, [[maybe_unused]] time now)
                         {
-                            switch (evdev_usage_enum(ev.usage))
+                            switch (ev.usage)
                             {
-                                case EVDEV_REL_DIAL:
+                                case evdev::rel_dial:
                                     pad.dials.dial1 = ev.value * 120;
                                     pad.changed_axes |= PAD_AXIS_DIAL1;
                                     pad_set_status(PAD_AXES_UPDATED);
                                     break;
-                                case EVDEV_REL_WHEEL:
+                                case evdev::rel_wheel:
                                     if (!pad.dials.has_hires_dial)
                                     {
                                         pad.dials.dial1 = -1 * ev.value * 120;
@@ -13683,7 +13640,7 @@ namespace netxs::lixx // li++, libinput++.
                                         pad_set_status(PAD_AXES_UPDATED);
                                     }
                                     break;
-                                case EVDEV_REL_HWHEEL:
+                                case evdev::rel_hwheel:
                                     if (!pad.dials.has_hires_dial)
                                     {
                                         pad.dials.dial2 = ev.value * 120;
@@ -13691,18 +13648,18 @@ namespace netxs::lixx // li++, libinput++.
                                         pad_set_status(PAD_AXES_UPDATED);
                                     }
                                     break;
-                                case EVDEV_REL_WHEEL_HI_RES:
+                                case evdev::rel_wheel_hi_res:
                                     pad.dials.dial1 = -1 * ev.value;
                                     pad.changed_axes |= PAD_AXIS_DIAL1;
                                     pad_set_status(PAD_AXES_UPDATED);
                                     break;
-                                case EVDEV_REL_HWHEEL_HI_RES:
+                                case evdev::rel_hwheel_hi_res:
                                     pad.dials.dial2 = ev.value;
                                     pad.changed_axes |= PAD_AXIS_DIAL2;
                                     pad_set_status(PAD_AXES_UPDATED);
                                     break;
                                 default:
-                                    log("Unhandled EV_REL event code %#x%", (ui32)ev.usage);
+                                    log("Unhandled EV_REL event code %#x%", ev.usage);
                                     break;
                             }
                         }
@@ -13728,13 +13685,13 @@ namespace netxs::lixx // li++, libinput++.
                         void pad_process_absolute([[maybe_unused]] libinput_device_sptr li_device, evdev_event& ev, [[maybe_unused]] time now)
                         {
                             auto axis = PAD_AXIS_NONE;
-                            switch (evdev_usage_enum(ev.usage))
+                            switch (ev.usage)
                             {
-                                case EVDEV_ABS_WHEEL:    axis = PAD_AXIS_RING1; break;
-                                case EVDEV_ABS_THROTTLE: axis = PAD_AXIS_RING2; break;
-                                case EVDEV_ABS_RX:       axis = PAD_AXIS_STRIP1; break;
-                                case EVDEV_ABS_RY:       axis = PAD_AXIS_STRIP2; break;
-                                case EVDEV_ABS_MISC:
+                                case evdev::abs_wheel:    axis = PAD_AXIS_RING1; break;
+                                case evdev::abs_throttle: axis = PAD_AXIS_RING2; break;
+                                case evdev::abs_rx:       axis = PAD_AXIS_STRIP1; break;
+                                case evdev::abs_ry:       axis = PAD_AXIS_STRIP2; break;
+                                case evdev::abs_misc:
                                     // The wacom driver always sends a 0 axis event on finger up, but we also get an ABS_MISC 15 on touch down and ABS_MISC 0 on touch up, on top of the actual event. This is kernel behavior for xf86-input-wacom backwards compatibility after the 3.17 wacom HID move. We use that event to tell when we truly went a full rotation around the wheel vs. a finger release. FIXME: On the Intuos5 and later the kernel merges all states into that event, so if any finger is down on any button, the wheel release won't trigger the ABS_MISC 0 but still send a 0 event. We can't currently detect this.
                                     pad.have_abs_misc_terminator = true;
                                     break;
@@ -14169,7 +14126,7 @@ namespace netxs::lixx // li++, libinput++.
                         }
                     void pad_process(libinput_device_sptr li_device, evdev_event& ev, time stamp)
                     {
-                        auto type = evdev_event_type_f(ev);
+                        auto type = evdev_usage_type(ev.usage);
                         switch (type)
                         {
                             case EV_REL: pad_process_relative(li_device, ev, stamp); break;
@@ -14185,7 +14142,7 @@ namespace netxs::lixx // li++, libinput++.
                     void pad_suspend(libinput_device_sptr li_device)
                     {
                         auto li = pad.li_device->li_context();
-                        for (auto usage = evdev_usage_from(EVDEV_KEY_ESC); usage <= EVDEV_KEY_MAX; usage = evdev_usage_next(usage))
+                        for (auto usage = evdev::key_esc; usage <= evdev::key_max; usage++)
                         {
                             auto button = evdev_usage_code(usage);
                             if (pad.next_button_state[button])
@@ -14588,9 +14545,9 @@ namespace netxs::lixx // li++, libinput++.
             void totem_process_abs([[maybe_unused]] libinput_device_sptr li_device, evdev_event& ev, [[maybe_unused]] time now)
             {
                 auto& slot = totem.slots[totem.slot_index];
-                switch (evdev_usage_enum(ev.usage))
+                switch (ev.usage)
                 {
-                    case EVDEV_ABS_MT_SLOT:
+                    case evdev::abs_mt_slot:
                         if ((ui64)ev.value >= totem.slots.size())
                         {
                             log("exceeded slot count (%d% of max %zd%)", ev.value, totem.slots.size());
@@ -14598,7 +14555,7 @@ namespace netxs::lixx // li++, libinput++.
                         }
                         totem.slot_index = ev.value;
                         return;
-                    case EVDEV_ABS_MT_TRACKING_ID:
+                    case evdev::abs_mt_tracking_id:
                         if (ev.value >= 0) // If the totem is already down on init, we currently ignore it.
                         {
                             slot.state = SLOT_STATE_BEGIN;
@@ -14608,21 +14565,21 @@ namespace netxs::lixx // li++, libinput++.
                             slot.state = SLOT_STATE_END;
                         }
                         break;
-                    case EVDEV_ABS_MT_POSITION_X:  slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_X); break;
-                    case EVDEV_ABS_MT_POSITION_Y:  slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_Y); break;
-                    case EVDEV_ABS_MT_TOUCH_MAJOR: slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_SIZE_MAJOR); break;
-                    case EVDEV_ABS_MT_TOUCH_MINOR: slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_SIZE_MINOR); break;
-                    case EVDEV_ABS_MT_ORIENTATION: slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_ROTATION_Z); break;
-                    case EVDEV_ABS_MT_TOOL_TYPE: if (ev.value != MT_TOOL_DIAL) log("Unexpected tool type %#x%, changing to dial", ev.usage); break;
+                    case evdev::abs_mt_position_x:  slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_X); break;
+                    case evdev::abs_mt_position_y:  slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_Y); break;
+                    case evdev::abs_mt_touch_major: slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_SIZE_MAJOR); break;
+                    case evdev::abs_mt_touch_minor: slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_SIZE_MINOR); break;
+                    case evdev::abs_mt_orientation: slot.changed_axes_bits.set(LIBINPUT_TABLET_TOOL_AXIS_ROTATION_Z); break;
+                    case evdev::abs_mt_tool_type: if (ev.value != MT_TOOL_DIAL) log("Unexpected tool type %#x%, changing to dial", ev.usage); break;
                     default: log("Unhandled ABS event code %#x%", ev.usage); break;
                 }
             }
             void totem_process_key([[maybe_unused]] libinput_device_sptr li_device, evdev_event& ev, [[maybe_unused]] time now)
             {
                 if (ev.value == 2) return; // Ignore kernel key repeat.
-                switch (evdev_usage_enum(ev.usage))
+                switch (ev.usage)
                 {
-                    case EVDEV_BTN_0: totem.button_state_now = !!ev.value; break;
+                    case evdev::btn_0: totem.button_state_now = !!ev.value; break;
                     default: log("Unhandled KEY event code %#x%", ev.usage); break;
                 }
             }
@@ -14630,7 +14587,7 @@ namespace netxs::lixx // li++, libinput++.
             {
                 auto global_state = slot_state_enum{};
                 auto enable_touch = faux;
-                auto type = evdev_event_type_f(ev);
+                auto type = evdev_usage_type(ev.usage);
                 switch(type)
                 {
                     case EV_ABS: totem_process_abs(li_device, ev, now); break;
@@ -14848,15 +14805,15 @@ namespace netxs::lixx // li++, libinput++.
                     {
                         static const auto axis_lut = std::to_array<std::pair<ui32, libinput_tablet_tool_axis>>(
                         {
-                            { EVDEV_ABS_X       , LIBINPUT_TABLET_TOOL_AXIS_X          },
-                            { EVDEV_ABS_Y       , LIBINPUT_TABLET_TOOL_AXIS_Y          },
-                            { EVDEV_ABS_Z       , LIBINPUT_TABLET_TOOL_AXIS_ROTATION_Z },
-                            { EVDEV_ABS_DISTANCE, LIBINPUT_TABLET_TOOL_AXIS_DISTANCE   },
-                            { EVDEV_ABS_PRESSURE, LIBINPUT_TABLET_TOOL_AXIS_PRESSURE   },
-                            { EVDEV_ABS_TILT_X  , LIBINPUT_TABLET_TOOL_AXIS_TILT_X     },
-                            { EVDEV_ABS_TILT_Y  , LIBINPUT_TABLET_TOOL_AXIS_TILT_Y     },
-                            { EVDEV_ABS_WHEEL   , LIBINPUT_TABLET_TOOL_AXIS_SLIDER     },
-                            { EVDEV_REL_WHEEL   , LIBINPUT_TABLET_TOOL_AXIS_REL_WHEEL  },
+                            { evdev::abs_x       , LIBINPUT_TABLET_TOOL_AXIS_X          },
+                            { evdev::abs_y       , LIBINPUT_TABLET_TOOL_AXIS_Y          },
+                            { evdev::abs_z       , LIBINPUT_TABLET_TOOL_AXIS_ROTATION_Z },
+                            { evdev::abs_distance, LIBINPUT_TABLET_TOOL_AXIS_DISTANCE   },
+                            { evdev::abs_pressure, LIBINPUT_TABLET_TOOL_AXIS_PRESSURE   },
+                            { evdev::abs_tilt_x  , LIBINPUT_TABLET_TOOL_AXIS_TILT_X     },
+                            { evdev::abs_tilt_y  , LIBINPUT_TABLET_TOOL_AXIS_TILT_Y     },
+                            { evdev::abs_wheel   , LIBINPUT_TABLET_TOOL_AXIS_SLIDER     },
+                            { evdev::rel_wheel   , LIBINPUT_TABLET_TOOL_AXIS_REL_WHEEL  },
                         });
                         auto iter = std::ranges::find_if(axis_lut, [&](auto a){ return a.first == usage; });
                         return iter != axis_lut.end() ? iter->second : LIBINPUT_TABLET_TOOL_AXIS_NONE;
@@ -14867,7 +14824,7 @@ namespace netxs::lixx // li++, libinput++.
                         auto current = ev.value;
                         auto delta = previous - current;
                         auto fuzz = li_device->libevdev_get_abs_fuzz(evdev_usage_code(ev.usage));
-                        if (evdev_usage_enum(ev.usage) == EVDEV_ABS_DISTANCE) // ABS_DISTANCE doesn't have have fuzz set and causes continuous updates for the cursor/lens tools.
+                        if (ev.usage == evdev::abs_distance) // ABS_DISTANCE doesn't have have fuzz set and causes continuous updates for the cursor/lens tools.
                         {
                             fuzz = std::max(2, fuzz); // Add a minimum fuzz of 2, same as the xf86-input-wacom driver.
                         }
@@ -14876,16 +14833,16 @@ namespace netxs::lixx // li++, libinput++.
                 void tablet_process_absolute(libinput_device_sptr li_device, evdev_event& ev, [[maybe_unused]] time now)
                 {
                     auto axis = libinput_tablet_tool_axis{};
-                    switch (evdev_usage_enum(ev.usage))
+                    switch (ev.usage)
                     {
-                        case EVDEV_ABS_X:
-                        case EVDEV_ABS_Y:
-                        case EVDEV_ABS_Z:
-                        case EVDEV_ABS_PRESSURE:
-                        case EVDEV_ABS_TILT_X:
-                        case EVDEV_ABS_TILT_Y:
-                        case EVDEV_ABS_DISTANCE:
-                        case EVDEV_ABS_WHEEL:
+                        case evdev::abs_x:
+                        case evdev::abs_y:
+                        case evdev::abs_z:
+                        case evdev::abs_pressure:
+                        case evdev::abs_tilt_x:
+                        case evdev::abs_tilt_y:
+                        case evdev::abs_distance:
+                        case evdev::abs_wheel:
                             axis = evdev_usage_to_axis(ev.usage);
                             if (axis == LIBINPUT_TABLET_TOOL_AXIS_NONE)
                             {
@@ -14900,21 +14857,21 @@ namespace netxs::lixx // li++, libinput++.
                                 tablet.status |= TABLET_AXES_UPDATED;
                             }
                             break;
-                        case EVDEV_ABS_MISC: // tool_id is the identifier for the tool we can use in libwacom to identify it (if we have one anyway).
+                        case evdev::abs_misc: // tool_id is the identifier for the tool we can use in libwacom to identify it (if we have one anyway).
                             tablet.current_tool.id = ev.value;
                             break;
                         // Intuos 3 strip data. Should only happen on the Pad device, not on the Pen device.
-                        case EVDEV_ABS_RX:
-                        case EVDEV_ABS_RY:
-                        case EVDEV_ABS_RZ: // Only on the 4D mouse (Intuos2), obsolete.
+                        case evdev::abs_rx:
+                        case evdev::abs_ry:
+                        case evdev::abs_rz: // Only on the 4D mouse (Intuos2), obsolete.
                         // Only on the 4D mouse (Intuos2), obsolete. The 24HD sends ABS_THROTTLE on the Pad device for the second wheel but we shouldn't get here on kernel >= 3.17.
-                        case EVDEV_ABS_THROTTLE:
+                        case evdev::abs_throttle:
                         default: log("Unhandled ABS event code %#x%", ev.usage); break;
                     }
                 }
                 void tablet_process_relative([[maybe_unused]] libinput_device_sptr li_device, evdev_event& ev, [[maybe_unused]] time now)
                 {
-                    if (evdev_usage_enum(ev.usage) == EVDEV_REL_WHEEL)
+                    if (ev.usage == evdev::rel_wheel)
                     {
                         auto axis = evdev_usage_to_axis(ev.usage);
                         if (axis == LIBINPUT_TABLET_TOOL_AXIS_NONE)
@@ -14942,35 +14899,35 @@ namespace netxs::lixx // li++, libinput++.
                 void tablet_process_key([[maybe_unused]] libinput_device_sptr li_device, evdev_event& ev, [[maybe_unused]] time now)
                 {
                     if (ev.value == 2) return; // Ignore kernel key repeat.
-                    auto usage = evdev_usage_enum(ev.usage);
+                    auto usage = ev.usage;
                     switch (usage)
                     {
-                        case EVDEV_BTN_TOOL_FINGER: log("Invalid tool 'finger' on tablet interface"); break;
-                        case EVDEV_BTN_TOOL_PEN:      _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_PEN);      break;
-                        case EVDEV_BTN_TOOL_RUBBER:   _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_ERASER);   break;
-                        case EVDEV_BTN_TOOL_BRUSH:    _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_BRUSH);    break;
-                        case EVDEV_BTN_TOOL_PENCIL:   _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_PENCIL);   break;
-                        case EVDEV_BTN_TOOL_AIRBRUSH: _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_AIRBRUSH); break;
-                        case EVDEV_BTN_TOOL_MOUSE:    _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_MOUSE);    break;
-                        case EVDEV_BTN_TOOL_LENS:     _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_LENS);     break;
-                        case EVDEV_BTN_TOUCH:
+                        case evdev::btn_tool_finger: log("Invalid tool 'finger' on tablet interface"); break;
+                        case evdev::btn_tool_pen:      _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_PEN);      break;
+                        case evdev::btn_tool_rubber:   _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_ERASER);   break;
+                        case evdev::btn_tool_brush:    _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_BRUSH);    break;
+                        case evdev::btn_tool_pencil:   _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_PENCIL);   break;
+                        case evdev::btn_tool_airbrush: _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_AIRBRUSH); break;
+                        case evdev::btn_tool_mouse:    _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_MOUSE);    break;
+                        case evdev::btn_tool_lens:     _tablet_set_state(ev, LIBINPUT_TABLET_TOOL_TYPE_LENS);     break;
+                        case evdev::btn_touch:
                             if (!tablet.axis_caps_bits[LIBINPUT_TABLET_TOOL_AXIS_PRESSURE])
                             {
                                 if (ev.value) tablet.status |= TABLET_TOOL_ENTERING_CONTACT;
                                 else          tablet.status |= TABLET_TOOL_LEAVING_CONTACT;
                             }
                             break;
-                        case EVDEV_BTN_LEFT:
-                        case EVDEV_BTN_RIGHT:
-                        case EVDEV_BTN_MIDDLE:
-                        case EVDEV_BTN_SIDE:
-                        case EVDEV_BTN_EXTRA:
-                        case EVDEV_BTN_FORWARD:
-                        case EVDEV_BTN_BACK:
-                        case EVDEV_BTN_TASK:
-                        case EVDEV_BTN_STYLUS:
-                        case EVDEV_BTN_STYLUS2:
-                        case EVDEV_BTN_STYLUS3:
+                        case evdev::btn_left:
+                        case evdev::btn_right:
+                        case evdev::btn_middle:
+                        case evdev::btn_side:
+                        case evdev::btn_extra:
+                        case evdev::btn_forward:
+                        case evdev::btn_back:
+                        case evdev::btn_task:
+                        case evdev::btn_stylus:
+                        case evdev::btn_stylus2:
+                        case evdev::btn_stylus3:
                             if (ev.value)
                             {
                                 tablet.next_button_state.set(evdev_usage_code(usage));
@@ -14987,10 +14944,10 @@ namespace netxs::lixx // li++, libinput++.
                 }
                 void tablet_process_misc([[maybe_unused]] libinput_device_sptr li_device, evdev_event& ev, [[maybe_unused]] time now)
                 {
-                    switch (evdev_usage_enum(ev.usage))
+                    switch (ev.usage)
                     {
-                        case EVDEV_MSC_SERIAL: if (ev.value != -1) tablet.current_tool.serial = ev.value; break;
-                        case EVDEV_MSC_SCAN: break;
+                        case evdev::msc_serial: if (ev.value != -1) tablet.current_tool.serial = ev.value; break;
+                        case evdev::msc_scan: break;
                         default: log("Unhandled MSC event code 'type=%% code='%%'", evdev_usage_type(ev.usage), evdev_usage_code(ev.usage)); break;
                     }
                 }
@@ -16265,7 +16222,7 @@ namespace netxs::lixx // li++, libinput++.
                 }
             void tablet_process(libinput_device_sptr li_device, evdev_event& ev, time stamp)
             {
-                auto type = evdev_event_type_f(ev);
+                auto type = evdev_usage_type(ev.usage);
                 switch (type)
                 {
                     case EV_ABS: tablet_process_absolute(   li_device, ev, stamp); break;
@@ -16277,7 +16234,7 @@ namespace netxs::lixx // li++, libinput++.
                                  tablet_reset_state();
                                  tablet.quirks.last_event_time = stamp;
                                  break;
-                    default: log("Unexpected event type %s% (%#x%)", evdev_event_get_type_name(ev), evdev_event_type_f(ev)); break;
+                    default: log("Unexpected event type %s% (%#x%)", libevdev_event_type_get_name(evdev_usage_type(ev.usage)), evdev_usage_type(ev.usage)); break;
                 }
             }
             void tablet_suspend(libinput_device_sptr li_device)
@@ -16658,8 +16615,8 @@ namespace netxs::lixx // li++, libinput++.
                     tablet.quirks.proximity_out_in_progress = true;
                     auto ev_events = std::to_array<evdev_event>(
                     {
-                        { .usage = evdev_usage_from(EVDEV_BTN_TOOL_PEN) },
-                        { .usage = evdev_usage_from(EVDEV_SYN_REPORT)   }
+                        { .usage = evdev::btn_tool_pen },
+                        { .usage = evdev::syn_report   }
                     });
                     for (auto& ev : ev_events)
                     {
@@ -16863,8 +16820,8 @@ namespace netxs::lixx // li++, libinput++.
             fallback_dispatch& fallback{ dispatch };
                         bool fallback_reject_relative(libinput_device_sptr li_device, evdev_event const& ev, [[maybe_unused]] time now)
                         {
-                            auto usage = evdev_usage_enum(ev.usage);
-                            if ((usage == EVDEV_REL_X || usage == EVDEV_REL_Y) && (li_device->device_caps & EVDEV_DEVICE_POINTER) == 0)
+                            auto usage = ev.usage;
+                            if ((usage == evdev::rel_x || usage == evdev::rel_y) && (li_device->device_caps & EVDEV_DEVICE_POINTER) == 0)
                             {
                                 log("REL_X/Y from a non-pointer device");
                                 return true;
@@ -16971,10 +16928,10 @@ namespace netxs::lixx // li++, libinput++.
                             void wheel_handle_direction_change(evdev_event& ev, time stamp)
                             {
                                 auto new_dir = WHEEL_DIR_UNKNOW;
-                                switch (evdev_usage_enum(ev.usage))
+                                switch (ev.usage)
                                 {
-                                    case EVDEV_REL_WHEEL_HI_RES:  new_dir = (ev.value > 0) ? WHEEL_DIR_VPOS : WHEEL_DIR_VNEG; break;
-                                    case EVDEV_REL_HWHEEL_HI_RES: new_dir = (ev.value > 0) ? WHEEL_DIR_HPOS : WHEEL_DIR_HNEG; break;
+                                    case evdev::rel_wheel_hi_res:  new_dir = (ev.value > 0) ? WHEEL_DIR_VPOS : WHEEL_DIR_VNEG; break;
+                                    case evdev::rel_hwheel_hi_res: new_dir = (ev.value > 0) ? WHEEL_DIR_HPOS : WHEEL_DIR_HNEG; break;
                                     default: return;
                                 }
                                 if (new_dir != WHEEL_DIR_UNKNOW && new_dir != fallback.wheel.dir)
@@ -16985,23 +16942,23 @@ namespace netxs::lixx // li++, libinput++.
                             }
                         void fallback_wheel_process_relative(libinput_device_sptr li_device, evdev_event& ev, time stamp)
                         {
-                            switch (evdev_usage_enum(ev.usage))
+                            switch (ev.usage)
                             {
-                                case EVDEV_REL_WHEEL:
+                                case evdev::rel_wheel:
                                     fallback_rotate_wheel(li_device, ev);
                                     fallback.wheel.lo_res.y += ev.value;
                                     if (fallback.wheel.emulate_hi_res_wheel) fallback.wheel.hi_res.y += ev.value * 120;
                                     fallback.pending_event = (evdev_event_type)(fallback.pending_event | EVDEV_WHEEL);
                                     wheel_handle_event(WHEEL_EVENT_SCROLL, stamp);
                                     break;
-                                case EVDEV_REL_HWHEEL:
+                                case evdev::rel_hwheel:
                                     fallback_rotate_wheel(li_device, ev);
                                     fallback.wheel.lo_res.x += ev.value;
                                     if (fallback.wheel.emulate_hi_res_wheel) fallback.wheel.hi_res.x += ev.value * 120;
                                     fallback.pending_event = (evdev_event_type)(fallback.pending_event | EVDEV_WHEEL);
                                     wheel_handle_event(WHEEL_EVENT_SCROLL, stamp);
                                     break;
-                                case EVDEV_REL_WHEEL_HI_RES:
+                                case evdev::rel_wheel_hi_res:
                                     fallback_rotate_wheel(li_device, ev);
                                     fallback.wheel.hi_res.y += ev.value;
                                     fallback.wheel.hi_res_event_received = true;
@@ -17009,7 +16966,7 @@ namespace netxs::lixx // li++, libinput++.
                                     wheel_handle_direction_change(ev, stamp);
                                     wheel_handle_event(WHEEL_EVENT_SCROLL, stamp);
                                     break;
-                                case EVDEV_REL_HWHEEL_HI_RES:
+                                case evdev::rel_hwheel_hi_res:
                                     fallback_rotate_wheel(li_device, ev);
                                     fallback.wheel.hi_res.x += ev.value;
                                     fallback.wheel.hi_res_event_received = true;
@@ -17025,13 +16982,13 @@ namespace netxs::lixx // li++, libinput++.
                     {
                         if (fallback_reject_relative(li_device, ev, stamp))
                             return;
-                        switch (evdev_usage_enum(ev.usage))
+                        switch (ev.usage)
                         {
-                            case EVDEV_REL_X:
+                            case evdev::rel_x:
                                 fallback.rel.x += ev.value;
                                 fallback.pending_event = (evdev_event_type)(fallback.pending_event | EVDEV_RELATIVE_MOTION);
                                 break;
-                            case EVDEV_REL_Y:
+                            case evdev::rel_y:
                                 fallback.rel.y += ev.value;
                                 fallback.pending_event = (evdev_event_type)(fallback.pending_event | EVDEV_RELATIVE_MOTION);
                                 break;
@@ -17042,9 +16999,9 @@ namespace netxs::lixx // li++, libinput++.
                         void fallback_process_touch(libinput_device_sptr li_device, evdev_event& ev, [[maybe_unused]] time now)
                         {
                             auto& slot = fallback.mt.slots[fallback.mt.slot];
-                            switch (evdev_usage_enum(ev.usage))
+                            switch (ev.usage)
                             {
-                                case EVDEV_ABS_MT_SLOT:
+                                case evdev::abs_mt_slot:
                                     if ((ui64)ev.value >= fallback.mt.slots.size())
                                     {
                                         log("exceeded slot count (%d% of max %zd%)", ev.value, fallback.mt.slots.size());
@@ -17052,7 +17009,7 @@ namespace netxs::lixx // li++, libinput++.
                                     }
                                     fallback.mt.slot = ev.value;
                                     return;
-                                case EVDEV_ABS_MT_TRACKING_ID:
+                                case evdev::abs_mt_tracking_id:
                                     if (ev.value >= 0)
                                     {
                                         fallback.pending_event = (evdev_event_type)(fallback.pending_event | EVDEV_ABSOLUTE_MT);
@@ -17083,19 +17040,19 @@ namespace netxs::lixx // li++, libinput++.
                                     }
                                     slot.dirty = true;
                                     break;
-                                case EVDEV_ABS_MT_POSITION_X:
+                                case evdev::abs_mt_position_x:
                                     li_device->evdev_device_check_abs_axis_range(ev.usage, ev.value);
                                     fallback.mt.slots[fallback.mt.slot].point.x = ev.value;
                                     fallback.pending_event = (evdev_event_type)(fallback.pending_event | EVDEV_ABSOLUTE_MT);
                                     slot.dirty = true;
                                     break;
-                                case EVDEV_ABS_MT_POSITION_Y:
+                                case evdev::abs_mt_position_y:
                                     li_device->evdev_device_check_abs_axis_range(ev.usage, ev.value);
                                     fallback.mt.slots[fallback.mt.slot].point.y = ev.value;
                                     fallback.pending_event = (evdev_event_type)(fallback.pending_event | EVDEV_ABSOLUTE_MT);
                                     slot.dirty = true;
                                     break;
-                                case EVDEV_ABS_MT_TOOL_TYPE:
+                                case evdev::abs_mt_tool_type:
                                     // The transitions matter - we (may) need to send a touch cancel event if we just switched to a palm touch. And the kernel may switch back to finger but we keep the touch as palm - but then we need to reset correctly on a new touch sequence.
                                     switch (ev.value)
                                     {
@@ -17110,14 +17067,14 @@ namespace netxs::lixx // li++, libinput++.
                         }
                         void fallback_process_absolute_motion(libinput_device_sptr li_device, evdev_event& ev)
                         {
-                            switch (evdev_usage_enum(ev.usage))
+                            switch (ev.usage)
                             {
-                                case EVDEV_ABS_X:
+                                case evdev::abs_x:
                                     li_device->evdev_device_check_abs_axis_range(ev.usage, ev.value);
                                     fallback.abs.point.x = ev.value;
                                     fallback.pending_event = (evdev_event_type)(fallback.pending_event | EVDEV_ABSOLUTE_MOTION);
                                     break;
-                                case EVDEV_ABS_Y:
+                                case evdev::abs_y:
                                     li_device->evdev_device_check_abs_axis_range(ev.usage, ev.value);
                                     fallback.abs.point.y = ev.value;
                                     fallback.pending_event = (evdev_event_type)(fallback.pending_event | EVDEV_ABSOLUTE_MOTION);
@@ -17137,31 +17094,31 @@ namespace netxs::lixx // li++, libinput++.
                         }
                         key_type get_key_type(ui32 evdev_usage)
                         {
-                            switch (evdev_usage_enum(evdev_usage))
+                            switch (evdev_usage)
                             {
-                                case EVDEV_BTN_TOOL_PEN:
-                                case EVDEV_BTN_TOOL_RUBBER:
-                                case EVDEV_BTN_TOOL_BRUSH:
-                                case EVDEV_BTN_TOOL_PENCIL:
-                                case EVDEV_BTN_TOOL_AIRBRUSH:
-                                case EVDEV_BTN_TOOL_MOUSE:
-                                case EVDEV_BTN_TOOL_LENS:
-                                case EVDEV_BTN_TOOL_QUINTTAP:
-                                case EVDEV_BTN_TOOL_DOUBLETAP:
-                                case EVDEV_BTN_TOOL_TRIPLETAP:
-                                case EVDEV_BTN_TOOL_QUADTAP:
-                                case EVDEV_BTN_TOOL_FINGER:
-                                case EVDEV_BTN_TOUCH:
+                                case evdev::btn_tool_pen:
+                                case evdev::btn_tool_rubber:
+                                case evdev::btn_tool_brush:
+                                case evdev::btn_tool_pencil:
+                                case evdev::btn_tool_airbrush:
+                                case evdev::btn_tool_mouse:
+                                case evdev::btn_tool_lens:
+                                case evdev::btn_tool_quinttap:
+                                case evdev::btn_tool_doubletap:
+                                case evdev::btn_tool_tripletap:
+                                case evdev::btn_tool_quadtap:
+                                case evdev::btn_tool_finger:
+                                case evdev::btn_touch:
                                     return KEY_TYPE_NONE;
                                 default: break;
                             }
-                            auto usage = evdev_usage_enum(evdev_usage);
-                            if (usage >= EVDEV_KEY_ESC && usage <= EVDEV_KEY_MICMUTE) return KEY_TYPE_KEY;
-                            if (usage >= EVDEV_BTN_MISC && usage <= EVDEV_BTN_GEAR_UP) return KEY_TYPE_BUTTON;
-                            if (usage >= EVDEV_KEY_OK && usage <= EVDEV_KEY_LIGHTS_TOGGLE) return KEY_TYPE_KEY;
-                            if (usage >= EVDEV_BTN_DPAD_UP && usage <= EVDEV_BTN_DPAD_RIGHT) return KEY_TYPE_BUTTON;
-                            if (usage >= EVDEV_KEY_ALS_TOGGLE && usage < EVDEV_BTN_TRIGGER_HAPPY) return KEY_TYPE_KEY;
-                            if (usage >= EVDEV_BTN_TRIGGER_HAPPY && usage <= EVDEV_BTN_TRIGGER_HAPPY40) return KEY_TYPE_BUTTON;
+                            auto usage = evdev_usage;
+                            if (usage >= evdev::key_esc           && usage <= evdev::key_micmute        ) return KEY_TYPE_KEY;
+                            if (usage >= evdev::btn_misc          && usage <= evdev::btn_gear_up        ) return KEY_TYPE_BUTTON;
+                            if (usage >= evdev::key_ok            && usage <= evdev::key_lights_toggle  ) return KEY_TYPE_KEY;
+                            if (usage >= evdev::btn_dpad_up       && usage <= evdev::btn_dpad_right     ) return KEY_TYPE_BUTTON;
+                            if (usage >= evdev::key_als_toggle    && usage <  evdev::btn_trigger_happy  ) return KEY_TYPE_KEY;
+                            if (usage >= evdev::btn_trigger_happy && usage <= evdev::btn_trigger_happy40) return KEY_TYPE_BUTTON;
                             return KEY_TYPE_NONE;
                         }
                         bool hw_is_key_down(ui32 usage)
@@ -17170,7 +17127,7 @@ namespace netxs::lixx // li++, libinput++.
                             auto code = evdev_usage_code(usage);
                             return fallback.next_hw_key_mask[code];
                         }
-                            ui32 update_seat_key_count(libinput_seat_sptr seat, keycode_t keycode, libinput_key_state state)
+                            ui32 update_seat_key_count(libinput_seat_sptr seat, ui32 keycode, libinput_key_state state)
                             {
                                 assert(keycode <= KEY_MAX);
                                 auto& key_count = seat->button_count[keycode];
@@ -17190,23 +17147,17 @@ namespace netxs::lixx // li++, libinput++.
                             auto code = evdev_usage_code(usage);
                             fallback.next_hw_key_mask.set(code, pressed);
                         }
-                            void keyboard_notify_key(libinput_device_sptr li_device, time stamp, keycode_t keycode, libinput_key_state state)
+                            void keyboard_notify_key(libinput_device_sptr li_device, time stamp, ui32 keycode, libinput_key_state state)
                             {
                                 if (li_device->device_has_cap(LIBINPUT_DEVICE_CAP_KEYBOARD))
                                 {
                                     auto seat_key_count = update_seat_key_count(li_device->seat, keycode, state);
                                     auto& key_event = li_device->seat->libinput->libinput_emplace_event<libinput_event_keyboard>();
-                                    key_event.key            = (ui32)keycode;
+                                    key_event.key            = keycode;
                                     key_event.seat_key_count = seat_key_count;
                                     key_event.state          = state;
                                     li_device->post_device_event(stamp, LIBINPUT_EVENT_KEYBOARD_KEY, key_event);
                                 }
-                            }
-                            keycode_t keycode_from_usage(ui32 usage)
-                            {
-                                assert(evdev_usage_type(usage) == EV_KEY);
-                                auto code = evdev_usage_code(usage);
-                                return keycode_t{ code };
                             }
                         void fallback_keyboard_notify_key(libinput_device_sptr li_device, time stamp, ui32 usage, libinput_key_state state)
                         {
@@ -17214,13 +17165,13 @@ namespace netxs::lixx // li++, libinput++.
                             if ((state == LIBINPUT_KEY_STATE_PRESSED  && down_count == 1)
                              || (state == LIBINPUT_KEY_STATE_RELEASED && down_count == 0))
                             {
-                                keyboard_notify_key(li_device, stamp, keycode_from_usage(usage), state);
+                                keyboard_notify_key(li_device, stamp, evdev_usage_code(usage), state);
                             }
                         }
                     void fallback_process_key(libinput_device_sptr li_device, evdev_event& ev, time stamp)
                     {
                         if (ev.value == 2) return; // Ignore kernel key repeat.
-                        if (ev.usage == EVDEV_BTN_TOUCH)
+                        if (ev.usage == evdev::btn_touch)
                         {
                             if (!li_device->is_mt)
                             {
@@ -17252,15 +17203,13 @@ namespace netxs::lixx // li++, libinput++.
                             case KEY_TYPE_BUTTON: break;
                         }
                     }
-                                        ::input_event input_event_init(time stamp, ui32 type, ui32 code, si32 value)
+                                        input_event_t input_event_init(time stamp, ui32 type, ui32 code, si32 value)
                                         {
                                             auto tval = time2tv(stamp);
-                                            auto event = ::input_event
-                                            {
-                                                .type  = (ui16)type,
-                                                .code  = (ui16)code,
-                                                .value = value,
-                                            };
+                                            auto event = input_event_t{};
+                                            event.type             = (ui16)type;
+                                            event.code             = (ui16)code;
+                                            event.value            = value;
                                             event.input_event_sec  = tval.tv_sec;
                                             event.input_event_usec = tval.tv_usec;
                                             return event;
@@ -17292,7 +17241,7 @@ namespace netxs::lixx // li++, libinput++.
                                             if (fallback.lid.reliability == RELIABILITY_WRITE_OPEN)
                                             {
                                                 auto fd = fallback.li_device->libevdev_get_fd();
-                                                auto events = std::array<::input_event, 2>{};
+                                                auto events = std::array<input_event_t, 2>{};
                                                 events[0] = fallback.fallback_impl.input_event_init(time{}, EV_SW, SW_LID, 0);
                                                 events[1] = fallback.fallback_impl.input_event_init(time{}, EV_SYN, SYN_REPORT, 0);
                                                 auto rc = write(fd, events.data(), sizeof(events));
@@ -17341,9 +17290,9 @@ namespace netxs::lixx // li++, libinput++.
                             auto state = libinput_switch_state{};
                             auto is_closed = faux;
                             //todo: this should to move to handle_state.
-                            switch (evdev_usage_enum(ev.usage))
+                            switch (ev.usage)
                             {
-                                case EVDEV_SW_LID:
+                                case evdev::sw_lid:
                                     is_closed = !!ev.value;
                                     fallback_lid_toggle_keyboard_listeners(is_closed);
                                     if (fallback.lid.is_closed != is_closed)
@@ -17352,7 +17301,7 @@ namespace netxs::lixx // li++, libinput++.
                                         fallback_lid_notify_toggle(li_device, stamp);
                                     }
                                     break;
-                                case EVDEV_SW_TABLET_MODE:
+                                case evdev::sw_tablet_mode:
                                     if (fallback.tablet_mode.sw.state != ev.value)
                                     {
                                         fallback.tablet_mode.sw.state = ev.value;
@@ -18058,7 +18007,7 @@ namespace netxs::lixx // li++, libinput++.
                             auto changed = std::array<ui32, 16>{}; // Usage of changed buttons.
                             auto nchanged = 0ul;
                             auto flushed = faux;
-                            for (auto usage = evdev_usage_from(EVDEV_KEY_RESERVED); usage <= EVDEV_KEY_MAX; usage = evdev_usage_next(usage))
+                            for (auto usage = evdev::key_reserved; usage <= evdev::key_max; usage++)
                             {
                                 if (get_key_type(usage) == KEY_TYPE_BUTTON)
                                 {
@@ -18145,7 +18094,7 @@ namespace netxs::lixx // li++, libinput++.
                         if (fallback.pending_event & EVDEV_KEY)
                         {
                             auto want_debounce = faux;
-                            for (auto usage = evdev_usage_from(EVDEV_KEY_RESERVED); usage <= EVDEV_KEY_MAX; usage = evdev_usage_next(usage))
+                            for (auto usage = evdev::key_reserved; usage <= evdev::key_max; usage++)
                             {
                                 if (hw_key_has_changed(usage) && get_key_type(usage) == KEY_TYPE_BUTTON)
                                 {
@@ -18171,7 +18120,7 @@ namespace netxs::lixx // li++, libinput++.
                         return;
                     }
                     warned = faux;
-                    auto type = evdev_event_type_f(ev);
+                    auto type = evdev_usage_type(ev.usage);
                     switch (type)
                     {
                         case EV_REL: fallback_process_relative(li_device, ev, stamp); break;
@@ -18219,7 +18168,7 @@ namespace netxs::lixx // li++, libinput++.
                             }
                         void release_pressed_keys(libinput_device_sptr li_device, time stamp)
                         {
-                            for (auto usage = evdev_usage_from(EVDEV_KEY_RESERVED); usage <= EVDEV_KEY_MAX; usage = evdev_usage_next(usage))
+                            for (auto usage = evdev::key_reserved; usage <= evdev::key_max; usage++)
                             {
                                 auto count = get_key_down_count(li_device, usage);
                                 if (count == 0) continue;
@@ -18237,7 +18186,7 @@ namespace netxs::lixx // li++, libinput++.
                                 count = get_key_down_count(li_device, usage);
                                 if (count != 0)
                                 {
-                                    log("releasing key %d% failed", evdev_usage_enum(usage));
+                                    log("releasing key %d% failed", usage);
                                     break;
                                 }
                             }
@@ -18583,7 +18532,7 @@ namespace netxs::lixx // li++, libinput++.
             }
                 bool fallback_any_button_down(libinput_device_sptr li_device)
                 {
-                    for (auto usage = evdev_usage_from(EVDEV_BTN_LEFT); usage < EVDEV_BTN_JOYSTICK; usage = evdev_usage_next(usage))
+                    for (auto usage = evdev::btn_left; usage < evdev::btn_joystick; usage++)
                     {
                         if (li_device->libevdev_has_event_code<EV_KEY>(evdev_usage_code(usage))
                          && fallback.fallback_impl.hw_is_key_down(usage))
@@ -20066,7 +20015,7 @@ namespace netxs::lixx // li++, libinput++.
             {
                 li_device->evdev_init_left_handed(fallback_dispatch::fallback_impl_t::fallback_change_to_left_handed);
             }
-            if (evdev_usage_enum(li_device->scroll.want_button))
+            if (li_device->scroll.want_button)
             {
                 li_device->evdev_init_button_scroll(fallback_dispatch::fallback_impl_t::fallback_change_scroll_method);
             }
@@ -20742,7 +20691,7 @@ namespace netxs::lixx // li++, libinput++.
                                         }
                                         return found;
                                     }
-                                bool parse_evcode_property(view prop, ::input_event* events, ui64& nevents)
+                                bool parse_evcode_property(view prop, input_event_t* events, ui64& nevents)
                                 {
                                     // Parses a string of the format "+EV_ABS;+KEY_A;-BTN_TOOL_DOUBLETAP;-ABS_X;"
                                     // where each element must be + or - (enable/disable) followed by a named event
@@ -20761,7 +20710,7 @@ namespace netxs::lixx // li++, libinput++.
                                     // On success, events contains nevents events with each event's value set to 1
                                     // or 0 depending on the + or - prefix.
                                     auto rc = true;
-                                    auto evs = std::array<::input_event, 32>{}; // A randomly chosen max so we avoid crazy quirks.
+                                    auto evs = std::array<input_event_t, 32>{}; // A randomly chosen max so we avoid crazy quirks.
                                     auto strv = utf::split(prop, ";");
                                     auto ncodes = (ui64)strv.size();
                                     if (strv.empty() || ncodes > evs.size())
@@ -21044,7 +20993,7 @@ namespace netxs::lixx // li++, libinput++.
                                 }
                                 else if (key == quirk_get_name(QUIRK_ATTR_EVENT_CODE))
                                 {
-                                    auto events = std::array<::input_event, 32>{};
+                                    auto events = std::array<input_event_t, 32>{};
                                     auto nevents = (ui64)events.size();
                                     p->id = QUIRK_ATTR_EVENT_CODE;
                                     if (parse_evcode_property(value, events.data(), nevents) && nevents != 0)

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -55,78 +55,6 @@ namespace netxs::lixx // li++, libinput++.
         #define log(...) noop()
     #endif
 
-    // For the Lenovo X230 custom accel. do not touch.
-    static constexpr auto x230_threshold                        = datetime::round<fp64, std::chrono::microseconds>(400us); // In units/us.
-    static constexpr auto x230_acceleration                     = 2.0; // Unitless factor.
-    static constexpr auto x230_incline                          = 1.1; // Unitless factor.
-    static constexpr auto x230_magic_slowdown                   = 0.4; // Unitless.
-    static constexpr auto x230_tp_magic_low_res_factor          = 4.0; // Unitless.
-
-    static constexpr auto libinput_accel_npoints_min            = 2;
-    static constexpr auto libinput_accel_npoints_max            = 64; // Custom acceleration function max number of points an arbitrary limit of sample points it should be more than enough for everyone.
-    static constexpr auto libinput_accel_step_max               = 10000;
-    static constexpr auto libinput_accel_point_min_value        = 0;
-    static constexpr auto libinput_accel_point_max_value        = 10000;
-
-    static constexpr auto max_velocity_diff                     = datetime::round<fp64, std::chrono::microseconds>(1ms); // Units/us.
-    static constexpr auto middlebutton_timeout                  = 50ms;
-    static constexpr auto debounce_timeout_bounce               = 25ms;
-    static constexpr auto debounce_timeout_spurious             = 12ms;
-    static constexpr auto wheel_scroll_timeout                  = 500ms;
-    static constexpr auto default_keyboard_activity_timeout_1   = 200ms;
-    static constexpr auto default_keyboard_activity_timeout_2   = 500ms;
-    static constexpr auto default_trackpoint_event_timeout      = 40ms;
-    static constexpr auto default_trackpoint_activity_timeout   = 300ms;
-    static constexpr auto default_draglock_timeout_period       = 300ms;
-    static constexpr auto default_drag_timeout_period_base      = 160ms;
-    static constexpr auto default_drag_timeout_period_perfinger = 20ms;
-    static constexpr auto default_tap_timeout_period            = 300ms; // Old laptops can't handle double taps with an interval of <200ms.
-    static constexpr auto timer_warning_limit                   = 20ms; // We only warn if we're more than 20ms behind.
-    static constexpr auto motion_timeout                        = 1000ms;
-    static constexpr auto first_motion_time_interval            = 7ms;  // Random but good enough interval for very first event.
-    static auto           forced_proxout_timeout                = 50ms; // The tablet sends events every ~2ms , 50ms should be plenty enough to detect out-of-range. This value is higher during test suite runs.
-    static constexpr auto palm_timeout                          = 200ms;
-    static constexpr auto thumb_timeout                         = 100ms;
-    static constexpr auto default_button_enter_timeout          = 100ms;
-    static constexpr auto default_button_leave_timeout          = 300ms;
-    static constexpr auto default_button_scroll_timeout         = 200ms;
-    static constexpr auto default_scroll_lock_timeout           = 300ms;
-    static constexpr auto default_gesture_hold_timeout          = 180ms;
-    static constexpr auto default_gesture_switch_timeout        = 100ms;
-    static constexpr auto default_gesture_swipe_timeout         = 150ms;
-    static constexpr auto default_gesture_pinch_timeout         = 300ms;
-    static constexpr auto quick_gesture_hold_timeout            = 40ms;
-    static constexpr auto active_threshold                      = 100ms;
-    static constexpr auto inactive_threshold                    = 50ms;
-    static constexpr auto default_scroll_event_timeout          = 100ms;
-    static constexpr auto minimum_acceleration_threshold        = datetime::round<fp64, std::chrono::microseconds>(200us); // In units/us.
-    static constexpr auto default_acceleration_threshold        = datetime::round<fp64, std::chrono::microseconds>(400us); // In units/us.
-    static constexpr auto default_acceleration                  = 2.0; // Unitless factor.
-    static constexpr auto default_incline                       = 1.1; // Unitless factor.
-    static constexpr auto fake_finger_overflow                  = 1ul << 7;
-    static constexpr auto touchpad_history_length               = 4;
-    static constexpr auto default_mouse_dpi                     = 1000;
-    static constexpr auto vendor_id_apple                       = 0x5ac;
-    static constexpr auto vendor_id_chicony                     = 0x4f2;
-    static constexpr auto vendor_id_logitech                    = 0x46d;
-    static constexpr auto vendor_id_wacom                       = 0x56a;
-    static constexpr auto vendor_id_synaptics_serial            = 0x002;
-    static constexpr auto product_id_apple_kbd_touchpad         = 0x273;
-    static constexpr auto product_id_apple_appletouch           = 0x21a;
-    static constexpr auto product_id_synaptics_serial           = 0x007;
-    static constexpr auto product_id_wacom_ekr                  = 0x0331;
-    consteval auto mm_to_dpi_normalized(auto mm) { return lixx::default_mouse_dpi / 25.4 * mm; }
-    static constexpr auto default_scroll_threshold              = lixx::mm_to_dpi_normalized(3);
-    static constexpr auto default_wheel_click_angle             = 15;
-    static constexpr auto event_code_undefined                  = 0xffff;
-    static constexpr auto thumb_ignore_speed_threshold          = 20; // mm/s.
-    static constexpr auto default_tap_move_threshold            = 1.3; // mm.
-    static constexpr auto pinch_disambiguation_move_threshold   = 1.5; // mm.
-    static constexpr auto tp_magic_slowdown_flat                = 0.2968;
-    static constexpr auto tp_magic_slowdown                     = 0.2968; // Unitless factor.
-    static constexpr auto hold_and_motion_threshold             = 0.5; // mm.
-    static constexpr auto tablet_history_length                 = 4;
-
     enum read_flags
     {
         LIBEVDEV_READ_FLAG_SYNC       = 1 << 0,
@@ -159,25 +87,6 @@ namespace netxs::lixx // li++, libinput++.
         LIBEVDEV_READ_STATUS_SUCCESS,
         LIBEVDEV_READ_STATUS_SYNC,
     };
-
-    static constexpr auto clock_type     = CLOCK_MONOTONIC;
-    static constexpr auto max_slots      = 0x100;
-    static constexpr auto min_queue_size = 0x100;
-    static constexpr auto abs_mt_min     = ABS_MT_SLOT;
-    static constexpr auto abs_mt_max     = ABS_MT_TOOL_Y;
-    static constexpr auto abs_mt_cnt     = lixx::abs_mt_max - lixx::abs_mt_min + 1;
-    static constexpr auto valid_flags    = LIBEVDEV_READ_FLAG_NORMAL | LIBEVDEV_READ_FLAG_SYNC | LIBEVDEV_READ_FLAG_FORCE_SYNC | LIBEVDEV_READ_FLAG_BLOCKING;
-
-    static constexpr fp64 v_us2ms(fp64 units_per_us) { return units_per_us * 1000.0; }
-    static constexpr fp64 v_us2s(fp64 units_per_us)  { return units_per_us * 1000000.0; }
-    static constexpr ::timeval time2tv(time t)
-    {
-        auto sec  = datetime::round<si64, std::chrono::seconds>(t);
-        auto usec = datetime::round<si64, std::chrono::microseconds>(t - std::chrono::seconds{ sec });
-        auto tv = ::timeval{ .tv_sec = (decltype(timeval::tv_sec))sec, .tv_usec = (decltype(timeval::tv_usec))usec };
-        return tv;
-    }
-
     enum libinput_dispatch_type
     {
         DISPATCH_FALLBACK,
@@ -808,9 +717,6 @@ namespace netxs::lixx // li++, libinput++.
 
     template<auto t, auto c>
     static constexpr auto _evbit = (t << 16) | c;
-    using button_code_t = ui32;
-    using keycode_t     = ui32;
-
     enum evdev_usage : ui32 // This is an enum to have the compiler help us a bit. The enum doesn't need to contain all event codes, only the ones we use in libinput - add to here as required.      * The order doesn't matter either since each enum value is just the type | code value anyway, keep it in somewhat logical groups where possible.
     {
         EVDEV_SYN_REPORT          = _evbit<EV_SYN, SYN_REPORT>,
@@ -907,7 +813,6 @@ namespace netxs::lixx // li++, libinput++.
         LIBINPUT_TABLET_TOOL_TYPE_LENS,     // A mouse tool with a lens.
         LIBINPUT_TABLET_TOOL_TYPE_TOTEM,    // A rotary device with positional and rotation data.
     };
-    static constexpr auto LIBINPUT_TABLET_TOOL_TYPE_MAX = LIBINPUT_TABLET_TOOL_TYPE_LENS;
     enum libinput_tablet_tool_axis
     {
         LIBINPUT_TABLET_TOOL_AXIS_NONE       = 0,
@@ -923,7 +828,6 @@ namespace netxs::lixx // li++, libinput++.
         LIBINPUT_TABLET_TOOL_AXIS_SIZE_MAJOR = 10,
         LIBINPUT_TABLET_TOOL_AXIS_SIZE_MINOR = 11,
     };
-    static constexpr auto LIBINPUT_TABLET_TOOL_AXIS_MAX = LIBINPUT_TABLET_TOOL_AXIS_SIZE_MINOR;
     enum pressure_heuristic_state
     {
         PRESSURE_HEURISTIC_STATE_PROXIN1, // First proximity in event.
@@ -1044,6 +948,103 @@ namespace netxs::lixx // li++, libinput++.
         BUTTON_STATE_IGNORE,
     };
 
+    static constexpr auto libinput_tablet_tool_type_min = LIBINPUT_TABLET_TOOL_TYPE_PEN;
+    static constexpr auto libinput_tablet_tool_type_max = LIBINPUT_TABLET_TOOL_TYPE_LENS;
+    static constexpr auto libinput_tablet_tool_axis_cnt = LIBINPUT_TABLET_TOOL_AXIS_SIZE_MINOR + 1;
+
+    // For the Lenovo X230 custom accel. do not touch.
+    static constexpr auto x230_threshold                        = datetime::round<fp64, std::chrono::microseconds>(400us); // In units/us.
+    static constexpr auto x230_acceleration                     = 2.0; // Unitless factor.
+    static constexpr auto x230_incline                          = 1.1; // Unitless factor.
+    static constexpr auto x230_magic_slowdown                   = 0.4; // Unitless.
+    static constexpr auto x230_tp_magic_low_res_factor          = 4.0; // Unitless.
+
+    static constexpr auto libinput_accel_npoints_min            = 2;
+    static constexpr auto libinput_accel_npoints_max            = 64; // Custom acceleration function max number of points an arbitrary limit of sample points it should be more than enough for everyone.
+    static constexpr auto libinput_accel_step_max               = 10000;
+    static constexpr auto libinput_accel_point_min_value        = 0;
+    static constexpr auto libinput_accel_point_max_value        = 10000;
+
+    static constexpr auto max_velocity_diff                     = datetime::round<fp64, std::chrono::microseconds>(1ms); // Units/us.
+    static constexpr auto middlebutton_timeout                  = 50ms;
+    static constexpr auto debounce_timeout_bounce               = 25ms;
+    static constexpr auto debounce_timeout_spurious             = 12ms;
+    static constexpr auto wheel_scroll_timeout                  = 500ms;
+    static constexpr auto default_keyboard_activity_timeout_1   = 200ms;
+    static constexpr auto default_keyboard_activity_timeout_2   = 500ms;
+    static constexpr auto default_trackpoint_event_timeout      = 40ms;
+    static constexpr auto default_trackpoint_activity_timeout   = 300ms;
+    static constexpr auto default_draglock_timeout_period       = 300ms;
+    static constexpr auto default_drag_timeout_period_base      = 160ms;
+    static constexpr auto default_drag_timeout_period_perfinger = 20ms;
+    static constexpr auto default_tap_timeout_period            = 300ms; // Old laptops can't handle double taps with an interval of <200ms.
+    static constexpr auto timer_warning_limit                   = 20ms; // We only warn if we're more than 20ms behind.
+    static constexpr auto motion_timeout                        = 1000ms;
+    static constexpr auto first_motion_time_interval            = 7ms;  // Random but good enough interval for very first event.
+    static auto           forced_proxout_timeout                = 50ms; // The tablet sends events every ~2ms , 50ms should be plenty enough to detect out-of-range. This value is higher during test suite runs.
+    static constexpr auto palm_timeout                          = 200ms;
+    static constexpr auto thumb_timeout                         = 100ms;
+    static constexpr auto default_button_enter_timeout          = 100ms;
+    static constexpr auto default_button_leave_timeout          = 300ms;
+    static constexpr auto default_button_scroll_timeout         = 200ms;
+    static constexpr auto default_scroll_lock_timeout           = 300ms;
+    static constexpr auto default_gesture_hold_timeout          = 180ms;
+    static constexpr auto default_gesture_switch_timeout        = 100ms;
+    static constexpr auto default_gesture_swipe_timeout         = 150ms;
+    static constexpr auto default_gesture_pinch_timeout         = 300ms;
+    static constexpr auto quick_gesture_hold_timeout            = 40ms;
+    static constexpr auto active_threshold                      = 100ms;
+    static constexpr auto inactive_threshold                    = 50ms;
+    static constexpr auto default_scroll_event_timeout          = 100ms;
+    static constexpr auto minimum_acceleration_threshold        = datetime::round<fp64, std::chrono::microseconds>(200us); // In units/us.
+    static constexpr auto default_acceleration_threshold        = datetime::round<fp64, std::chrono::microseconds>(400us); // In units/us.
+    static constexpr auto default_acceleration                  = 2.0; // Unitless factor.
+    static constexpr auto default_incline                       = 1.1; // Unitless factor.
+    static constexpr auto fake_finger_overflow                  = 1ul << 7;
+    static constexpr auto touchpad_history_length               = 4;
+    static constexpr auto default_mouse_dpi                     = 1000;
+    static constexpr auto vendor_id_apple                       = 0x5ac;
+    static constexpr auto vendor_id_chicony                     = 0x4f2;
+    static constexpr auto vendor_id_logitech                    = 0x46d;
+    static constexpr auto vendor_id_wacom                       = 0x56a;
+    static constexpr auto vendor_id_synaptics_serial            = 0x002;
+    static constexpr auto product_id_apple_kbd_touchpad         = 0x273;
+    static constexpr auto product_id_apple_appletouch           = 0x21a;
+    static constexpr auto product_id_synaptics_serial           = 0x007;
+    static constexpr auto product_id_wacom_ekr                  = 0x0331;
+    consteval auto mm_to_dpi_normalized(auto mm) { return lixx::default_mouse_dpi / 25.4 * mm; }
+    static constexpr auto default_scroll_threshold              = lixx::mm_to_dpi_normalized(3);
+    static constexpr auto default_wheel_click_angle             = 15;
+    static constexpr auto event_code_undefined                  = 0xffff;
+    static constexpr auto thumb_ignore_speed_threshold          = 20; // mm/s.
+    static constexpr auto default_tap_move_threshold            = 1.3; // mm.
+    static constexpr auto pinch_disambiguation_move_threshold   = 1.5; // mm.
+    static constexpr auto tp_magic_slowdown_flat                = 0.2968;
+    static constexpr auto tp_magic_slowdown                     = 0.2968; // Unitless factor.
+    static constexpr auto hold_and_motion_threshold             = 0.5; // mm.
+    static constexpr auto tablet_history_length                 = 4;
+
+    static constexpr auto clock_type     = CLOCK_MONOTONIC;
+    static constexpr auto max_slots      = 0x100;
+    static constexpr auto min_queue_size = 0x100;
+    static constexpr auto abs_mt_min     = ABS_MT_SLOT;
+    static constexpr auto abs_mt_max     = ABS_MT_TOOL_Y;
+    static constexpr auto abs_mt_cnt     = lixx::abs_mt_max - lixx::abs_mt_min + 1;
+    static constexpr auto valid_flags    = LIBEVDEV_READ_FLAG_NORMAL | LIBEVDEV_READ_FLAG_SYNC | LIBEVDEV_READ_FLAG_FORCE_SYNC | LIBEVDEV_READ_FLAG_BLOCKING;
+
+    static constexpr fp64 v_us2ms(fp64 units_per_us) { return units_per_us * 1000.0; }
+    static constexpr fp64 v_us2s(fp64 units_per_us)  { return units_per_us * 1000000.0; }
+    static constexpr ::timeval time2tv(time t)
+    {
+        auto sec  = datetime::round<si64, std::chrono::seconds>(t);
+        auto usec = datetime::round<si64, std::chrono::microseconds>(t - std::chrono::seconds{ sec });
+        auto tv = ::timeval{ .tv_sec = (decltype(timeval::tv_sec))sec, .tv_usec = (decltype(timeval::tv_usec))usec };
+        return tv;
+    }
+
+    using button_code_t = ui32;
+    using keycode_t     = ui32;
+
     using fp64_range = netxs::limits<fp64>;
     using si32_range = netxs::limits<si32>;
     using fp64_rect  = netxs::xysz<fp64>;
@@ -1058,7 +1059,7 @@ namespace netxs::lixx // li++, libinput++.
     using libinput_device_sptr = sptr<struct libinput_device_t>;
 
     using button_state_t = std::bitset<KEY_CNT>;
-    using tablet_axes_bitset = std::bitset<LIBINPUT_TABLET_TOOL_AXIS_MAX + 1>;
+    using tablet_axes_bitset = std::bitset<lixx::libinput_tablet_tool_axis_cnt>;
 
     struct matrix
     {
@@ -14926,8 +14927,8 @@ namespace netxs::lixx // li++, libinput++.
         si32_coor                            last_smooth_point;
         history_t                            history;
         tablet_axes_bitset                   axis_caps_bits;
-        si32                                 current_value[LIBINPUT_TABLET_TOOL_AXIS_MAX + 1];
-        si32                                 prev_value[LIBINPUT_TABLET_TOOL_AXIS_MAX + 1];
+        si32                                 current_value[lixx::libinput_tablet_tool_axis_cnt];
+        si32                                 prev_value[lixx::libinput_tablet_tool_axis_cnt];
         std::list<libinput_tablet_tool_sptr> tool_list; // Only used for tablets that don't report serial numbers.
         button_state_t                       next_button_state;
         button_state_t                       prev_button_state;
@@ -16482,7 +16483,7 @@ namespace netxs::lixx // li++, libinput++.
                 auto li = tablet.li_device->li_context();
                 auto state = 0;
                 auto tool = libinput_tablet_tool_type{};
-                for (tool = LIBINPUT_TABLET_TOOL_TYPE_PEN; tool <= LIBINPUT_TABLET_TOOL_TYPE_MAX; tool = (libinput_tablet_tool_type)(tool + 1))
+                for (tool = lixx::libinput_tablet_tool_type_min; tool <= lixx::libinput_tablet_tool_type_max; tool = (libinput_tablet_tool_type)(tool + 1))
                 {
                     auto code = tablet_tool_to_evcode(tool);
                     // We only expect one tool to be in proximity at a time.

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -5185,19 +5185,19 @@ namespace netxs::lixx // li++, libinput++.
         virtual ~evdev_dispatch_t()
         { }
 
-        virtual                  void                       process([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] evdev_event& event, [[maybe_unused]] time now)                                                                           { } // Process an evdev input event.
-        virtual                  void                       suspend([[maybe_unused]] libinput_device_sptr li_device)                                                                                                                                           { } // Device is being suspended.
-        virtual                  void                        remove()                                                                                                                                                                                          { } // Device is being removed (may be nullptr).
-        virtual                  void                       destroy()                                                                                                                                                                                          { } // Destroy an event dispatch handler and free all its resources.
-        virtual                  void                  device_added([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr added_li_device)                                                                                    { } // A new device was added.
-        virtual                  void                device_removed([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr removed_li_device)                                                                                  { } // A device was removed.
-        virtual                  void              device_suspended([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr suspended_li_device)                                                                                { } // A device was suspended.
-        virtual                  void                device_resumed([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr resumed_li_device)                                                                                  { } // A device was resumed.
-        virtual                  void                    post_added([[maybe_unused]] libinput_device_sptr li_device)                                                                                                                                           { } // Called immediately after the LIBINPUT_EVENT_DEVICE_ADDED event was sent.
-        virtual                  void      touch_arbitration_toggle([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_arbitration_state which, [[maybe_unused]] phys_rect const* area/* may be nullptr */, [[maybe_unused]] time now) { } // For touch arbitration, called on the device that should enable/disable touch capabilities.
-        virtual                  void touch_arbitration_update_rect([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] phys_rect const* area, [[maybe_unused]] time now)                                                                        { } // Called when touch arbitration is on, updates the area where touch arbitration should apply.
-        virtual libinput_switch_state              get_switch_state([[maybe_unused]] libinput_switch which)                                                                                                                                                    { return libinput_switch_state{}; } // Return the state of the given switch.
-        virtual                  void            left_handed_toggle([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] bool left_handed_enabled)                                                                                                { }
+        virtual                  void                       process([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] evdev_event& event, [[maybe_unused]] time now)                                                { } // Process an evdev input event.
+        virtual                  void                       suspend([[maybe_unused]] libinput_device_sptr li_device)                                                                                                                { } // Device is being suspended.
+        virtual                  void                        remove()                                                                                                                                                               { } // Device is being removed (may be nullptr).
+        virtual                  void                       destroy()                                                                                                                                                               { } // Destroy an event dispatch handler and free all its resources.
+        virtual                  void                  device_added([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr added_li_device)                                                         { } // A new device was added.
+        virtual                  void                device_removed([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr removed_li_device)                                                       { } // A device was removed.
+        virtual                  void              device_suspended([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr suspended_li_device)                                                     { } // A device was suspended.
+        virtual                  void                device_resumed([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_device_sptr resumed_li_device)                                                       { } // A device was resumed.
+        virtual                  void                    post_added([[maybe_unused]] libinput_device_sptr li_device)                                                                                                                { } // Called immediately after the LIBINPUT_EVENT_DEVICE_ADDED event was sent.
+        virtual                  void      touch_arbitration_toggle([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] libinput_arbitration_state which, [[maybe_unused]] phys_rect area, [[maybe_unused]] time now) { } // For touch arbitration, called on the device that should enable/disable touch capabilities.
+        virtual                  void touch_arbitration_update_rect([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] phys_rect area, [[maybe_unused]] time now)                                                    { } // Called when touch arbitration is on, updates the area where touch arbitration should apply.
+        virtual libinput_switch_state              get_switch_state([[maybe_unused]] libinput_switch which)                                                                                                                         { return libinput_switch_state{}; } // Return the state of the given switch.
+        virtual                  void            left_handed_toggle([[maybe_unused]] libinput_device_sptr li_device, [[maybe_unused]] bool left_handed_enabled)                                                                     { }
     };
 
     // Helpers
@@ -12556,7 +12556,7 @@ namespace netxs::lixx // li++, libinput++.
                     tp_change_rotation(li_device, DO_NOTIFY);
                 }
             }
-            void tp_interface_toggle_touch([[maybe_unused]] libinput_device_sptr li_device, libinput_arbitration_state which, [[maybe_unused]] phys_rect const* area, time stamp)
+            void tp_interface_toggle_touch([[maybe_unused]] libinput_device_sptr li_device, libinput_arbitration_state which, [[maybe_unused]] phys_rect area, time stamp)
             {
                 if (which == tp.arbitration.state) return;
                 switch (which)
@@ -13853,15 +13853,15 @@ namespace netxs::lixx // li++, libinput++.
         };
 
         tp_impl_t tp_impl{ *this };
-        void                  process(libinput_device_sptr li_device, evdev_event& ev, time stamp)                                       { tp_impl.        tp_interface_process(li_device, ev, stamp); }
-        void                  suspend(libinput_device_sptr li_device)                                                                    { tp_impl.        tp_interface_suspend(li_device); }
-        void                   remove()                                                                                                  { tp_impl.         tp_interface_remove(); }
-        void             device_added(libinput_device_sptr li_device, libinput_device_sptr added_li_device)                              { tp_impl.   tp_interface_device_added(li_device, added_li_device); }
-        void           device_removed(libinput_device_sptr li_device, libinput_device_sptr removed_li_device)                            { tp_impl. tp_interface_device_removed(li_device, removed_li_device); }
-        void       left_handed_toggle(libinput_device_sptr li_device, bool left_handed_enabled)                                          { tp_impl.touchpad_left_handed_toggled(li_device, left_handed_enabled); }
-        void touch_arbitration_toggle(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect const* area, time now) { tp_impl.   tp_interface_toggle_touch(li_device, which, area, now); }
-        void         device_suspended(libinput_device_sptr li_device, libinput_device_sptr suspended_li_device)                          { device_removed(li_device, suspended_li_device); }
-        void           device_resumed(libinput_device_sptr li_device, libinput_device_sptr resumed_li_device)                            { device_added(li_device, resumed_li_device); }
+        void                  process(libinput_device_sptr li_device, evdev_event& ev, time stamp)                                { tp_impl.        tp_interface_process(li_device, ev, stamp); }
+        void                  suspend(libinput_device_sptr li_device)                                                             { tp_impl.        tp_interface_suspend(li_device); }
+        void                   remove()                                                                                           { tp_impl.         tp_interface_remove(); }
+        void             device_added(libinput_device_sptr li_device, libinput_device_sptr added_li_device)                       { tp_impl.   tp_interface_device_added(li_device, added_li_device); }
+        void           device_removed(libinput_device_sptr li_device, libinput_device_sptr removed_li_device)                     { tp_impl. tp_interface_device_removed(li_device, removed_li_device); }
+        void       left_handed_toggle(libinput_device_sptr li_device, bool left_handed_enabled)                                   { tp_impl.touchpad_left_handed_toggled(li_device, left_handed_enabled); }
+        void touch_arbitration_toggle(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect area, time now) { tp_impl.   tp_interface_toggle_touch(li_device, which, area, now); }
+        void         device_suspended(libinput_device_sptr li_device, libinput_device_sptr suspended_li_device)                   { device_removed(li_device, suspended_li_device); }
+        void           device_resumed(libinput_device_sptr li_device, libinput_device_sptr resumed_li_device)                     { device_added(li_device, resumed_li_device); }
     };
     using tp_dispatch_sptr = sptr<tp_dispatch>;
 
@@ -14886,15 +14886,15 @@ namespace netxs::lixx // li++, libinput++.
                 auto dispatch = touch_device->dispatch;
                 if (enable_touch_device)
                 {
-                    dispatch->touch_arbitration_toggle(touch_device, state, &r, now);
+                    dispatch->touch_arbitration_toggle(touch_device, state, r, now);
                 }
                 else
                 {
                     switch (totem.arbitration_state)
                     {
                         case ARBITRATION_IGNORE_ALL: ::abort();
-                        case ARBITRATION_NOT_ACTIVE:  dispatch->touch_arbitration_toggle(touch_device, state, &r, now); break;
-                        case ARBITRATION_IGNORE_RECT: dispatch->touch_arbitration_update_rect(touch_device, &r, now); break;
+                        case ARBITRATION_NOT_ACTIVE:  dispatch->touch_arbitration_toggle(touch_device, state, r, now); break;
+                        case ARBITRATION_IGNORE_RECT: dispatch->touch_arbitration_update_rect(touch_device, r, now); break;
                     }
                 }
                 totem.arbitration_state = state;
@@ -16253,9 +16253,9 @@ namespace netxs::lixx // li++, libinput++.
                         {
                             if (tablet.touch_li_device && tablet.arbitration == ARBITRATION_IGNORE_RECT)
                             {
-                                auto rect = tablet_calculate_arbitration_rect();
+                                auto area = tablet_calculate_arbitration_rect();
                                 auto dispatch = tablet.touch_li_device->dispatch;
-                                dispatch->touch_arbitration_update_rect(tablet.touch_li_device, &rect, stamp);
+                                dispatch->touch_arbitration_update_rect(tablet.touch_li_device, area, stamp);
                             }
                         }
                             void tablet_reset_changed_axes()
@@ -16570,7 +16570,7 @@ namespace netxs::lixx // li++, libinput++.
                         if (!process_tool_twice) break;
                     }
                 }
-                    void tablet_set_touch_device_enabled(libinput_arbitration_state which, phys_rect const* area, time stamp)
+                    void tablet_set_touch_device_enabled(libinput_arbitration_state which, phys_rect area, time stamp)
                     {
                         if (auto touch_li_device = tablet.touch_li_device)
                         {
@@ -16600,7 +16600,7 @@ namespace netxs::lixx // li++, libinput++.
                     {
                         return;
                     }
-                    tablet_set_touch_device_enabled(which, &r, stamp);
+                    tablet_set_touch_device_enabled(which, r, stamp);
                 }
                 void tablet_reset_state()
                 {
@@ -16631,7 +16631,7 @@ namespace netxs::lixx // li++, libinput++.
             {
                 auto li = tablet.li_device->li_context();
                 auto now = datetime::now();
-                tablet_set_touch_device_enabled(ARBITRATION_NOT_ACTIVE, nullptr, now);
+                tablet_set_touch_device_enabled(ARBITRATION_NOT_ACTIVE, phys_rect{}, now);
                 if (!(tablet.status & TABLET_TOOL_OUT_OF_PROXIMITY))
                 {
                     tablet.status |= TABLET_TOOL_LEAVING_PROXIMITY;
@@ -16650,7 +16650,7 @@ namespace netxs::lixx // li++, libinput++.
                         {
                             // We found a better device, let's swap it out.
                             auto li = tablet.li_device->li_context();
-                            tablet_set_touch_device_enabled(ARBITRATION_NOT_ACTIVE, nullptr, datetime::now());
+                            tablet_set_touch_device_enabled(ARBITRATION_NOT_ACTIVE, phys_rect{}, datetime::now());
                             log("touch-arbitration: removing pairing for %s%<->%s%", li_device->devname, tablet.touch_li_device->devname);
                         }
                         else
@@ -18649,7 +18649,7 @@ namespace netxs::lixx // li++, libinput++.
                         switch_notify_toggle(li_device, stamp, LIBINPUT_SWITCH_TABLET_MODE, LIBINPUT_SWITCH_STATE_ON);
                     }
                 }
-                    device_coord_rect evdev_phys_rect_to_units(libinput_device_sptr li_device, phys_rect const* mm)
+                    device_coord_rect evdev_phys_rect_to_units(libinput_device_sptr li_device, phys_rect mm)
                     {
                         auto units = device_coord_rect{};
                         if (li_device->abs.absinfo_x == nullptr || li_device->abs.absinfo_y == nullptr)
@@ -18659,20 +18659,19 @@ namespace netxs::lixx // li++, libinput++.
                         }
                         auto absx = li_device->abs.absinfo_x;
                         auto absy = li_device->abs.absinfo_y;
-                        units.x = mm->x * absx->resolution + absx->minimum;
-                        units.y = mm->y * absy->resolution + absy->minimum;
-                        units.w = mm->w * absx->resolution;
-                        units.h = mm->h * absy->resolution;
+                        units.x = mm.x * absx->resolution + absx->minimum;
+                        units.y = mm.y * absy->resolution + absy->minimum;
+                        units.w = mm.w * absx->resolution;
+                        units.h = mm.h * absy->resolution;
                         return units;
                     }
-                void fallback_interface_update_rect(libinput_device_sptr li_device, phys_rect const* phys_area, [[maybe_unused]] time now)
+                void fallback_interface_update_rect(libinput_device_sptr li_device, phys_rect phys_area, [[maybe_unused]] time now)
                 {
-                    assert(phys_area);
                     // Existing touches do not change, we just update the rect and only new touches in these areas will be ignored. If you want to paint over your finger, be my guest.
                     auto area = evdev_phys_rect_to_units(li_device, phys_area);
                     fallback.arbitration.area = area;
                 }
-                void fallback_interface_toggle_touch(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect const* phys_area, time stamp)
+                void fallback_interface_toggle_touch(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect phys_area, time stamp)
                 {
                     auto area = device_coord_rect{};
                     [[maybe_unused]] auto state = (char const*)nullptr;
@@ -18685,7 +18684,6 @@ namespace netxs::lixx // li++, libinput++.
                             state = "not-active";
                             break;
                         case ARBITRATION_IGNORE_RECT:
-                            assert(phys_area);
                             area = evdev_phys_rect_to_units(li_device, phys_area);
                             cancel_touches(li_device, &area, stamp);
                             fallback.arbitration.area = area;
@@ -19046,17 +19044,17 @@ namespace netxs::lixx // li++, libinput++.
         };
 
         fallback_impl_t fallback_impl{ *this };
-        void                           process(libinput_device_sptr li_device, evdev_event& ev, time now)                                                             { fallback_impl.                fallback_interface_process(li_device, ev, now); }
-        void                           suspend(libinput_device_sptr li_device)                                                                                        { fallback_impl.                fallback_interface_suspend(li_device); }
-        void                            remove()                                                                                                                      { fallback_impl.                 fallback_interface_remove(); }
-        void                      device_added(libinput_device_sptr li_device, libinput_device_sptr added_li_device)                                                  { fallback_impl.           fallback_interface_device_added(li_device, added_li_device); }
-        void                    device_removed(libinput_device_sptr li_device, libinput_device_sptr removed_li_device)                                                { fallback_impl.         fallback_interface_device_removed(li_device, removed_li_device); }
-        void                  device_suspended(libinput_device_sptr li_device, libinput_device_sptr suspended_li_device)                                              { fallback_impl.         fallback_interface_device_removed(li_device, suspended_li_device); }
-        void                    device_resumed(libinput_device_sptr li_device, libinput_device_sptr resumed_li_device)                                                { fallback_impl.           fallback_interface_device_added(li_device, resumed_li_device); }
-        void                        post_added(libinput_device_sptr li_device)                                                                                        { fallback_impl.     fallback_interface_sync_initial_state(li_device); }
-        void          touch_arbitration_toggle(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect const* area/* may be nullptr */, time now) { fallback_impl.           fallback_interface_toggle_touch(li_device, which, area, now) ; }
-        void     touch_arbitration_update_rect(libinput_device_sptr li_device, phys_rect const* area, time now)                                                       { fallback_impl.            fallback_interface_update_rect(li_device, area, now); }
-        libinput_switch_state get_switch_state(libinput_switch which)                                                                                                 { return fallback_impl.fallback_interface_get_switch_state(which); }
+        void                           process(libinput_device_sptr li_device, evdev_event& ev, time now)                                  { fallback_impl.                fallback_interface_process(li_device, ev, now); }
+        void                           suspend(libinput_device_sptr li_device)                                                             { fallback_impl.                fallback_interface_suspend(li_device); }
+        void                            remove()                                                                                           { fallback_impl.                 fallback_interface_remove(); }
+        void                      device_added(libinput_device_sptr li_device, libinput_device_sptr added_li_device)                       { fallback_impl.           fallback_interface_device_added(li_device, added_li_device); }
+        void                    device_removed(libinput_device_sptr li_device, libinput_device_sptr removed_li_device)                     { fallback_impl.         fallback_interface_device_removed(li_device, removed_li_device); }
+        void                  device_suspended(libinput_device_sptr li_device, libinput_device_sptr suspended_li_device)                   { fallback_impl.         fallback_interface_device_removed(li_device, suspended_li_device); }
+        void                    device_resumed(libinput_device_sptr li_device, libinput_device_sptr resumed_li_device)                     { fallback_impl.           fallback_interface_device_added(li_device, resumed_li_device); }
+        void                        post_added(libinput_device_sptr li_device)                                                             { fallback_impl.     fallback_interface_sync_initial_state(li_device); }
+        void          touch_arbitration_toggle(libinput_device_sptr li_device, libinput_arbitration_state which, phys_rect area, time now) { fallback_impl.           fallback_interface_toggle_touch(li_device, which, area, now) ; }
+        void     touch_arbitration_update_rect(libinput_device_sptr li_device, phys_rect area, time now)                                   { fallback_impl.            fallback_interface_update_rect(li_device, area, now); }
+        libinput_switch_state get_switch_state(libinput_switch which)                                                                      { return fallback_impl.fallback_interface_get_switch_state(which); }
     };
     using fallback_dispatch_sptr = sptr<fallback_dispatch>;
 

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -1336,14 +1336,6 @@ namespace netxs::lixx // li++, libinput++.
         };
 
     // Helpers
-    bool parse_boolean_property(view prop, bool& b)
-    {
-        if (prop.empty()) return faux;
-        else if (prop == "1") b = true;
-        else if (prop == "0") b = faux;
-        else return faux;
-        return true;
-    }
     fp64_coor normalize_for_dpi(fp64_coor coor, si32 dpi)
     {
         auto norm = coor * lixx::default_mouse_dpi / dpi;
@@ -3734,13 +3726,7 @@ namespace netxs::lixx // li++, libinput++.
         }
         bool parse_udev_flag(view property)
         {
-            auto b = faux;
-            if (auto val = udev_device_get_property_value(property))
-            if (!parse_boolean_property(val, b))
-            {
-                log("property %s% has invalid value '%s%'", property, val);
-            }
-            return b;
+            return udev_device_get_property_value(property) == "1";
         }
         evdev_ud_device_tags evdev_device_get_udev_tags()
         {
@@ -20686,10 +20672,9 @@ namespace netxs::lixx // li++, libinput++.
                             }
                             bool parse_model(section_sptr s, view key, view value)
                             {
-                                auto b = faux;
+                                auto b = value == "1";
                                 auto q = QUIRK_MODEL_ALPS_SERIAL_TOUCHPAD;
                                 assert(key.starts_with("Model"));
-                                if (!parse_boolean_property(value.data(), b)) return faux;
                                 do
                                 {
                                     if (key == quirk_get_name(q))
@@ -21032,22 +21017,16 @@ namespace netxs::lixx // li++, libinput++.
                                 else if (key == quirk_get_name(QUIRK_ATTR_USE_VELOCITY_AVERAGING))
                                 {
                                     p->id = QUIRK_ATTR_USE_VELOCITY_AVERAGING;
-                                    if (parse_boolean_property(value, b))
-                                    {
-                                        p->type = PT_BOOL;
-                                        p->value.b = b;
-                                        rc = true;
-                                    }
+                                    p->type = PT_BOOL;
+                                    p->value.b = value == "1";
+                                    rc = true;
                                 }
                                 else if (key == quirk_get_name(QUIRK_ATTR_TABLET_SMOOTHING))
                                 {
                                     p->id = QUIRK_ATTR_TABLET_SMOOTHING;
-                                    if (parse_boolean_property(value, b))
-                                    {
-                                        p->type = PT_BOOL;
-                                        p->value.b = b;
-                                        rc = true;
-                                    }
+                                    p->type = PT_BOOL;
+                                    p->value.b = value == "1";
+                                    rc = true;
                                 }
                                 else if (key == quirk_get_name(QUIRK_ATTR_THUMB_PRESSURE_THRESHOLD))
                                 {
@@ -21117,12 +21096,9 @@ namespace netxs::lixx // li++, libinput++.
                                 else if (key == quirk_get_name(QUIRK_ATTR_IS_VIRTUAL))
                                 {
                                     p->id = QUIRK_ATTR_IS_VIRTUAL;
-                                    if (parse_boolean_property(value, b))
-                                    {
-                                        p->type = PT_BOOL;
-                                        p->value.b = b;
-                                        rc = true;
-                                    }
+                                    p->type = PT_BOOL;
+                                    p->value.b = value == "1";
+                                    rc = true;
                                 }
                                 else
                                 {

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -1444,6 +1444,7 @@ namespace netxs::lixx // li++, libinput++.
         result.y = d.y >= 0 ? in.y - lag_y : in.y + lag_y;
         return result;
     }
+
     fp64 absinfo_range(::input_absinfo const* abs)
     {
         return (fp64)(abs->maximum - abs->minimum + 1);
@@ -1473,6 +1474,7 @@ namespace netxs::lixx // li++, libinput++.
         auto value = v - absinfo->minimum;
         return value / absinfo->resolution;
     }
+
     char const* event_type_to_str(libinput_event_type type)
     {
         switch(type)
@@ -3666,7 +3668,7 @@ namespace netxs::lixx // li++, libinput++.
         si32 libevdev_get_event_value(ui32 type, ui32 code)
         {
             auto value = 0;
-            if (libevdev_has_event_type(type) && libevdev_has_event_code(type, code))
+            if (libevdev_has_event_code(type, code))
             {
                      if (type == EV_ABS) value = abs_values[code].value;
                 else if (type == EV_KEY) value = key_values[code];
@@ -3986,15 +3988,6 @@ namespace netxs::lixx // li++, libinput++.
                 return 0;
             }
             return -1;
-        }
-        si32 libevdev_fetch_event_value(ui32 type, ui32 code, si32& value)
-        {
-            if (libevdev_has_event_type(type) && libevdev_has_event_code(type, code))
-            {
-                value = libevdev_get_event_value(type, code);
-                return 1;
-            }
-            return 0;
         }
         si32 libevdev_fetch_slot_value(ui32 slot, ui32 code, si32& value)
         {
@@ -6325,10 +6318,6 @@ namespace netxs::lixx // li++, libinput++.
         bool parse_udev_flag(view property)
         {
             return ud_device->parse_udev_flag(property);
-        }
-        si32 libevdev_fetch_event_value(ui32 type, ui32 code, si32& value)
-        {
-            return ud_device->libevdev_fetch_event_value(type, code, value);
         }
         si32 libevdev_next_event(ui32 flags, ::input_event& ev)
         {
@@ -16447,8 +16436,8 @@ namespace netxs::lixx // li++, libinput++.
                 for (tool = lixx::libinput_tablet_tool_type_min; tool <= lixx::libinput_tablet_tool_type_max; tool = (libinput_tablet_tool_type)(tool + 1))
                 {
                     auto code = tablet_tool_to_evcode(tool);
-                    // We only expect one tool to be in proximity at a time.
-                    if (li_device->libevdev_fetch_event_value(EV_KEY, code, state) && state)
+                    state = li_device->libevdev_get_event_value(EV_KEY, code);
+                    if (state) // We only expect one tool to be in proximity at a time.
                     {
                         tablet.tool_state = (1ul << tool);
                         tablet.prev_tool_state = (1ul << tool);

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -1051,6 +1051,7 @@ namespace netxs::lixx // li++, libinput++.
     using fp64_coor  = netxs::xy2d<fp64>;
     using si32_rect  = netxs::xysz<si32>;
     using si32_coor  = netxs::xy2d<si32>;
+    static constexpr auto zero_coor = fp64_coor{};
 
     using fd_t = os::fd_t;
 
@@ -9071,8 +9072,7 @@ namespace netxs::lixx // li++, libinput++.
                                                         }
                                                     void gesture_notify_hold_begin(libinput_device_sptr li_device, time stamp, si32 finger_count)
                                                     {
-                                                        static constexpr auto zero = fp64_coor{};
-                                                        gesture_notify(li_device, stamp, LIBINPUT_EVENT_GESTURE_HOLD_BEGIN, finger_count, 0, zero, zero, 0.0, 0.0);
+                                                        gesture_notify(li_device, stamp, LIBINPUT_EVENT_GESTURE_HOLD_BEGIN, finger_count, 0, lixx::zero_coor, lixx::zero_coor, 0.0, 0.0);
                                                     }
                                                         fp64_coor device_float_average(fp64_coor a, fp64_coor b)
                                                         {
@@ -9159,8 +9159,7 @@ namespace netxs::lixx // li++, libinput++.
                                                 }
                                                     void gesture_notify_hold_end(libinput_device_sptr li_device, time stamp, si32 finger_count, bool cancelled)
                                                     {
-                                                        static constexpr const auto zero = fp64_coor{}; //todo make it static global
-                                                        gesture_notify(li_device, stamp, LIBINPUT_EVENT_GESTURE_HOLD_END, finger_count, cancelled, zero, zero, 0, 0.0);
+                                                        gesture_notify(li_device, stamp, LIBINPUT_EVENT_GESTURE_HOLD_END, finger_count, cancelled, lixx::zero_coor, lixx::zero_coor, 0, 0.0);
                                                     }
                                                         void tp_gesture_end(time stamp, gesture_cancelled cancelled)
                                                         {
@@ -9401,8 +9400,7 @@ namespace netxs::lixx // li++, libinput++.
                                                 }
                                                     void gesture_notify_pinch_end(libinput_device_sptr li_device, time stamp, si32 finger_count, fp64 scale, bool cancelled)
                                                     {
-                                                        const auto zero = fp64_coor{};
-                                                        gesture_notify(li_device, stamp, LIBINPUT_EVENT_GESTURE_PINCH_END, finger_count, cancelled, zero, zero, scale, 0.0);
+                                                        gesture_notify(li_device, stamp, LIBINPUT_EVENT_GESTURE_PINCH_END, finger_count, cancelled, lixx::zero_coor, lixx::zero_coor, scale, 0.0);
                                                     }
                                                 void tp_gesture_handle_event_on_state_pinch(gesture_event event, time stamp)
                                                 {
@@ -9456,8 +9454,7 @@ namespace netxs::lixx // li++, libinput++.
                                                 }
                                                     void gesture_notify_swipe_end(libinput_device_sptr li_device, time stamp, si32 finger_count, bool cancelled)
                                                     {
-                                                        const auto zero = fp64_coor{};
-                                                        gesture_notify(li_device, stamp, LIBINPUT_EVENT_GESTURE_SWIPE_END, finger_count, cancelled, zero, zero, 0.0, 0.0);
+                                                        gesture_notify(li_device, stamp, LIBINPUT_EVENT_GESTURE_SWIPE_END, finger_count, cancelled, lixx::zero_coor, lixx::zero_coor, 0.0, 0.0);
                                                     }
                                                 void tp_gesture_handle_event_on_state_swipe(gesture_event event, time stamp)
                                                 {
@@ -9875,12 +9872,11 @@ namespace netxs::lixx // li++, libinput++.
                                             void tp_edge_scroll_stop_events(time stamp)
                                             {
                                                 auto li_device = tp.li_device;
-                                                const auto zero = fp64_coor{};
                                                 for (auto& t : tp.touches)
                                                 {
                                                     if (t.scroll.direction != -1)
                                                     {
-                                                        li_device->evdev_notify_axis_finger(stamp, 1ul << t.scroll.direction, zero);
+                                                        li_device->evdev_notify_axis_finger(stamp, 1ul << t.scroll.direction, lixx::zero_coor);
                                                         t.scroll.direction = -1;
                                                         t.scroll.edge = EDGE_NONE; // Reset touch to area state, avoids loading the state machine with special case handling.
                                                         t.scroll.edge_state = EDGE_SCROLL_TOUCH_STATE_AREA;
@@ -11458,8 +11454,7 @@ namespace netxs::lixx // li++, libinput++.
                                             auto delta = tp_filter_motion(raw, stamp);
                                             if (delta || raw)
                                             {
-                                                const auto zero = fp64_coor{};
-                                                gesture_notify_swipe(tp.li_device, stamp, LIBINPUT_EVENT_GESTURE_SWIPE_BEGIN, tp.gesture.finger_count, zero, zero);
+                                                gesture_notify_swipe(tp.li_device, stamp, LIBINPUT_EVENT_GESTURE_SWIPE_BEGIN, tp.gesture.finger_count, lixx::zero_coor, lixx::zero_coor);
                                                 tp.gesture.state = GESTURE_STATE_SWIPE;
                                             }
                                         }
@@ -11494,7 +11489,6 @@ namespace netxs::lixx // li++, libinput++.
                                             }
                                         void tp_gesture_handle_state_pinch_start(time stamp)
                                         {
-                                            const auto zero = fp64_coor{};
                                             auto angle = 0.0;
                                             auto distance = 0.0;
                                             auto center = fp64_coor{};
@@ -11509,7 +11503,7 @@ namespace netxs::lixx // li++, libinput++.
                                             auto delta = tp_filter_motion(fdelta, stamp);
                                             if (delta || fdelta || scale != tp.gesture.prev_scale || angle_delta != 0.0)
                                             {
-                                                gesture_notify_pinch(tp.li_device, stamp, LIBINPUT_EVENT_GESTURE_PINCH_BEGIN, tp.gesture.finger_count, zero, zero, 1.0, 0.0);
+                                                gesture_notify_pinch(tp.li_device, stamp, LIBINPUT_EVENT_GESTURE_PINCH_BEGIN, tp.gesture.finger_count, lixx::zero_coor, lixx::zero_coor, 1.0, 0.0);
                                                 tp.gesture.prev_scale = scale;
                                                 tp.gesture.state = GESTURE_STATE_PINCH;
                                             }
@@ -11628,7 +11622,6 @@ namespace netxs::lixx // li++, libinput++.
                                     auto delta = (fp64*)nullptr;
                                     auto normalized = fp64_coor{};
                                     auto tmp = fp64_coor{};
-                                    const auto zero = fp64_coor{};
                                     for (auto& t : tp.touches)
                                     {
                                         if (!t.dirty) continue;
@@ -11641,7 +11634,7 @@ namespace netxs::lixx // li++, libinput++.
                                                 if (t.scroll.direction != -1)
                                                 {
                                                     // Send stop scroll event.
-                                                    device->evdev_notify_axis_finger(stamp, (1ul << t.scroll.direction), zero);
+                                                    device->evdev_notify_axis_finger(stamp, (1ul << t.scroll.direction), lixx::zero_coor);
                                                     t.scroll.direction = -1;
                                                 }
                                                 continue;
@@ -11669,7 +11662,7 @@ namespace netxs::lixx // li++, libinput++.
                                                 normalized = tp_normalize_delta(t.point - t.scroll.initial);
                                                 // Use a reasonably large threshold until locked into scrolling mode, to avoid accidentally locking in scrolling mode when trying to use the entire touchpad to move the pointer. The user can wait for the timeout to trigger to do a small scroll.
                                                 // Convert mm to a distance normalized to lixx::default_mouse_dpi.
-                                                if (::fabs(*delta) < lixx::default_scroll_threshold) normalized = zero;
+                                                if (::fabs(*delta) < lixx::default_scroll_threshold) normalized = lixx::zero_coor;
                                                 else                                                 normalized = tmp;
                                                 break;
                                             case EDGE_SCROLL_TOUCH_STATE_EDGE: break;

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -3360,7 +3360,7 @@ namespace netxs::lixx // li++, libinput++.
             //        auto filename = entry.path().filename().string();
             //        if (std::regex_match(filename, touchpad_regex))
             //        {
-            //            set ID_INPUT_TOUCHPAD_INTEGRATION=internal|external
+            //            set ID_INPUT_TOUCHPAD_INTEGRATION=internal | external
             //        }
             //        if (std::regex_match(filename, mouse_regex))
             //        {
@@ -7829,7 +7829,7 @@ namespace netxs::lixx // li++, libinput++.
                                             }
                                             tp.quirks.nonmotion_event_count = 0;
                                         }
-                                        if ((tp.queued & (TOUCHPAD_EVENT_OTHERAXIS|TOUCHPAD_EVENT_MOTION)) == TOUCHPAD_EVENT_OTHERAXIS)
+                                        if ((tp.queued & (TOUCHPAD_EVENT_OTHERAXIS | TOUCHPAD_EVENT_MOTION)) == TOUCHPAD_EVENT_OTHERAXIS)
                                         {
                                             tp.quirks.nonmotion_event_count++;
                                         }
@@ -9917,7 +9917,7 @@ namespace netxs::lixx // li++, libinput++.
                                                     case 1:
                                                     case 2:
                                                     case 3:
-                                                        button = lixx::tap_button_map[tp.buttons.map][nfingers-1];
+                                                        button = lixx::tap_button_map[tp.buttons.map][nfingers - 1];
                                                         break;
                                                     default:
                                                         button = 0;
@@ -13629,7 +13629,7 @@ namespace netxs::lixx // li++, libinput++.
                     {
                         return;
                     }
-                    if (tp.buttons.state & 0x3) // BTN_LEFT|BTN_RIGHT.
+                    if (tp.buttons.state & 0x3) // BTN_LEFT | BTN_RIGHT.
                     {
                         return;
                     }
@@ -16499,7 +16499,7 @@ namespace netxs::lixx // li++, libinput++.
                 bool tablet_is_display_tablet([[maybe_unused]] WacomDevice* wacom)
                 {
                     #if HAVE_LIBWACOM
-                    return !wacom || (::libwacom_get_integration_flags(wacom) & (WACOM_DEVICE_INTEGRATED_SYSTEM|WACOM_DEVICE_INTEGRATED_DISPLAY));
+                    return !wacom || (::libwacom_get_integration_flags(wacom) & (WACOM_DEVICE_INTEGRATED_SYSTEM | WACOM_DEVICE_INTEGRATED_DISPLAY));
                     #else
                     return true;
                     #endif

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -715,6 +715,42 @@ namespace netxs::ui
                         return { type::rgbcolor, get_color(4) };
                     }
                 }
+                else if (data.starts_with("0x")) // ; 0xbbggrr
+                {
+                    if (data.length() >= 8)
+                    {
+                        auto b1 = to_byte(data[2]);
+                        auto b2 = to_byte(data[3]);
+                        auto g1 = to_byte(data[4]);
+                        auto g2 = to_byte(data[5]);
+                        auto r1 = to_byte(data[6]);
+                        auto r2 = to_byte(data[7]);
+                        data.remove_prefix(8); // sizeof 0xbbggrr
+                        auto c = (b1 << 4 ) + (b2      )
+                               + (g1 << 12) + (g2 << 8 )
+                               + (r1 << 20) + (r2 << 16)
+                               + 0xFF000000;
+                        return { type::rgbcolor, c };
+                    }
+                }
+                else if (data.starts_with("#")) // ; #rrggbb
+                {
+                    if (data.length() >= 7)
+                    {
+                        auto r1 = to_byte(data[1]);
+                        auto r2 = to_byte(data[2]);
+                        auto g1 = to_byte(data[3]);
+                        auto g2 = to_byte(data[4]);
+                        auto b1 = to_byte(data[5]);
+                        auto b2 = to_byte(data[6]);
+                        data.remove_prefix(7); // sizeof #rrggbb
+                        auto c = (b1 << 4 ) + (b2      )
+                               + (g1 << 12) + (g2 << 8 )
+                               + (r1 << 20) + (r2 << 16)
+                               + 0xFF000000;
+                        return { type::rgbcolor, c };
+                    }
+                }
                 else // Lookup custom color names stored in settings.xml.
                 {
                     auto shadow = data;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -558,10 +558,10 @@ R"==(
                 "   LeftClick to launch instance ""\n"
                 "   RightClick to set as default "
             </tooltip_footer>
-            <Terminal    label="Terminal Emulator" title="Terminal"       tooltip="\e[1m Terminal Console                \e[m\n"|tooltip_footer/>
-            <Tile        label="Window Manager"    title="Window Manager" tooltip="\e[1m Tiling Window Manager           \e[m\n"|tooltip_footer/>
-            <Site        label="Viewport Marker"   title="Site "          tooltip="\e[1m Desktop Viewport Marker         \e[m\n"|tooltip_footer/>
-            <Logs        label="Log Monitor"       title="Log Monitor"    tooltip="\e[1m Log Monitor                     \e[m\n"|tooltip_footer/>
+            <Terminal    label="Terminal Emulator" title="Terminal"       tooltip="\e[1m Terminal Console               \e[m\n"|tooltip_footer/>
+            <Tile        label="Window Manager"    title="Window Manager" tooltip="\e[1m Tiling Window Manager          \e[m\n"|tooltip_footer/>
+            <Site        label="Viewport Marker"   title="Site "          tooltip="\e[1m Desktop Viewport Marker        \e[m\n"|tooltip_footer/>
+            <Logs        label="Log Monitor"       title="Log Monitor"    tooltip="\e[1m Log Monitor                    \e[m\n"|tooltip_footer/>
             <Grips    tooltip=" LeftDrag to adjust taskbar width "/>
             <UserList tooltip=" List of active connections ">
                 <Admins label="admins"/>

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -555,8 +555,8 @@ R"==(
                 </App>
             </Apps>
             <tooltip_footer>
-                "\e[m\n""   LeftClick to launch instance ""\n"
-                        "   RightClick to set as default "
+                "   LeftClick to launch instance ""\n"
+                "   RightClick to set as default "
             </tooltip_footer>
             <Terminal    label="Terminal Emulator" title="Terminal"       tooltip="\e[1m Terminal Console                \e[m\n"|tooltip_footer/>
             <Tile        label="Window Manager"    title="Window Manager" tooltip="\e[1m Tiling Window Manager           \e[m\n"|tooltip_footer/>


### PR DESCRIPTION
### Changes

- Fix `en-US` tooltips.
- Eliminate gaps between consecutive grip positions on scrollbar paging.
- Terminal: Add support for `#rrggbb` and `0xbbggrr` formats for OSC 4, 10-12.
- Refactor lixx.hpp (work in progress).