### PR TITLE
Input event reporting (fine scrolling)

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -583,7 +583,7 @@ Standard object names
 |                 |                          | `vtm.gate.AntialiasingMode() -> int`               | Toggle anti-aliasing mode.
 |`applet`         | Running applet           | `vtm.applet.Warp(int l, int r, int t, int b)`      | Request to deform the applet window. The parameters specify four deltas for the left, right, top and bottom sides of the applet window.
 |                 |                          | `vtm.applet.ZOrder() -> int`                       | Request the current z-order state of the applet window.
-|                 |                          | `vtm.applet.ZOrder(int n) -> int`                  | Set the current z-order state for the applet window. -1: backmost; 0: plain; 1: topmost.
+|                 |                          | `vtm.applet.ZOrder(int n) -> int`                  | Set the current z-order state for the applet window. -1: backmost; 0: normal; 1: topmost.
 |                 |                          | `vtm.applet.Close()`                               | Close applet window.
 |                 |                          | `vtm.applet.Minimize()`                            | Minimize applet window.
 |                 |                          | `vtm.applet.Maximize()`                            | Maximize applet window.

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -645,6 +645,8 @@ Standard object names
 |                 |                          | `vtm.terminal.ClearScrollback()`                   | Clear the terminal scrollback buffer.
 |                 |                          | `vtm.terminal.ScrollbackSize() -> int n, m, q`     | Get the current scrollback buffer parameters (three integer values):<br>`n` Initial buffer size<br>`m` Grow step<br>`q` Grow limit
 |                 |                          | `vtm.terminal.ScrollbackSize(int n, int m, int q)` | Set scrollback buffer parameters:<br>`n` Initial buffer size<br>`m` Grow step<br>`q` Grow limit
+|                 |                          | `vtm.terminal.EventReporting(string args, ...)`    | Enable event reporting for the specified sources:<br>`"keyboard"` Keyboard events<br>`"mouse"` Mouse events<br>`"focus"` Focus events<br>`"format"` Line format events<br>`"clipoard"` Clipboard events<br>`"window"` Window size and selection events<br>`"system"` System signals<br>`""` Switch event reporting off
+|                 |                          | `vtm.terminal.EventReporting()`                    | Get a list of active event sources.
 |                 |                          | `vtm.terminal.Restart()`                           | Restart the current terminal session.
 |                 |                          | `vtm.terminal.Quit()`                              | Close terminal.
 

--- a/doc/vt-input-mode.md
+++ b/doc/vt-input-mode.md
@@ -89,7 +89,7 @@ Field             | Descriprtion
   ```
 - Mouse
   ```
-  ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coord=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ESC \
+  ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ESC \
   ```
 - Focus
   ```
@@ -362,20 +362,20 @@ Key ID | Name               | Generic Name       | Scan Code | Notes
 ### Mouse
 
 ```
-ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coord=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ESC \
+ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ESC \
 ```
 
 Attribute                   | Description
 ----------------------------|------------
 `id=0`                      | Seat id.
 `kbmods=<KeyMods>`          | Keyboard modifiers (see Keyboard event).
-`coord=<X>,<Y>`             | Pixel-wise coordinates of the mouse pointer. Each coordinate is represented in the form of a floating point value of the sum of the integer coordinate of the cell in the terminal window grid and the relative offset within the cell in the range `[0.0f, 1.0f)`.
+`coor=<X>,<Y>`              | Pixel-wise coordinates of the mouse pointer. Each coordinate is represented in the form of a floating point value of the sum of the integer coordinate of the cell in the terminal window grid and the relative offset within the cell in the range `[0.0f, 1.0f)`.
 `buttons=<ButtonState>`     | Mouse button state.
 `scroll=<DeltaX>,<DeltaY>`  | Integer value of high resolution horizontal and vertical scroll delta in integer 1/120 units.
 
 In response to the activation of `mouse` tracking, the application receives a vt-sequence containing current mouse state:
 ```
-ESC _ event=mouse ; kbmods=<KeyMods> ; coord=<X>,<Y> ; buttons=<ButtonState> ESC \
+ESC _ event=mouse ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ESC \
 ```
 
 The mouse tracking event fires on any mouse activity, as well as on keyboard modifier changes.

