### PR TITLE
Fix scrollbar scrolling for mouse reporting with non-float coords

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.08.04";
+    static const auto version = "v2025.08.04a";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -4649,8 +4649,8 @@ namespace netxs::ui
                 static constexpr auto Sixa = !Axis; // Orthogonal axis.
                 auto d1 = std::abs(delta[Axis]);
                 auto d2 = std::abs(delta[Sixa]);
-                if (d1 > d2) scroll_air = grip_origin + delta[Axis];
-                else         scroll_air = grip_origin + delta[Sixa] * r; // Allows precise (1:1) scrolling using the orthogonal axis.
+                if (d1 >= d2) scroll_air = grip_origin + delta[Axis];
+                else          scroll_air = grip_origin + delta[Sixa] * r; // Allows precise (1:1) scrolling using the orthogonal axis.
                 s_to_m();
             }
             void commit(rect& handle)
@@ -4759,11 +4759,10 @@ namespace netxs::ui
                     }
                     else
                     {
-                        if (auto delta = gear.coord - drag_origin)
-                        {
-                            calc.stepby(delta);
-                            send<e2::form::upon::scroll::bycoor::_<Axis>>();
-                        }
+                        log("mouse move now=%% coor=%%", datetime::now(), gear.coord);
+                        auto delta = gear.coord - drag_origin;
+                        calc.stepby(delta);
+                        send<e2::form::upon::scroll::bycoor::_<Axis>>();
                     }
                     gear.dismiss();
                 }

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -4657,7 +4657,7 @@ namespace netxs::ui
             {
                 auto step = delta * r;
                 auto prev_scroll_air = scroll_air;
-                scroll_air = std::clamp(scroll_air + step, 0, (fp64)s);
+                scroll_air = std::clamp(scroll_air + step, 0.0, (fp64)s);
                 grip_origin += scroll_air - prev_scroll_air;
                 s_to_m();
             }


### PR DESCRIPTION
### Changes

- Fix scrollbar scrolling for mouse reporting with non-float coords.
- Allow precise scrolling of text line by line using the mouse wheel while holding down the mouse button.