### PR TITLE
Enable floating point (pixel-wise) mouse reporting over Win32 Console API

### DIFF
--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -703,7 +703,7 @@ namespace netxs::app::shared
             chord_block->attach_cells({ 5, 3 }, {           {}, label(skin::globals().NsInfoGeneric), label(skin::globals().NsInfoLiteral), label(skin::globals().NsInfoSpecific), label(skin::globals().NsInfoScancodes),
                                                  pressed_label, pressed[0],       pressed[1],       pressed[2],        pressed[3],
                                                 released_label, released[0],      released[1],      released[2],       released[3] });
-            released[0]->set("<Press any keys>")->hidden = faux;
+            released[0]->set(skin::globals().NsInfo_pressanykeys)->hidden = faux;
             auto& update = window_ptr->base::field([pressed, released](auto& boss, hids& gear, bool is_key_event)
             {
                 //log("vkchord=%% keyid=%% hexvkchord=%% hexscchord=%% hexchchord=%%", input::key::kmap::to_string(gear.vkchord, faux),

--- a/src/netxs/apps/test.hpp
+++ b/src/netxs/apps/test.hpp
@@ -58,7 +58,7 @@ namespace netxs::app::test
             {
                 return ansi::mgl(1).wrp(wrap::off).fgc(hdrclr).unc(whitedk).cap(caption).erl().und(unln::none).eol().fgc(txtclr).mgl(3).unc(0).wrp(wrap::on);
             };
-            return ansi::mgl(1).mgr(2).jet(bias::center)
+            auto crop = ansi::mgl(1).mgr(2).jet(bias::center)
                 .add("\n")
                 .wrp(wrap::off).fgc(hdrclr).cap(skin::globals().NsInfoSF, 3, 3, faux).eol()
                 .jet(bias::left)
@@ -260,8 +260,10 @@ namespace netxs::app::test
                 .add(header(skin::globals().NsInfoCharacterHalves))
                 .add("\n")
                 .add("😎", vss<21,11>, " 😃", vss<21,21>, "<VS21_11/VS21_21\n")
-                .add("\n")
-                .add(header(skin::globals().NsInfosRGBBlending))
+                .add("\n");
+            if constexpr (debugmode)
+            {
+                crop.add(header(skin::globals().NsInfosRGBBlending))
                 .add("\n")
                 .add(skin::globals().NsInfoPressCtrlCaps)
                 .add("\n")
@@ -275,6 +277,8 @@ namespace netxs::app::test
                 .bgc(argb{})
                 .fgc(purered).add(" test \n")
                 .fgc(purecyan).add(" test ");
+            }
+            return crop;
         };
 
         auto get_text = []

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -612,8 +612,9 @@ namespace netxs::ansi
             return *this;
         }
         template<class T>
-        auto& mouse_sgr(T const& gear, twod coor) // escx: Mouse tracking report (SGR).
+        auto& mouse_sgr(T const& gear, fp2d coor) // escx: Mouse tracking report (SGR).
         {
+            if (std::isnan(coor.x)) return *this;
             using hids = T;
             static constexpr auto left     = si32{ 0  };
             static constexpr auto mddl     = si32{ 1  };
@@ -681,13 +682,14 @@ namespace netxs::ansi
             auto count = std::max(1, std::abs(gear.m_sys.wheelsi));
             while (count--)
             {
-                add("\033[<", ctrl, ';', coor.x, ';', coor.y, pressed ? 'M' : 'm');
+                add("\033[<", ctrl, ';', (si32)coor.x, ';', (si32)coor.y, pressed ? 'M' : 'm');
             }
             return *this;
         }
         template<class T>