--- a/doc/vt-input-mode.md
+++ b/doc/vt-input-mode.md
@@ -89,7 +89,7 @@ Field             | Descriprtion
   ```
 - Mouse
   ```
-  ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ESC \
+  ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ; finescroll=<DeltaX>,<DeltaY> ESC \
   ```
 - Focus
   ```
@@ -123,7 +123,7 @@ ESC _ event=keyboard ; id=0 ; kbmods=<KeyMods> ; keyid=<KeyId> ; pressed=<KeyDow
 
 Attribute                     | Description
 ------------------------------|------------
-`id=0`                        | Seat id.
+`id=0`                        | Device group id.
 `kbmods=<KeyMods>`            | Keyboard modifiers.
 `keyid=<KeyId>`               | Physical key ID.
 `pressed=<KeyDown>`           | Key state:<br>\<KeyDown\>=1 - Pressed.<br>\<KeyDown\>=0 - Released.
@@ -362,21 +362,17 @@ Key ID | Name               | Generic Name       | Scan Code | Notes
 ### Mouse
 
 ```
-ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ESC \
+ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> finescroll=<DeltaX>,<DeltaY> ESC \
 ```
 
-Attribute                   | Description
-----------------------------|------------
-`id=0`                      | Seat id.
-`kbmods=<KeyMods>`          | Keyboard modifiers (see Keyboard event).
-`coor=<X>,<Y>`              | Pixel-wise coordinates of the mouse pointer. Each coordinate is represented in the form of a floating point value of the sum of the integer coordinate of the cell in the terminal window grid and the relative offset within the cell in the range `[0.0f, 1.0f)`.
-`buttons=<ButtonState>`     | Mouse button state.
-`scroll=<DeltaX>,<DeltaY>`  | Integer value of high resolution horizontal and vertical scroll delta in integer 1/120 units.
-
-In response to the activation of `mouse` tracking, the application receives a vt-sequence containing current mouse state:
-```
-ESC _ event=mouse ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ESC \
-```
+Attribute                       | Description
+--------------------------------|------------
+`id=0`                          | Device group id.
+`kbmods=<KeyMods>`              | Keyboard modifiers (see Keyboard event).
+`coor=<X>,<Y>`                  | Pixel-wise coordinates of the mouse pointer. Each coordinate is represented in the form of a floating point value of the sum of the integer coordinate of the cell in the terminal window grid and the relative offset within the cell in the range `[0.0f, 1.0f)`.
+`buttons=<ButtonState>`         | Mouse button state.
+`scroll=<DeltaX>,<DeltaY>`      | Integer values of low resolution horizontal and vertical scroll deltas in integer 1/1 units (one scroll line corresponds to a value of 1).
+`finescroll=<DeltaX>,<DeltaY>`  | Integer values of high resolution horizontal and vertical scroll deltas in integer 1/120 units (one scroll line corresponds to a value of 120).
 
 The mouse tracking event fires on any mouse activity, as well as on keyboard modifier changes.
 
@@ -402,7 +398,7 @@ ESC _ event=focus ; id=0 ; state=<FocusState> ESC \
 
 Attribute            | Description
 ---------------------|------------
-`id=0`               | Seat id.
+`id=0`               | Device group id.
 `state=<FocusState>` | Terminal window focus:<br>\<FocusState\>=1 - Focused.<br>\<FocusState\>=0 - Unfocused.
 
 In response to the activation of `focus` tracking, the application receives a vt-sequence containing current focus state.
@@ -429,7 +425,7 @@ ESC _ event=clipboard ; id=0 ; format=<ClipFormat> ; security=<SecLevel> ; data=
 
 Attribute             | Description
 ----------------------|------------
-`id=0`                | Seat id.
+`id=0`                | Device group id.
 `format=<ClipFormat>` | Clipboard data format.
 `security=<SecLevel>` | Security level.
 `data=<Data>`         | Base64 encoded data.

