### PR TITLE
Allows precise (1:1) scrolling using the orthogonal axis

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.08.03b";
+    static const auto version = "v2025.08.04";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -4644,9 +4644,13 @@ namespace netxs::ui
                 scroll_len = std::max(1, new_size[Axis]);
                 m_to_s();
             }
-            void stepby(fp32 delta)
+            void stepby(fp2d delta)
             {
-                scroll_air = grip_origin + delta;
+                static constexpr auto Sixa = !Axis; // Orthogonal axis.
+                auto d1 = std::abs(delta[Axis]);
+                auto d2 = std::abs(delta[Sixa]);
+                if (d1 > d2) scroll_air = grip_origin + delta[Axis];
+                else         scroll_air = grip_origin + delta[Sixa] * r; // Allows precise (1:1) scrolling using the orthogonal axis.
                 s_to_m();
             }
             void commit(rect& handle)
@@ -4755,7 +4759,7 @@ namespace netxs::ui
                     }
                     else
                     {
-                        if (auto delta = (gear.coord - drag_origin)[Axis])
+                        if (auto delta = gear.coord - drag_origin)
                         {
                             calc.stepby(delta);
                             send<e2::form::upon::scroll::bycoor::_<Axis>>();
@@ -4775,10 +4779,10 @@ namespace netxs::ui
                     auto dir = calc.inside(twod{ gear.coord }[Axis]);
                     if (dir == 0) // Inside the grip.
                     {
-                        calc.captured = true;
                         drag_origin = gear.coord;
                         calc.m_to_s();
                         calc.grip_origin = calc.scroll_air;
+                        calc.captured = true;
                     }
                     else // Outside the grip.
                     {

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -2669,10 +2669,10 @@ namespace netxs::lixx // li++, libinput++.
                                             }
                                         }
                                         break;
-                    case M_VERSION:     if (m->version == s->match->version)                            matched_flags |= flag; break;
-                    case M_DMI:         if (::fnmatch(s->match->dmi2.data(), m->dmi2.data(), 0) == 0)   matched_flags |= flag; break;
-                    case M_DT:          if (::fnmatch(s->match->dt2.data(), m->dt2.data(), 0) == 0)     matched_flags |= flag; break;
-                    case M_UDEV_TYPE:   if (s->match->ud_type & m->ud_type)                             matched_flags |= flag; break;
+                    case M_VERSION:     if (m->version == s->match->version)                          { matched_flags |= flag; } break;
+                    case M_DMI:         if (::fnmatch(s->match->dmi2.data(), m->dmi2.data(), 0) == 0) { matched_flags |= flag; } break;
+                    case M_DT:          if (::fnmatch(s->match->dt2.data(), m->dt2.data(), 0) == 0)   { matched_flags |= flag; } break;
+                    case M_UDEV_TYPE:   if (s->match->ud_type & m->ud_type)                           { matched_flags |= flag; } break;
                     default: ::abort();
                 }
                 if (prev_matched_flags != matched_flags)


### PR DESCRIPTION
### Changes

- Allows precise (1:1) scrolling using the orthogonal axis (just drag the scrollbar grip in the perpendicular direction).