-        auto& mouse_x11(T const& gear, twod coor, bool utf8) // escx: Mouse tracking report (X11).
+        auto& mouse_x11(T const& gear, fp2d coor, bool utf8) // escx: Mouse tracking report (X11).
         {
+            if (std::isnan(coor.x)) return *this;
             using hids = T;
             static constexpr auto left     = si32{ 0  };
             static constexpr auto mddl     = si32{ 1  };
@@ -739,15 +741,15 @@ namespace netxs::ansi
                 if (utf8)
                 {
                     add("\033[M");
-                    utf::to_utf_from_code(std::clamp(ctrl,   0, si16max - 32) + 32, *this);
-                    utf::to_utf_from_code(std::clamp(coor.x, 1, si16max - 32) + 32, *this);
-                    utf::to_utf_from_code(std::clamp(coor.y, 1, si16max - 32) + 32, *this);
+                    utf::to_utf_from_code(std::clamp(ctrl,         0, si16max - 32) + 32, *this);
+                    utf::to_utf_from_code(std::clamp((si32)coor.x, 1, si16max - 32) + 32, *this);
+                    utf::to_utf_from_code(std::clamp((si32)coor.y, 1, si16max - 32) + 32, *this);
                 }
                 else
                 {
-                    add("\033[M", (char)(std::clamp(ctrl,   0, 127-32) + 32),
-                                  (char)(std::clamp(coor.x, 1, 127-32) + 32),
-                                  (char)(std::clamp(coor.y, 1, 127-32) + 32));
+                    add("\033[M", (char)(std::clamp(ctrl,         0, 127-32) + 32),
+                                  (char)(std::clamp((si32)coor.x, 1, 127-32) + 32),
+                                  (char)(std::clamp((si32)coor.y, 1, 127-32) + 32));
                 }
             }
             return *this;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.08.10";
+    static const auto version = "v2025.08.12";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1003,6 +1003,16 @@ struct impl : consrv
                 if (gear.m_sys.hzwheel) flags |= MOUSE_HWHEELED;
             }
             auto lock = std::lock_guard{ locker };