--- a/doc/vt-input-mode.md
+++ b/doc/vt-input-mode.md
@@ -33,11 +33,43 @@ Existing approaches have the following drawbacks:
 
 - We use HEX-form of the uint32 (IEEE-754 32-bit binary float, Little-Endian) for the floating point value representation.
 - Space characters are not used in sequence payloads and are only used for readability of the description.
-- All unescaped symbols outside of this protocol should be treated as clipboard pasted data.
+- //todo: keyboard only: All unescaped symbols outside of this protocol should be treated as clipboard pasted data.
 
-### Format
+## Event tracking activation
 
-Signaling uses APC `ESC _ <payload> ESC \` with an event-specific payload syntax.
+Event tracking is activated by sending an APC vt-sequence to the terminal with a script to switch the event tracking mode.
+
+The following APC sequences set/reset/request event tracking for the specified event `"Source"`s:
+
+- Set:
+  ```
+  ESC _ vtm.terminal.EventReporting("Source0", ..., "SourceN") ESC \
+  ```
+- Reset (the event tracking is deactivated if an empty string is specified.):
+  ```
+  ESC _ vtm.terminal.EventReporting("") ESC \
+  ```
+- Get a list of active sources:
+  ```
+  ESC _ src_list=vtm.terminal.EventReporting() ESC \
+  ```
+
+Sources      | Events to track
+-------------|----------------
+`"keyboard"` | Keyboard.
+`"mouse"`    | Mouse.
+`"focus"`    | Focus.
+`"format"`   | Line format.
+`"clipboard"`| Clipboard.
+`"window"`   | Window size and selection.
+`"system"`   | System signals.
+`""`         | Empty string to set all event reporting off.
+
+/todo: keyboard only: Note: By enabling `vt-input-mode`, all current terminal modes are automatically saved (to be restored on exit) and switched to something like "raw" mode, in which input is available character by character, echoing is disabled, and all special processing of terminal input and output characters is disabled (except for `LF` to `CR+LF` conversion).
+
+### Event format
+
+The event signaling also uses APC `ESC _ <payload> ESC \` with an event-specific payload syntax.
 
 The payload consists of a list of attributes in the following format:
 ```
@@ -48,27 +80,6 @@ Field             | Descriprtion
 ------------------|-------------
 `<attr>`          | Attribute name.
 `<val>,...,<val>` | Comma-separated value list.
-
-## Initialization
-
-```
-Set:   ESC _ events=<Source0>,...,<SourceN> ESC \
-Reset: ESC _ events ESC \
-```
-
-Source     | Events to track
------------|----------------
-`keyboard` | Keyboard.
-`mouse`    | Mouse.
-`focus`    | Focus.
-`format`   | Line format.
-`clipoard` | Clipboard.
-`window`   | Window size and selection.
-`system`   | System signals.
-
-This sequence enables `vt-input-mode` and event tracking for the specified event `Source`s. The `vt-input-mode` is deactivated if none of the `Source`s is specified.
-
-Note: By enabling `vt-input-mode`, all current terminal modes are automatically saved (to be restored on exit) and switched to something like "raw" mode, in which input is available character by character, echoing is disabled, and all special processing of terminal input and output characters is disabled (except for `LF` to `CR+LF` conversion).
 
 ## Events
 
@@ -91,7 +102,7 @@ Note: By enabling `vt-input-mode`, all current terminal modes are automatically 
 //todo Textinput, Text, IME or Input for IME preview etc
 - Clipboard
   ```
-  ESC _ event=clipoard ; id=0 ; format=<ClipFormat> ; security=<SecLevel> ; data=<Data> ESC \
+  ESC _ event=clipboard ; id=0 ; format=<ClipFormat> ; security=<SecLevel> ; data=<Data> ESC \
   ```
 - Window
   ```
@@ -413,7 +424,7 @@ In response to the activation of `format` tracking, the application receives a v
 ### Clipboard
 
 ```
