### PR TITLE
Fix terminal transparency

### DIFF
--- a/doc/apps.md
+++ b/doc/apps.md
@@ -21,8 +21,7 @@
 - Terminal control using Lua scripts via APC.
 - Special (Exclusive) keyboard mode for terminal window to transfer all keyboard data to the terminal as is.
 - Configurable scrollback buffer size (100k lines by default, limited by `max_int32` and system RAM).
-- Support for outputting plain text over other colored text while preserving all SGR attributes (a-la transparent color).
-- Support for printing SGR attributes without text over existing text (coloring by printing colored null characters).
+- Independent text-only and color-only output.
 - Search for text in the scrollback buffer.
 - Linear and rectangular text selection for copying and searching.
 - Full [VT2D](character_geometry.md) support.
@@ -45,16 +44,18 @@
   - Floating point (pixel-wise) mouse reporting.
 - Stdin/stdout logging.
 
-### Support for outputting plain text over other colored text while preserving all SGR attributes
+### Independent text-only and color-only output
 
-Outputting plain text over other colored text while preserving all SGR attributes allows changing the text inside cells without having to re-specify the color and other SGR attributes for the output string. This significantly simplifies and speeds up the output of intensively updated colored text blocks. This is achieved by using the so-called "transparent" color. The "transparent" color could be enabled by setting the following values ​​for the background color: red=255, green=255, blue=255, alpha=0.
+#### Text-only output
+
+Outputting plain text over other colored text while preserving all SGR attributes allows changing the text inside cells without having to re-specify the color and other SGR attributes for the output string (there may be a large number of attributes, and the one who prints may not even support it). This significantly simplifies and speeds up the output of intensively updated colored text blocks. This is achieved by using the so-called "transparent" color. The "transparent" color could be enabled by setting the following values ​​for the background color: red=255, green=255, blue=255, alpha=0.
 
 For example, replacing the letter `e` with `A` inside a colored text block:
 ```bash
 printf "\e[44;31m Hello \e[mTest\b\b\b\b\b\b\b\b\b\e[48:2:255:255:255:0mA\e[m\n"
 ```
 
-### Support for printing SGR attributes without text over existing text
+#### Color-only output
 
 Printing SGR attributes without text over existing content allows to colorize existing on-screen blocks without having to re-print the text itself. Keeping the existing text on-screen is achieved by using the required number of null characters as the output string. When outputting a null character, the vtm terminal keeps the current character in the cell, updating only the SGR attributes.
 

--- a/doc/apps.md
+++ b/doc/apps.md
@@ -24,6 +24,7 @@
 - Independent text-only and color-only output.
 - Search for text in the scrollback buffer.
 - Linear and rectangular text selection for copying and searching.
+- True color with alpha transparency.
 - Full [VT2D](character_geometry.md) support.
 - UI Shadows as SGR attribute.
 - Support for several formats of copying the selected text:
@@ -44,15 +45,40 @@
   - Floating point (pixel-wise) mouse reporting.
 - Stdin/stdout logging.
 