+            struct fp32_mouse_t
+            {
+                ui32 EventType = MENU_EVENT;
+                ui32 id = nt::console::event::custom | nt::console::event::fp32_mouse;
+                fp32 x = fp32nan; // Floating point x mouse coord.
+                fp32 y = fp32nan; // Floating point y mouse coord.
+                fp32 pad{};
+            };
+            auto r2 = fp32_mouse_t{ .x = gear.coord.x, .y = gear.coord.y };
+            stream.emplace_back(*reinterpret_cast<INPUT_RECORD*>(&r2));
             stream.emplace_back(INPUT_RECORD
             {
                 .EventType = MOUSE_EVENT,

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -23,7 +23,7 @@ struct consrv
     virtual fd_t watch() = 0;
     virtual bool send(view utf8) = 0;
     virtual void keybd(input::hids& gear, bool decckm) = 0;
-    virtual void mouse(input::hids& gear, bool moved, twod coord, input::mouse::prot encod, input::mouse::mode state) = 0;
+    virtual void mouse(input::hids& gear, bool moved, fp2d coord, input::mouse::prot encod, input::mouse::mode state) = 0;
     virtual void paste(view block) = 0;
     virtual void focus(bool state) = 0;
     virtual void winsz(twod newsz) = 0;
@@ -959,16 +959,22 @@ struct impl : consrv
         void style(si32 format)
         {
             auto lock = std::lock_guard{ locker };
-            auto data = INPUT_RECORD{ .EventType = MENU_EVENT };
-            data.Event.MenuEvent.dwCommandId = nt::console::event::custom | nt::console::event::style;
-            stream.emplace_back(data);
-            data.Event.MenuEvent.dwCommandId = nt::console::event::custom | format;
-            stream.emplace_back(data);
+            auto data = nt::console::style_input{ .format = format };
+            stream.emplace_back(*reinterpret_cast<INPUT_RECORD*>(&data));
             ondata.reset();
             signal.notify_one();
         }
-        void mouse(input::hids& gear, twod coord)
+        void mouse(input::hids& gear, fp2d coord)
         {
+            if (std::isnan(coord.x)) // Forward a mouse halt event.
+            {
+                auto lock = std::lock_guard{ locker };
+                auto r2 = nt::console::fp2d_mouse_input{ .coord = coord };
+                stream.emplace_back(*reinterpret_cast<INPUT_RECORD*>(&r2));
+                ondata.reset();
+                signal.notify_one();
+                return;
+            }
             auto state = os::nt::ms_kbstate(gear.ctlstat);
             auto bttns = gear.m_sys.buttons & 0b00011111;
             auto moved = gear.m_sys.buttons == gear.m_sav.buttons && gear.m_sys.wheelfp == 0.f; // No events means mouse move. MSFT: "MOUSE_EVENT_RECORD::dwEventFlags: If this value is zero, it indicates a mouse button being pressed or released". Far Manager relies on this.
@@ -982,7 +988,7 @@ struct impl : consrv
                 {
                     auto& s = dclick[i];
                     auto fired = gear.m_sys.timecod;
-                    if (fired - s.fired < gear.delay && s.coord == coord) // Set the double-click flag if the delay has not expired and the mouse is in the same position.
+                    if (fired - s.fired < gear.delay && s.coord == twod{ coord }) // Set the double-click flag if the delay has not expired and the mouse is in the same cell.
                     {
                         flags |= DOUBLE_CLICK;
                         s.fired = {};
@@ -1003,15 +1009,7 @@ struct impl : consrv
                 if (gear.m_sys.hzwheel) flags |= MOUSE_HWHEELED;
             }
             auto lock = std::lock_guard{ locker };
-            struct fp32_mouse_t
-            {
-                ui32 EventType = MENU_EVENT;
-                ui32 id = nt::console::event::custom | nt::console::event::fp32_mouse;
-                fp32 x = fp32nan; // Floating point x mouse coord.
-                fp32 y = fp32nan; // Floating point y mouse coord.
-                fp32 pad{};
-            };
-            auto r2 = fp32_mouse_t{ .x = gear.coord.x, .y = gear.coord.y };
+            auto r2 = nt::console::fp2d_mouse_input{ .coord = coord };
             stream.emplace_back(*reinterpret_cast<INPUT_RECORD*>(&r2));
             stream.emplace_back(INPUT_RECORD
             {
@@ -1022,8 +1020,8 @@ struct impl : consrv
                     {
                         .dwMousePosition =
                         {
-                            .X = (si16)std::clamp<si32>(coord.x, si16min, si16max),
-                            .Y = (si16)std::clamp<si32>(coord.y, si16min, si16max),
+                            .X = (si16)std::clamp<si32>((si32)coord.x, si16min, si16max),
+                            .Y = (si16)std::clamp<si32>((si32)coord.y, si16min, si16max),
                         },
                         .dwButtonState     = (DWORD)bttns,
                         .dwControlKeyState = state,
@@ -4944,7 +4942,7 @@ struct impl : consrv
             uiterm.mtrack.setmode(input::mouse::prot::w32);
         }
     }
-    void mouse(input::hids& gear, bool /*moved*/, twod coord, input::mouse::prot /*encod*/,
+    void mouse(input::hids& gear, bool /*moved*/, fp2d coord, input::mouse::prot /*encod*/,
                  input::mouse::mode /*state*/) { events.mouse(gear, coord);        }
     void keybd(input::hids& gear, bool decckm) { events.keybd(gear, decckm);       }
     void paste(view block)                     { events.paste(block);              }
@@ -5163,7 +5161,7 @@ struct consrv : ipc::stdcon
     {
         //todo win32-input-mode
     }
-    void mouse(input::hids& /*gear*/, bool /*moved*/, twod /*coord*/, input::mouse::prot /*encod*/, input::mouse::mode /*state*/)
+    void mouse(input::hids& /*gear*/, bool /*moved*/, fp2d /*coord*/, input::mouse::prot /*encod*/, input::mouse::mode /*state*/)
     {
         //todo win32-input-mode
     }

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -283,7 +283,7 @@ namespace netxs
         constexpr twod clamp(twod point) const
         {
             auto [min, max] = twod::sort(coor, coor + size);
-            return std::clamp(point, min, max - dot_11);
+            return std::clamp(point, min, std::max(min, max - dot_11)); // Use std::max for zero size cases.
         }
         // rect: Is the point inside the rect.
         constexpr bool hittest(twod p) const

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -92,6 +92,8 @@ namespace netxs
     static constexpr auto fp64min = std::numeric_limits<fp64>::lowest();
     static constexpr auto fp32epsilon = std::numeric_limits<fp32>::min();
     static constexpr auto fp64epsilon = std::numeric_limits<fp64>::min();
+    static constexpr auto fp32nan = std::numeric_limits<fp32>::quiet_NaN();
+    static constexpr auto fp64nan = std::numeric_limits<fp64>::quiet_NaN();
     static constexpr auto debugmode
         #if defined(DEBUG)
         = true;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -558,6 +558,7 @@ namespace netxs::os
                     static constexpr auto style       = 0;
                     static constexpr auto paste_begin = 1;
                     static constexpr auto paste_end   = 2;
+                    static constexpr auto fp32_mouse  = 3;
                 }
                 namespace op
                 {
@@ -5051,10 +5052,24 @@ namespace netxs::os
                         }
                         else if (r.EventType == MENU_EVENT) // Forward console control events.
                         {
+                            struct fp32_mouse_t
+                            {
+                                ui32 EventType = MENU_EVENT;
+                                ui32 id = nt::console::event::custom | nt::console::event::fp32_mouse;
+                                fp32 x = fp32nan; // Floating point x mouse coord.
+                                fp32 y = fp32nan; // Floating point y mouse coord.
+                                fp32 pad{};
+                            };
                             if (r.Event.MenuEvent.dwCommandId & nt::console::event::custom)
                             switch (r.Event.MenuEvent.dwCommandId ^ nt::console::event::custom)
                             {
-                                case nt::console::event::style:
+                                case nt::console::event::fp32_mouse:
+                                    {
+                                        auto& r2 = *reinterpret_cast<fp32_mouse_t*>(&r);
+                                        log("coord{ %%, %% }", r2.x, r2.y);
+                                    }
+                                    break;
+                                case nt::console::event::style://todo mark the style events somehow in order to distinguish it from fp32_mouse
                                     if (head != tail && head->EventType == MENU_EVENT)
                                     {
                                         auto& next_rec = *head++;

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -349,6 +349,7 @@ R"==(
             <script="vtm.defapp.ShowClosingPreview(not vtm.gear.IsKeyRepeated())"                 on="preview:Esc" /> <!-- Pred window close action. -->
             <script="if (vtm.defapp.ShowClosingPreview()) then vtm.defapp.Close() end"            on="preview:-Esc"/> <!-- Close the window on Esc release. -->
             <script="if (vtm.gear.IsKeyRepeated()) then vtm.defapp.ShowClosingPreview(false) end" on="preview:Any" /> <!-- Preview for "Any" is always triggered after all other previews. Non-preview "Any" is triggered before all other keys. -->
+            <script="if (vtm.defapp.ShowClosingPreview()) then local focus_count=vtm(); vtm.defapp.ShowClosingPreview(focus_count~=0) end" source="applet" on="release:e2::form::state::focus::count" /> <!-- Disable window closing preview when focus is lost. -->
             <script="vtm.defapp.ScrollViewportByPage( 0, 1)"                                      on="PageUp"      />
             <script="vtm.defapp.ScrollViewportByPage( 0,-1)"                                      on="PageDown"    />
             <script="vtm.defapp.ScrollViewportByStep( 0, 3)"                                      on="UpArrow"     />


### PR DESCRIPTION
### Changes

- Enable floating point (pixel-wise) mouse reporting over Win32 Console API.