-ESC _ event=clipoard ; id=0 ; format=<ClipFormat> ; security=<SecLevel> ; data=<Data> ESC \
+ESC _ event=clipboard ; id=0 ; format=<ClipFormat> ; security=<SecLevel> ; data=<Data> ESC \
 ```
 
 Attribute             | Description

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -629,15 +629,17 @@ namespace netxs::ansi
             auto h1 = 0;
             auto v2 = wheelfp;
             auto h2 = 0;
+            auto x = coor.x;
+            auto y = coor.y;
             if (gear.m_sys.hzwheel)
             {
                 std::swap(h1, v1);
                 std::swap(h2, v2);
             }
             add("\033_event=mouse;id=", gear.id, ";kbmods=", gear.m_sys.ctlstat, ";coor=");
-            utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&coor.x)), 4 * 2, [&](char c){ add(c); });
+            utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&x)), 4 * 2, [&](char c){ add(c); });
             add(",");
-            utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&coor.y)), 4 * 2, [&](char c){ add(c); });
+            utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&y)), 4 * 2, [&](char c){ add(c); });
             add(";buttons=", gear.m_sys.buttons, ";scroll=", h1, ",", v1, ";finescroll=", h2, ",", v2, "\033\\");
             return *this;
         }

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -629,17 +629,19 @@ namespace netxs::ansi
             auto h1 = 0;
             auto v2 = wheelfp;
             auto h2 = 0;
-            auto xy = xy2d<ui32>{};
-            ::memcpy(&xy, &coor, sizeof(xy));
+            auto x = ui32{};
+            auto y = ui32{};
+            ::memcpy(&x, &coor.x, sizeof(x));
+            ::memcpy(&y, &coor.y, sizeof(y));
             if (gear.m_sys.hzwheel)
             {
                 std::swap(h1, v1);
                 std::swap(h2, v2);
             }
             add("\033_event=mouse;id=", gear.id, ";kbmods=", gear.m_sys.ctlstat, ";coor=");
-            utf::_to_hex(netxs::letoh(xy.x), 4 * 2, [&](char c){ add(c); });
+            utf::_to_hex(netxs::letoh(x), 4 * 2, [&](char c){ add(c); });
             add(",");
-            utf::_to_hex(netxs::letoh(xy.y), 4 * 2, [&](char c){ add(c); });
+            utf::_to_hex(netxs::letoh(y), 4 * 2, [&](char c){ add(c); });
             add(";buttons=", gear.m_sys.buttons, ";scroll=", h1, ",", v1, ";finescroll=", h2, ",", v2, "\033\\");
             return *this;
         }

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -612,6 +612,22 @@ namespace netxs::ansi
             return *this;
         }
         template<class T>
+        auto& mouse_vtm(T const& gear, fp2d coor) // escx: Mouse tracking report (vt-input-mode).
+        {
+            //  ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coord=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ST
+            auto wheeldt = netxs::saturate_cast<si32>(gear.m_sys.wheelfp * 120);
+            auto h = gear.m_sys.hzwheel ? wheeldt : 0;
+            auto v = gear.m_sys.hzwheel ? 0 : wheeldt;
+            add("\033_event=mouse;id=", gear.id, ";kbmods=", gear.m_sys.ctlstat,
+                //todo use utf::_to_hex(auto number, size_t width, auto push)
+                //todo letoh/htole
+                ";coord=", utf::to_hex(*reinterpret_cast<ui32*>(&coor.x)),
+                      ",", utf::to_hex(*reinterpret_cast<ui32*>(&coor.y)),
+              ";buttons=", gear.m_sys.buttons,
+               ";scroll=", h, ",", v, "\033\\");
+            return *this;
+        }
+        template<class T>
         auto& mouse_sgr(T const& gear, fp2d coor) // escx: Mouse tracking report (SGR).
         {
             if (std::isnan(coor.x)) return *this;

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -614,17 +614,16 @@ namespace netxs::ansi
         template<class T>
         auto& mouse_vtm(T const& gear, fp2d coor) // escx: Mouse tracking report (vt-input-mode).
         {
-            //  ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coord=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ST
+            //  ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ST
             auto wheeldt = netxs::saturate_cast<si32>(gear.m_sys.wheelfp * 120);
-            auto h = gear.m_sys.hzwheel ? wheeldt : 0;
-            auto v = gear.m_sys.hzwheel ? 0 : wheeldt;
-            add("\033_event=mouse;id=", gear.id, ";kbmods=", gear.m_sys.ctlstat,
-                //todo use utf::_to_hex(auto number, size_t width, auto push)
-                //todo letoh/htole
-                ";coord=", utf::to_hex(*reinterpret_cast<ui32*>(&coor.x)),
-                      ",", utf::to_hex(*reinterpret_cast<ui32*>(&coor.y)),
-              ";buttons=", gear.m_sys.buttons,
-               ";scroll=", h, ",", v, "\033\\");
+            auto v = wheeldt;
+            auto h = 0;
+            if (gear.m_sys.hzwheel) std::swap(h, v);
+            add("\033_event=mouse;id=", gear.id, ";kbmods=", gear.m_sys.ctlstat, ";coor=");
+            utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&coor.x)), 4 * 2, [&](char c){ add(c); });
+            add(",");
+            utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&coor.y)), 4 * 2, [&](char c){ add(c); });
+            add(";buttons=", gear.m_sys.buttons, ";scroll=", h, ",", v, "\033\\");
             return *this;
         }
         template<class T>

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -629,17 +629,17 @@ namespace netxs::ansi
             auto h1 = 0;
             auto v2 = wheelfp;
             auto h2 = 0;
-            auto x = *reinterpret_cast<ui32*>(&coor.x);
-            auto y = *reinterpret_cast<ui32*>(&coor.y);
+            auto xy = xy2d<ui32>{};
+            ::memcpy(&xy, &coor, sizeof(xy));
             if (gear.m_sys.hzwheel)
             {
                 std::swap(h1, v1);
                 std::swap(h2, v2);
             }
             add("\033_event=mouse;id=", gear.id, ";kbmods=", gear.m_sys.ctlstat, ";coor=");
-            utf::_to_hex(netxs::letoh(x), 4 * 2, [&](char c){ add(c); });
+            utf::_to_hex(netxs::letoh(xy.x), 4 * 2, [&](char c){ add(c); });
             add(",");
-            utf::_to_hex(netxs::letoh(y), 4 * 2, [&](char c){ add(c); });
+            utf::_to_hex(netxs::letoh(xy.y), 4 * 2, [&](char c){ add(c); });
             add(";buttons=", gear.m_sys.buttons, ";scroll=", h1, ",", v1, ";finescroll=", h2, ",", v2, "\033\\");
             return *this;
         }

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -260,6 +260,14 @@ namespace netxs::ansi
     static const auto paste_begin = "\033[200~"sv; // Bracketed paste begin.
     static const auto paste_end   = "\033[201~"sv; // Bracketed paste end.
 
+    static constexpr auto apc_prefix_mouse            = "event=mouse;"sv;
+    static constexpr auto apc_prefix_mouse_id         = "id="sv;         // ui32
+    static constexpr auto apc_prefix_mouse_kbmods     = "kbmods="sv;     // ui32
+    static constexpr auto apc_prefix_mouse_coor       = "coor="sv;       // fp32,fp32
+    static constexpr auto apc_prefix_mouse_buttons    = "buttons="sv;    // ui32
+    static constexpr auto apc_prefix_mouse_scroll     = "scroll="sv;     // si32,si32
+    static constexpr auto apc_prefix_mouse_finescroll = "finescroll="sv; // si32,si32
+
     template<class Base>
     class basevt
     {
@@ -541,8 +549,8 @@ namespace netxs::ansi
         }
         auto& vmouse(bool b) // escx: Focus and Mouse position reporting/tracking.
         {
-            return add(b ? "\033[?1002;1003;1004;1006;10060h"
-                         : "\033[?1002;1003;1004;1006;10060l");
+            return add(b ? "\033[?1002;1003;1004;1006;10060h\033_vtm.terminal.EventReporting('mouse')\033\\"
+                         : "\033[?1002;1003;1004;1006;10060l\033_vtm.terminal.EventReporting('')\033\\");
         }
         auto& setutf(bool b)        { return add(b ? "\033%G"      : "\033%@"        ); } // escx: Select UTF-8 character set (true) or default (faux). Not supported by Apple Terminal on macOS.
         auto& altbuf(bool b)        { return add(b ? "\033[?1049h" : "\033[?1049l"   ); } // escx: Alternative buffer.
@@ -615,15 +623,22 @@ namespace netxs::ansi
         auto& mouse_vtm(T const& gear, fp2d coor) // escx: Mouse tracking report (vt-input-mode).
         {
             //  ESC _ event=mouse ; id=0 ; kbmods=<KeyMods> ; coor=<X>,<Y> ; buttons=<ButtonState> ; scroll=<DeltaX>,<DeltaY> ST
-            auto wheeldt = netxs::saturate_cast<si32>(gear.m_sys.wheelfp * 120);
-            auto v = wheeldt;
-            auto h = 0;
-            if (gear.m_sys.hzwheel) std::swap(h, v);
+            auto wheelfp = netxs::saturate_cast<si32>(gear.m_sys.wheelfp * 120);
+            //todo make it fp2d
+            auto v1 = gear.m_sys.wheelsi;
+            auto h1 = 0;
+            auto v2 = wheelfp;
+            auto h2 = 0;
+            if (gear.m_sys.hzwheel)
+            {
+                std::swap(h1, v1);
+                std::swap(h2, v2);
+            }
             add("\033_event=mouse;id=", gear.id, ";kbmods=", gear.m_sys.ctlstat, ";coor=");
             utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&coor.x)), 4 * 2, [&](char c){ add(c); });
             add(",");
             utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&coor.y)), 4 * 2, [&](char c){ add(c); });
-            add(";buttons=", gear.m_sys.buttons, ";scroll=", h, ",", v, "\033\\");
+            add(";buttons=", gear.m_sys.buttons, ";scroll=", h1, ",", v1, ";finescroll=", h2, ",", v2, "\033\\");
             return *this;
         }
         template<class T>

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -629,17 +629,17 @@ namespace netxs::ansi
             auto h1 = 0;
             auto v2 = wheelfp;
             auto h2 = 0;
-            auto x = coor.x;
-            auto y = coor.y;
+            auto x = *reinterpret_cast<ui32*>(&coor.x);
+            auto y = *reinterpret_cast<ui32*>(&coor.y);
             if (gear.m_sys.hzwheel)
             {
                 std::swap(h1, v1);
                 std::swap(h2, v2);
             }
             add("\033_event=mouse;id=", gear.id, ";kbmods=", gear.m_sys.ctlstat, ";coor=");
-            utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&x)), 4 * 2, [&](char c){ add(c); });
+            utf::_to_hex(netxs::letoh(x), 4 * 2, [&](char c){ add(c); });
             add(",");
-            utf::_to_hex(netxs::letoh(*reinterpret_cast<ui32*>(&y)), 4 * 2, [&](char c){ add(c); });
+            utf::_to_hex(netxs::letoh(y), 4 * 2, [&](char c){ add(c); });
             add(";buttons=", gear.m_sys.buttons, ";scroll=", h1, ",", v1, ";finescroll=", h2, ",", v2, "\033\\");
             return *this;
         }

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.08.13";
+    static const auto version = "v2025.08.14";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -282,6 +282,17 @@ namespace netxs::events
         ::lua_settop(lua, 0);
         (push_value(args), ...);
     }
+    void luna::set_return_array(txts const& str_list)
+    {
+        ::lua_settop(lua, 0);
+        ::lua_createtable(lua, 0, 0);
+        auto i = 0;
+        for (auto& s : str_list)
+        {
+            ::lua_pushlstring(lua, s.data(), s.size());
+            ::lua_rawseti(lua, -2, ++i);
+        }
+    }
     si32 luna::args_count()
     {
         return ::lua_gettop(lua);

--- a/src/netxs/desktopio/events.hpp
+++ b/src/netxs/desktopio/events.hpp
@@ -157,6 +157,7 @@ namespace netxs::events
         static si32 vtmlua_push_value(      lua_State* lua, auto&& v);
         si32 push_value(auto&& v);
         void set_return(auto... args);
+        void set_return_array(txts const& str_list);
         si32 args_count();
         void read_args(si32 index, auto add_item);
         auto get_args_or(si32 idx, auto fallback = {});

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -752,16 +752,19 @@ namespace netxs::input
             move = 1 << 2,
             over = 1 << 3,
             utf8 = 1 << 4,
+            vtim = 1 << 5, // vt-input-mode
             buttons_press = bttn,
             buttons_drags = bttn | drag,
             all_movements = bttn | drag | move,
             negative_args = bttn | drag | move | over,
+            vt_input_mode = bttn | drag | move | over | vtim,
         };
         enum prot
         {
             x11,
             sgr,
             w32,
+            //vtm, // vt-input-mode
         };
         struct buttons
         {

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4527,7 +4527,13 @@ namespace netxs::os
 
                 if (attached)
                 {
-                    if (encod == prot::w32) termlink->mouse(gear, moved, coord, encod, state);
+                    if (state & mode::vtim)
+                    {
+                        auto guard = std::lock_guard{ writemtx };
+                        writebuf.mouse_vtm(gear, coord);
+                        writesyn.notify_one();
+                    }
+                    else if (encod == prot::w32) termlink->mouse(gear, moved, coord, encod, state);
                     else
                     {
                         if (state & mode::move

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -5239,6 +5239,7 @@ namespace netxs::os
                     focus,
                     style,
                     paste,
+                    mousevtim,
                 };
                 static const auto style_cmd = "\033[" + std::to_string(ansi::ccc_stl) + ":";
                 auto take_sequence = [](qiew& cache) // s.size() always > 1.
@@ -5293,6 +5294,37 @@ namespace netxs::os
                         else if (c == 'O') // SS3: ESC O byte
                         {
                             s = s.substr(0, 3);
+                        }
+                        else if (c == '_') // APC: ESC _ payload ST
+                        {
+                            incomplete = true;
+                            while (head != tail) // Looking for ST
+                            {
+                                auto d = *head++;
+                                if (d == ansi::c0_bel)
+                                {
+                                    s = qiew{ s.begin() + 2, std::prev(head) };
+                                    incomplete = faux;
+                                    break;
+                                }
+                                else if (d == ansi::c0_esc && head != tail && *head == '\\')
+                                {
+                                    s = { s.begin() + 2, std::prev(head) };
+                                    incomplete = faux;
+                                    head++;
+                                    break;
+                                }
+                            }
+                            if (!incomplete) // Return payload only, not a whole APC sequence.
+                            {
+                                cache = { head, tail };
+                                if (s.starts_with(ansi::apc_prefix_mouse))
+                                {
+                                    s.remove_prefix(ansi::apc_prefix_mouse.size());
+                                    t = type::mousevtim;
+                                }
+                                return std::tuple{ t, s, incomplete };
+                            }
                         }
                         else // ESC cluster == Alt+cluster
                         {
@@ -5641,6 +5673,73 @@ namespace netxs::os
                         {
                             auto [t, s, incomplete] = take_sequence(cache);
                             if (incomplete) break;
+                            else if (t == type::mousevtim) // ESC _ payload ST
+                            {
+                                utf::split<true>(s, ';', [&](qiew frag)
+                                {
+                                    if (frag.starts_with(ansi::apc_prefix_mouse_kbmods))
+                                    {
+                                        frag.remove_prefix(ansi::apc_prefix_mouse_kbmods.size());
+                                        if (auto v = utf::to_int<ui32>(frag))
+                                        {
+                                            m.ctlstat = v.value();
+                                            k.ctlstat = m.ctlstat;
+                                        }
+                                    }
+                                    else if (frag.starts_with(ansi::apc_prefix_mouse_coor))
+                                    {
+                                        frag.remove_prefix(ansi::apc_prefix_mouse_coor.size());
+                                        if (auto x = utf::to_int<ui32, 16>(frag); x && frag)
+                                        {
+                                            frag.pop_front(); // Pop ','
+                                            if (auto y = utf::to_int<ui32, 16>(frag))
+                                            {
+                                                m.coordxy.x = *reinterpret_cast<fp32*>(&x.value());
+                                                m.coordxy.y = *reinterpret_cast<fp32*>(&y.value());
+                                            }
+                                        }
+                                    }
+                                    else if (frag.starts_with(ansi::apc_prefix_mouse_buttons))
+                                    {
+                                        frag.remove_prefix(ansi::apc_prefix_mouse_buttons.size());
+                                        if (auto b = utf::to_int<ui32>(frag))
+                                        {
+                                            m.buttons = b.value();
+                                        }
+                                    }
+                                    else if (frag.starts_with(ansi::apc_prefix_mouse_scroll))
+                                    {
+                                        frag.remove_prefix(ansi::apc_prefix_mouse_scroll.size());
+                                        if (auto h = utf::to_int<si32>(frag); h && frag)
+                                        {
+                                            frag.pop_front(); // Pop ','
+                                            if (auto v = utf::to_int<si32>(frag))
+                                            {
+                                                //todo make it twod
+                                                m.hzwheel = h.value() != 0;
+                                                m.wheelsi = m.hzwheel ? h.value() : v.value();
+                                            }
+                                        }
+                                    }
+                                    else if (frag.starts_with(ansi::apc_prefix_mouse_finescroll))
+                                    {
+                                        frag.remove_prefix(ansi::apc_prefix_mouse_finescroll.size());
+                                        if (auto h = utf::to_int<si32>(frag); h && frag)
+                                        {
+                                            frag.pop_front(); // Pop ','
+                                            if (auto v = utf::to_int<si32>(frag))
+                                            {
+                                                //todo make it fp2d
+                                                m.hzwheel = h.value() != 0;
+                                                m.wheelfp = (m.hzwheel ? h.value() : v.value()) / 120.0;
+                                            }
+                                        }
+                                    }
+                                });
+                                m.changed++;
+                                m.timecod = datetime::now();
+                                mouse(m);
+                            }
                             else if (t == type::mouse) // ESC [ < ctrl ; xpos ; ypos M
                             {
                                 auto tmp = s.substr(3); // Pop "\033[<"

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -8746,8 +8746,11 @@ namespace netxs::ui
                                                             auto mouse_tracking = event_sources & ui::terminal::event_source::mouse;
                                                             if ((prev_event_sources & ui::terminal::event_source::mouse) != mouse_tracking)
                                                             {
-                                                                mouse_tracking ? mtrack.enable(input::mouse::mode::vt_input_mode)
-                                                                               : mtrack.disable(input::mouse::mode::vt_input_mode);
+                                                                base::enqueue([&, mouse_tracking](auto& /*boss*/) // Perform switching outside of Lua script context.
+                                                                {
+                                                                    mouse_tracking ? mtrack.enable(input::mouse::mode::vt_input_mode)
+                                                                                   : mtrack.disable(input::mouse::mode::vt_input_mode);
+                                                                });
                                                             }
                                                             luafx.set_return();
                                                         }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1698,7 +1698,7 @@ namespace netxs::ui
                         script_body = qiew{ q.begin(), std::prev(head) };
                         break;
                     }
-                    else if (c == ansi::c0_bel || (c == ansi::c0_esc && head != tail && *head == '\\'))
+                    else if (c == ansi::c0_esc && head != tail && *head == '\\')
                     {
                         script_body = qiew{ q.begin(), std::prev(head) };
                         head++;


### PR DESCRIPTION
### Changes

- Implement mouse event reporting via [`vt-input-mode`](https://github.com/directvt/vtm/blob/master/doc/vt-input-mode.md#mouse) protocol. This protocol is capable of reporting pixel-wise mouse coordinates, as well as deltas for fine scrolling (for example when using touchpads).