+### True color with alpha transparency
+
+The built-in terminal is capable of outputting alpha transparent (from 0 to 255, in the RGBA sense) text and thus making "holes" in the GUI terminal window. Transparency can be set for both the text background and the foreground using the SGR attributes `48:2` and `38:2`:
+
+  - `ESC` `[` `48` `:` `2` `:` [ `:` ] `red` `:` `green` `:` `blue` [ `:alpha` ] `m`
+  - `ESC` `[` `38` `:` `2` `:` [ `:` ] `red` `:` `green` `:` `blue` [ `:alpha` ] `m`
+
+For example, outputting a pixel-art image with transparency (pwsh):
+
+```pwsh
+" `e[48:2:0:0:0:255m`e[38:2:0:0:0:255m   `e[38:2:4:0:0:4m▄`e[38:2:20:0:0:20m▄`e[48:2:3:0:0:3m`e[38:2:51:0:0:51m▄`e[48:2:9:0:0:9m`e[38:2:95:0:0:95m▄`e[48:2:11:0:0:11m`e[38:2:104:0:0:104m▄`e[48:2:8:0:0:8m`e[38:2:83:0:0:83m▄`e[48:2:2:0:0:2m`e[38:2:38:0:0:38m▄`e[48:2:0:0:0:255m`e[38:2:14:0:0:14m▄`e[38:2:3:0:0:3m▄`e[38:2:15:0:0:15m▄`e[48:2:2:0:0:2m`e[38:2:39:0:0:39m▄`e[48:2:8:0:0:8m`e[38:2:84:0:0:84m▄`e[48:2:10:0:0:10m`e[38:2:104:0:0:104m▄`e[48:2:9:0:0:9m`e[38:2:93:0:0:93m▄`e[48:2:3:0:0:3m`e[38:2:50:0:0:50m▄`e[48:2:0:0:0:255m`e[38:2:19:0:0:19m▄`e[38:2:4:0:0:4m▄`e[38:2:0:0:0:255m   ";`
+"  `e[38:2:5:0:0:5m▄`e[48:2:8:0:0:8m`e[38:2:57:0:0:57m▄`e[48:2:54:0:0:54m`e[38:2:193:0:0:193m▄`e[48:2:157:0:0:157m`e[38:2:243:0:0:243m▄`e[48:2:224:0:0:224m`e[38:2:254:0:0:254m▄`e[48:2:237:0:0:237m`e[38:2:255:0:0:255m▄`e[48:2:238:0:0:238m▄`e[48:2:234:0:0:234m▄`e[48:2:211:0:0:211m`e[38:2:252:0:0:252m▄`e[48:2:125:0:0:125m`e[38:2:239:0:0:239m▄`e[48:2:49:0:0:49m`e[38:2:219:0:0:219m▄`e[48:2:128:0:0:128m`e[38:2:240:0:0:240m▄`e[48:2:212:0:0:212m`e[38:2:253:0:0:253m▄`e[48:2:234:0:0:234m`e[38:2:255:0:0:255m▄`e[48:2:238:0:0:238m▄`e[48:2:237:0:0:237m▄`e[48:2:224:0:0:224m`e[38:2:254:0:0:254m▄`e[48:2:153:0:0:153m`e[38:2:242:0:0:242m▄`e[48:2:50:0:0:50m`e[38:2:192:0:0:192m▄`e[48:2:7:0:0:7m`e[38:2:54:0:0:54m▄`e[48:2:0:0:0:255m`e[38:2:4:0:0:4m▄`e[38:2:0:0:0:255m ";`
+" `e[48:2:1:0:0:1m`e[38:2:5:0:0:5m▄`e[48:2:23:0:0:23m`e[38:2:66:0:0:66m▄`e[48:2:168:0:0:168m`e[38:2:228:0:0:228m▄`e[48:2:244:0:0:244m`e[38:2:254:0:0:254m▄`e[48:2:255:0:0:255m`e[38:2:255:0:0:255m       `e[48:2:253:0:0:253m▄`e[48:2:255:0:0:255m       `e[48:2:243:0:0:243m`e[38:2:254:0:0:254m▄`e[48:2:162:0:0:162m`e[38:2:226:0:0:226m▄`e[48:2:22:0:0:22m`e[38:2:58:0:0:58m▄`e[48:2:0:0:0:255m`e[38:2:4:0:0:4m▄`e[38:2:0:0:0:255m";`
+" `e[48:2:11:0:0:11m`e[38:2:12:0:0:12m▄`e[48:2:108:0:0:108m`e[38:2:119:0:0:119m▄`e[48:2:239:0:0:239m`e[38:2:240:0:0:240m▄`e[48:2:255:0:0:255m`e[38:2:255:0:0:255m                 `e[48:2:238:0:0:238m`e[38:2:239:0:0:239m▄`e[48:2:102:0:0:102m`e[38:2:107:0:0:107m▄`e[48:2:10:0:0:10m`e[38:2:11:0:0:11m▄`e[48:2:0:0:0:255m`e[38:2:0:0:0:255m";`
+" `e[48:2:9:0:0:9m`e[38:2:3:0:0:3m▄`e[48:2:95:0:0:95m`e[38:2:44:0:0:44m▄`e[48:2:236:0:0:236m`e[38:2:213:0:0:213m▄`e[48:2:255:0:0:255m`e[38:2:253:0:0:253m▄`e[38:2:255:0:0:255m               `e[38:2:252:0:0:252m▄`e[48:2:235:0:0:235m`e[38:2:210:0:0:210m▄`e[48:2:88:0:0:88m`e[38:2:40:0:0:40m▄`e[48:2:8:0:0:8m`e[38:2:2:0:0:2m▄`e[48:2:0:0:0:255m`e[38:2:0:0:0:255m";`
+"  `e[48:2:15:0:0:15m`e[38:2:1:0:0:1m▄`e[48:2:124:0:0:124m`e[38:2:26:0:0:26m▄`e[48:2:232:0:0:232m`e[38:2:144:0:0:144m▄`e[48:2:254:0:0:254m`e[38:2:235:0:0:235m▄`e[48:2:255:0:0:255m`e[38:2:254:0:0:254m▄`e[38:2:255:0:0:255m           `e[38:2:254:0:0:254m▄`e[48:2:254:0:0:254m`e[38:2:235:0:0:235m▄`e[48:2:232:0:0:232m`e[38:2:144:0:0:144m▄`e[48:2:117:0:0:117m`e[38:2:25:0:0:25m▄`e[48:2:14:0:0:14m`e[38:2:1:0:0:1m▄`e[48:2:0:0:0:255m`e[38:2:0:0:0:255m ";`
+"   `e[48:2:2:0:0:2m▄`e[48:2:29:0:0:29m`e[38:2:2:0:0:2m▄`e[48:2:144:0:0:144m`e[38:2:29:0:0:29m▄`e[48:2:235:0:0:235m`e[38:2:144:0:0:144m▄`e[48:2:254:0:0:254m`e[38:2:235:0:0:235m▄`e[48:2:255:0:0:255m`e[38:2:254:0:0:254m▄`e[38:2:255:0:0:255m       `e[38:2:254:0:0:254m▄`e[48:2:254:0:0:254m`e[38:2:233:0:0:233m▄`e[48:2:234:0:0:234m`e[38:2:140:0:0:140m▄`e[48:2:144:0:0:144m`e[38:2:28:0:0:28m▄`e[48:2:29:0:0:29m`e[38:2:2:0:0:2m▄`e[48:2:2:0:0:2m`e[38:2:0:0:0:255m▄`e[48:2:0:0:0:255m  ";`
+"     `e[48:2:2:0:0:2m▄`e[48:2:29:0:0:29m`e[38:2:2:0:0:2m▄`e[48:2:144:0:0:144m`e[38:2:28:0:0:28m▄`e[48:2:234:0:0:234m`e[38:2:137:0:0:137m▄`e[48:2:254:0:0:254m`e[38:2:232:0:0:232m▄`e[48:2:255:0:0:255m`e[38:2:253:0:0:253m▄`e[38:2:255:0:0:255m   `e[38:2:253:0:0:253m▄`e[48:2:253:0:0:253m`e[38:2:227:0:0:227m▄`e[48:2:230:0:0:230m`e[38:2:119:0:0:119m▄`e[48:2:130:0:0:130m`e[38:2:24:0:0:24m▄`e[48:2:26:0:0:26m`e[38:2:2:0:0:2m▄`e[48:2:2:0:0:2m`e[38:2:0:0:0:255m▄`e[48:2:0:0:0:255m    ";`
+"       `e[48:2:2:0:0:2m▄`e[48:2:25:0:0:25m`e[38:2:1:0:0:1m▄`e[48:2:126:0:0:126m`e[38:2:23:0:0:23m▄`e[48:2:229:0:0:229m`e[38:2:116:0:0:116m▄`e[48:2:253:0:0:253m`e[38:2:227:0:0:227m▄`e[48:2:255:0:0:255m`e[38:2:251:0:0:251m▄`e[48:2:253:0:0:253m`e[38:2:226:0:0:226m▄`e[48:2:226:0:0:226m`e[38:2:111:0:0:111m▄`e[48:2:112:0:0:112m`e[38:2:20:0:0:20m▄`e[48:2:21:0:0:21m`e[38:2:1:0:0:1m▄`e[48:2:1:0:0:1m`e[38:2:0:0:0:255m▄`e[48:2:0:0:0:255m      ";`
+"         `e[48:2:1:0:0:1m▄`e[48:2:21:0:0:21m`e[38:2:1:0:0:1m▄`e[48:2:110:0:0:110m`e[38:2:15:0:0:15m▄`e[48:2:205:0:0:205m`e[38:2:48:0:0:48m▄`e[48:2:110:0:0:110m`e[38:2:15:0:0:15m▄`e[48:2:20:0:0:20m`e[38:2:1:0:0:1m▄`e[48:2:1:0:0:1m`e[38:2:0:0:0:255m▄`e[48:2:0:0:0:255m        ";`
+"            `e[48:2:3:0:0:3m▄`e[48:2:0:0:0:255m           ";`
+"`e[m ";
+
+```
+
 ### Independent text-only and color-only output
 
 #### Text-only output
 
 Outputting plain text over other colored text while preserving all SGR attributes allows changing the text inside cells without having to re-specify the color and other SGR attributes for the output string (there may be a large number of attributes, and the one who prints may not even support it). This significantly simplifies and speeds up the output of intensively updated colored text blocks. This is achieved by using the so-called "transparent" color. The "transparent" color could be enabled by setting the following values ​​for the background color: red=255, green=255, blue=255, alpha=0.
 
-For example, replacing the letter `e` with `A` inside a colored text block:
+For example, replacing the string `Hello` with `World` inside a colored text line:
 ```bash
-printf "\e[44;31m Hello \e[mTest\b\b\b\b\b\b\b\b\b\e[48:2:255:255:255:0mA\e[m\n"
+printf "\e[44;31m Hello \e[m Mono text\r\e[48:2::255:255:255:0m World\e[m\n"
 ```
 
 #### Color-only output
@@ -113,7 +139,7 @@ The special (visible in the UI as Exclusive) terminal window mode allows all key
 Name         | Sequence                           | Description
 -------------|------------------------------------|------------
 `CCC_SBS`    | `ESC [` 24 : n : m : q `p`         | Set scrollback buffer parameters:<br>`n` Initial buffer size<br>`m` Grow step<br>`q` Grow limit
-`CCC_SGR`    | `ESC [` 28 : Pm `p`                | Set terminal background SGR attribute:<br>`m` SGR attribute (attribute m may include subarguments separated by colons), 0 — reset all attributes, _default is 0_
+`CCC_SGR`    | `ESC [` 28 : m `p`                 | Set terminal background SGR attribute:<br>`m` SGR attribute (attribute m may include subarguments separated by colons), 0 — reset all attributes, _default is 0_
 `CCC_SEL`    | `ESC [` 29 : n `p`                 | Set text selection mode:<br>`n = 0` Selection is off<br>`n = 1` Select and copy as plaintext (default)<br>`n = 2` Select and copy as ANSI/VT text<br>`n = 3` Select and copy as RTF-document<br>`n = 4` Select and copy as HTML-code<br>`n = 5` Select and copy as protected plaintext (suppressed preview, [details](https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats#cloud-clipboard-and-clipboard-history-formats))
 `CCC_PAD`    | `ESC [` 30 : n `p`                 | Set scrollback buffer left and right side padding:<br>`n` Width in cells, _max = 255, default is 0_
 `CCC_RST`    | `ESC [` 1 `p`                      | Reset all parameters to default

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.08.24";
+    static const auto version = "v2025.08.26";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -4255,22 +4255,19 @@ namespace netxs::lixx // li++, libinput++.
         }
         bool evdev_check_min_max(ui32 code)
         {
-            if (libevdev_has_event_code<EV_ABS>(code))
+            if (auto absinfo = libevdev_get_abs_info(code))
+            if (absinfo->minimum == absinfo->maximum)
             {
-                auto absinfo = libevdev_get_abs_info(code);
-                if (absinfo->minimum == absinfo->maximum)
+                // Some devices have a sort-of legitimate min/max of 0 for ABS_MISC and above (e.g. Roccat Kone XTD). Don't ignore them, simply disable the axes so we won't get events, we don't know what to do with them anyway.
+                if (absinfo->minimum == 0 && code >= ABS_MISC && code < ABS_MT_SLOT)
                 {
-                    // Some devices have a sort-of legitimate min/max of 0 for ABS_MISC and above (e.g. Roccat Kone XTD). Don't ignore them, simply disable the axes so we won't get events, we don't know what to do with them anyway.
-                    if (absinfo->minimum == 0 && code >= ABS_MISC && code < ABS_MT_SLOT)
-                    {
-                        log("disabling EV_ABS %#x% on device (min == max == 0)", code);
-                        libevdev_disable_event_code<EV_ABS>(code);
-                    }
-                    else
-                    {
-                        log("device has min == max on EV_ABS 'code=%%'", code);
-                        return faux;
-                    }
+                    log("Disabling EV_ABS %#x% on device (min == max == 0)", code);
+                    libevdev_disable_event_code<EV_ABS>(code);
+                }
+                else
+                {
+                    log("Device has min == max on EV_ABS 'code=%%'", code);
+                    return faux;
                 }
             }
             return true;
@@ -4425,11 +4422,6 @@ namespace netxs::lixx // li++, libinput++.
         void evdev_extract_abs_axes(Li& li, ui32 udev_tags)
         {
             auto fuzz = 0;
-            if (!libevdev_has_event_code<EV_ABS>(ABS_X)
-             || !libevdev_has_event_code<EV_ABS>(ABS_Y))
-            {
-                return;
-            }
             if (evdev_fix_abs_resolution(li, ABS_X, ABS_Y))
             {
                 abs.is_fake_resolution = true;
@@ -7454,22 +7446,16 @@ namespace netxs::lixx // li++, libinput++.
         ui32 libinput_device_config_accel_get_profiles()
         {
             if (!libinput_device_config_accel_is_available()) return 0;
-            return config.accel->get_profiles(This());
+            else                                              return config.accel->get_profiles(This());
         }
         libinput_config_status libinput_device_config_accel_set_profile(libinput_config_accel_profile profile)
         {
-            switch (profile)
-            {
-                case LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT:
-                case LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE:
-                case LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM: break;
-                default: return LIBINPUT_CONFIG_STATUS_INVALID;
-            }
-            if (libinput_device_config_accel_is_available() && (libinput_device_config_accel_get_profiles() & profile))
-            {
-                return config.accel->set_profile(This(), profile);
-            }
-            else return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
+            auto ok = profile == LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT
+                   || profile == LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE
+                   || profile == LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM;
+                 if (!ok)                                                   return LIBINPUT_CONFIG_STATUS_INVALID;
+            else if (libinput_device_config_accel_get_profiles() & profile) return config.accel->set_profile(This(), profile);
+            else                                                            return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
         }
         void evdev_read_calibration_prop()
         {
@@ -7605,7 +7591,7 @@ namespace netxs::lixx // li++, libinput++.
             {
                 auto filter_ptr = li_device->pointer_filter;
                 return filter_ptr ? LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE | LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT | LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM
-                                : LIBINPUT_CONFIG_ACCEL_PROFILE_NONE;
+                                  : LIBINPUT_CONFIG_ACCEL_PROFILE_NONE;
             }
         void evdev_device_init_pointer_acceleration(motion_filter_sptr filter)
         {
@@ -13623,18 +13609,13 @@ namespace netxs::lixx // li++, libinput++.
                         if (filter->filter_get_type() != profile)
                         {
                             auto speed = filter->filter_get_speed();
-                            if (tp.tp_impl.tp_init_accel(profile))
-                            {
-                                tp.tp_impl.tp_accel_config_set_speed(speed);
-                            }
-                            else
-                            {
-                                return LIBINPUT_CONFIG_STATUS_UNSUPPORTED;
-                            }
+                            tp.tp_impl.tp_init_accel(profile);
+                            tp.tp_impl.tp_accel_config_set_speed(speed);
                         }
+                        //todo always true
                         return LIBINPUT_CONFIG_STATUS_SUCCESS;
                     }
-                bool tp_init_accel(libinput_config_accel_profile which)
+                void tp_init_accel(libinput_config_accel_profile which)
                 {
                     auto filter = motion_filter_sptr{};
                     auto dpi = tp.dpi;
@@ -13669,10 +13650,8 @@ namespace netxs::lixx // li++, libinput++.
                         }
                         filter = ptr::shared<touchpad_accelerator>(dpi, eds_threshold, eds_value, use_v_avg);
                     }
-                    if (!filter) return faux;
                     tp.evdev_device_init_pointer_acceleration(filter);
                     tp.pointer_config.set_profile = tp_accel_config_set_profile;
-                    return true;
                 }
                     void tp_tap_handle_timeout(time now)
                     {
@@ -14542,10 +14521,7 @@ namespace netxs::lixx // li++, libinput++.
                 }
                 tp.dpi = tp.ud_device.abs.absinfo_x->resolution * 25.4; // Set the dpi to that of the x axis, because that's what we normalize to when needed.
                 tp_init_hysteresis();
-                if (!tp_init_accel(LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE))
-                {
-                    return faux;
-                }
+                tp_init_accel(LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE);
                 tp_init_tap();
                 tp_init_buttons();
                 tp_init_dwt();
@@ -19424,11 +19400,14 @@ namespace netxs::lixx // li++, libinput++.
             }
             void fallback_dispatch_init_abs(libinput_device_sptr li_device)
             {
-                if (!li_device->libevdev_has_event_code<EV_ABS>(ABS_X)) return;
-                generic.abs.point.x = li_device->ud_device.abs.absinfo_x->value;
-                generic.abs.point.y = li_device->ud_device.abs.absinfo_y->value;
-                generic.abs.seat_slot = -1;
-                li_device->evdev_device_init_abs_range_warnings();
+                if (li_device->libevdev_has_event_code<EV_ABS>(ABS_X)
+                 && li_device->libevdev_has_event_code<EV_ABS>(ABS_Y))
+                {
+                    generic.abs.point.x = li_device->ud_device.abs.absinfo_x->value;
+                    generic.abs.point.y = li_device->ud_device.abs.absinfo_y->value;
+                    generic.abs.seat_slot = -1;
+                    li_device->evdev_device_init_abs_range_warnings();
+                }
             }
                     bool parse_switch_reliability_property(view prop, switch_reliability& reliability)
                     {
@@ -19513,6 +19492,7 @@ namespace netxs::lixx // li++, libinput++.
                 }
                 generic.mt.slot = active_slot;
                 generic.mt.has_palm = li_device->libevdev_has_event_code<EV_ABS>(ABS_MT_TOOL_TYPE);
+                if (li_device->ud_device.abs.absinfo_x       && li_device->ud_device.abs.absinfo_y)
                 if (li_device->ud_device.abs.absinfo_x->fuzz || li_device->ud_device.abs.absinfo_y->fuzz)
                 {
                     generic.mt.want_hysteresis = true;
@@ -19827,7 +19807,8 @@ namespace netxs::lixx // li++, libinput++.
         {
             if (udev_tags & EVDEV_UDEV_TAG_ACCELEROMETER) ud_device.evdev_disable_accelerometer_axes();
             if (!ud_device.evdev_is_fake_mt_device()) ud_device.evdev_fix_android_mt();
-            if (ud_device.libevdev_has_event_code<EV_ABS>(ABS_X))
+            if (ud_device.libevdev_has_event_code<EV_ABS>(ABS_X)
+             && ud_device.libevdev_has_event_code<EV_ABS>(ABS_Y))
             {
                 ud_device.evdev_extract_abs_axes(li, udev_tags);
                 if (ud_device.evdev_is_fake_mt_device())

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2801,7 +2801,7 @@ namespace netxs::ui
                          && match.length()
                          && owner.selmod == mime::textonly;
                 canvas.move(full.coor - dest.coor());
-                dest.plot(canvas, cell::shaders::fuse);
+                dest.plot(canvas, cell::shaders::flat);
                 if (auto area = canvas.area())
                 {
                     if (find)
@@ -5174,7 +5174,7 @@ namespace netxs::ui
                     auto height = curln.height(panel.x);
                     auto length = curln.length();
                     auto adjust = curln.style.jet();
-                    dest.output(curln, coor, cell::shaders::fuse);
+                    dest.output(curln, coor, cell::shaders::flat);
                     //dest.output_proxy(curln, coor, [&](auto const& coord, auto const& subblock, auto isr_to_l)
                     //{
                     //    dest.text(coord, subblock, isr_to_l, cell::shaders::fusefull);


### PR DESCRIPTION
### Changes

- Fix terminal transparency.
  The built-in terminal is capable of outputting alpha transparent (from 0 to 255, in the RGBA sense) text and thus making "holes" in the GUI terminal window. Transparency can be set for both the text background and the foreground using the SGR attributes `48:2` and `38:2`:
    - `ESC` `[` `48` `:` `2` `:` [ `:` ] `red` `:` `green` `:` `blue` [ `:alpha` ] `m`
    - `ESC` `[` `38` `:` `2` `:` [ `:` ] `red` `:` `green` `:` `blue` [ `:alpha` ] `m`

For example, outputting a pixel-art image with transparency (pwsh):

```pwsh
" `e[48:2:0:0:0:255m`e[38:2:0:0:0:255m   `e[38:2:4:0:0:4m▄`e[38:2:20:0:0:20m▄`e[48:2:3:0:0:3m`e[38:2:51:0:0:51m▄`e[48:2:9:0:0:9m`e[38:2:95:0:0:95m▄`e[48:2:11:0:0:11m`e[38:2:104:0:0:104m▄`e[48:2:8:0:0:8m`e[38:2:83:0:0:83m▄`e[48:2:2:0:0:2m`e[38:2:38:0:0:38m▄`e[48:2:0:0:0:255m`e[38:2:14:0:0:14m▄`e[38:2:3:0:0:3m▄`e[38:2:15:0:0:15m▄`e[48:2:2:0:0:2m`e[38:2:39:0:0:39m▄`e[48:2:8:0:0:8m`e[38:2:84:0:0:84m▄`e[48:2:10:0:0:10m`e[38:2:104:0:0:104m▄`e[48:2:9:0:0:9m`e[38:2:93:0:0:93m▄`e[48:2:3:0:0:3m`e[38:2:50:0:0:50m▄`e[48:2:0:0:0:255m`e[38:2:19:0:0:19m▄`e[38:2:4:0:0:4m▄`e[38:2:0:0:0:255m   ";`
"  `e[38:2:5:0:0:5m▄`e[48:2:8:0:0:8m`e[38:2:57:0:0:57m▄`e[48:2:54:0:0:54m`e[38:2:193:0:0:193m▄`e[48:2:157:0:0:157m`e[38:2:243:0:0:243m▄`e[48:2:224:0:0:224m`e[38:2:254:0:0:254m▄`e[48:2:237:0:0:237m`e[38:2:255:0:0:255m▄`e[48:2:238:0:0:238m▄`e[48:2:234:0:0:234m▄`e[48:2:211:0:0:211m`e[38:2:252:0:0:252m▄`e[48:2:125:0:0:125m`e[38:2:239:0:0:239m▄`e[48:2:49:0:0:49m`e[38:2:219:0:0:219m▄`e[48:2:128:0:0:128m`e[38:2:240:0:0:240m▄`e[48:2:212:0:0:212m`e[38:2:253:0:0:253m▄`e[48:2:234:0:0:234m`e[38:2:255:0:0:255m▄`e[48:2:238:0:0:238m▄`e[48:2:237:0:0:237m▄`e[48:2:224:0:0:224m`e[38:2:254:0:0:254m▄`e[48:2:153:0:0:153m`e[38:2:242:0:0:242m▄`e[48:2:50:0:0:50m`e[38:2:192:0:0:192m▄`e[48:2:7:0:0:7m`e[38:2:54:0:0:54m▄`e[48:2:0:0:0:255m`e[38:2:4:0:0:4m▄`e[38:2:0:0:0:255m ";`
" `e[48:2:1:0:0:1m`e[38:2:5:0:0:5m▄`e[48:2:23:0:0:23m`e[38:2:66:0:0:66m▄`e[48:2:168:0:0:168m`e[38:2:228:0:0:228m▄`e[48:2:244:0:0:244m`e[38:2:254:0:0:254m▄`e[48:2:255:0:0:255m`e[38:2:255:0:0:255m       `e[48:2:253:0:0:253m▄`e[48:2:255:0:0:255m       `e[48:2:243:0:0:243m`e[38:2:254:0:0:254m▄`e[48:2:162:0:0:162m`e[38:2:226:0:0:226m▄`e[48:2:22:0:0:22m`e[38:2:58:0:0:58m▄`e[48:2:0:0:0:255m`e[38:2:4:0:0:4m▄`e[38:2:0:0:0:255m";`
" `e[48:2:11:0:0:11m`e[38:2:12:0:0:12m▄`e[48:2:108:0:0:108m`e[38:2:119:0:0:119m▄`e[48:2:239:0:0:239m`e[38:2:240:0:0:240m▄`e[48:2:255:0:0:255m`e[38:2:255:0:0:255m                 `e[48:2:238:0:0:238m`e[38:2:239:0:0:239m▄`e[48:2:102:0:0:102m`e[38:2:107:0:0:107m▄`e[48:2:10:0:0:10m`e[38:2:11:0:0:11m▄`e[48:2:0:0:0:255m`e[38:2:0:0:0:255m";`
" `e[48:2:9:0:0:9m`e[38:2:3:0:0:3m▄`e[48:2:95:0:0:95m`e[38:2:44:0:0:44m▄`e[48:2:236:0:0:236m`e[38:2:213:0:0:213m▄`e[48:2:255:0:0:255m`e[38:2:253:0:0:253m▄`e[38:2:255:0:0:255m               `e[38:2:252:0:0:252m▄`e[48:2:235:0:0:235m`e[38:2:210:0:0:210m▄`e[48:2:88:0:0:88m`e[38:2:40:0:0:40m▄`e[48:2:8:0:0:8m`e[38:2:2:0:0:2m▄`e[48:2:0:0:0:255m`e[38:2:0:0:0:255m";`
"  `e[48:2:15:0:0:15m`e[38:2:1:0:0:1m▄`e[48:2:124:0:0:124m`e[38:2:26:0:0:26m▄`e[48:2:232:0:0:232m`e[38:2:144:0:0:144m▄`e[48:2:254:0:0:254m`e[38:2:235:0:0:235m▄`e[48:2:255:0:0:255m`e[38:2:254:0:0:254m▄`e[38:2:255:0:0:255m           `e[38:2:254:0:0:254m▄`e[48:2:254:0:0:254m`e[38:2:235:0:0:235m▄`e[48:2:232:0:0:232m`e[38:2:144:0:0:144m▄`e[48:2:117:0:0:117m`e[38:2:25:0:0:25m▄`e[48:2:14:0:0:14m`e[38:2:1:0:0:1m▄`e[48:2:0:0:0:255m`e[38:2:0:0:0:255m ";`
"   `e[48:2:2:0:0:2m▄`e[48:2:29:0:0:29m`e[38:2:2:0:0:2m▄`e[48:2:144:0:0:144m`e[38:2:29:0:0:29m▄`e[48:2:235:0:0:235m`e[38:2:144:0:0:144m▄`e[48:2:254:0:0:254m`e[38:2:235:0:0:235m▄`e[48:2:255:0:0:255m`e[38:2:254:0:0:254m▄`e[38:2:255:0:0:255m       `e[38:2:254:0:0:254m▄`e[48:2:254:0:0:254m`e[38:2:233:0:0:233m▄`e[48:2:234:0:0:234m`e[38:2:140:0:0:140m▄`e[48:2:144:0:0:144m`e[38:2:28:0:0:28m▄`e[48:2:29:0:0:29m`e[38:2:2:0:0:2m▄`e[48:2:2:0:0:2m`e[38:2:0:0:0:255m▄`e[48:2:0:0:0:255m  ";`
"     `e[48:2:2:0:0:2m▄`e[48:2:29:0:0:29m`e[38:2:2:0:0:2m▄`e[48:2:144:0:0:144m`e[38:2:28:0:0:28m▄`e[48:2:234:0:0:234m`e[38:2:137:0:0:137m▄`e[48:2:254:0:0:254m`e[38:2:232:0:0:232m▄`e[48:2:255:0:0:255m`e[38:2:253:0:0:253m▄`e[38:2:255:0:0:255m   `e[38:2:253:0:0:253m▄`e[48:2:253:0:0:253m`e[38:2:227:0:0:227m▄`e[48:2:230:0:0:230m`e[38:2:119:0:0:119m▄`e[48:2:130:0:0:130m`e[38:2:24:0:0:24m▄`e[48:2:26:0:0:26m`e[38:2:2:0:0:2m▄`e[48:2:2:0:0:2m`e[38:2:0:0:0:255m▄`e[48:2:0:0:0:255m    ";`
"       `e[48:2:2:0:0:2m▄`e[48:2:25:0:0:25m`e[38:2:1:0:0:1m▄`e[48:2:126:0:0:126m`e[38:2:23:0:0:23m▄`e[48:2:229:0:0:229m`e[38:2:116:0:0:116m▄`e[48:2:253:0:0:253m`e[38:2:227:0:0:227m▄`e[48:2:255:0:0:255m`e[38:2:251:0:0:251m▄`e[48:2:253:0:0:253m`e[38:2:226:0:0:226m▄`e[48:2:226:0:0:226m`e[38:2:111:0:0:111m▄`e[48:2:112:0:0:112m`e[38:2:20:0:0:20m▄`e[48:2:21:0:0:21m`e[38:2:1:0:0:1m▄`e[48:2:1:0:0:1m`e[38:2:0:0:0:255m▄`e[48:2:0:0:0:255m      ";`
"         `e[48:2:1:0:0:1m▄`e[48:2:21:0:0:21m`e[38:2:1:0:0:1m▄`e[48:2:110:0:0:110m`e[38:2:15:0:0:15m▄`e[48:2:205:0:0:205m`e[38:2:48:0:0:48m▄`e[48:2:110:0:0:110m`e[38:2:15:0:0:15m▄`e[48:2:20:0:0:20m`e[38:2:1:0:0:1m▄`e[48:2:1:0:0:1m`e[38:2:0:0:0:255m▄`e[48:2:0:0:0:255m        ";`
"            `e[48:2:3:0:0:3m▄`e[48:2:0:0:0:255m           ";`
"`e[m ";

```