### PR TITLE
Fix spaces after wide characters (in titles, on copy, etc)

### DIFF
--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -158,7 +158,7 @@ namespace netxs::app::desk
                         }
                     };
                 });
-            auto label_format = [](view utf8){ return ansi::add(utf8).mgl(0).wrp(wrap::off).jet(bias::left).nil(); };
+            static auto label_format = [](view utf8){ return ansi::add(utf8).mgl(0).wrp(wrap::off).jet(bias::left).nil(); };
             auto app_label = item_area->attach(slot::_1, ui::item::ctor(label_format(current_title)))
                 ->active()
                 //todo taskbar keybd navigation

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -38,12 +38,18 @@ namespace netxs::app::desk
         EVENTPACK( desk::events, ui::e2::extra::slot2 )
         {
             EVENT_XS( usrs, netxs::sptr<desk::usrs> ), // List of connected users.
-            EVENT_XS( apps, netxs::sptr<desk::apps> ), // List of running apps.
             EVENT_XS( menu, netxs::sptr<desk::menu> ), // List of registered apps.
             EVENT_XS( exec, spec                    ), // Request to run app.
             EVENT_XS( quit, bool                    ), // Request to close all instances.
+            GROUP_XS( apps, netxs::sptr<desk::apps> ),
             GROUP_XS( ui  , text                    ),
 
+            SUBSET_XS( apps )
+            {
+                EVENT_XS( applist, netxs::sptr<desk::apps> ), // request: Take a list of running apps.
+                EVENT_XS( created, netxs::ui::sptr         ), // release: App window created.
+                EVENT_XS( removed, netxs::ui::sptr         ), // release: App window removed.
+            };
             SUBSET_XS( ui )
             {
                 EVENT_XS( sync    , bool        ),
@@ -707,7 +713,7 @@ namespace netxs::app::desk
                     boss.LISTEN(tier::anycast, e2::form::upon::started, root_ptr)
                     {
                         auto world_ptr = world.This();
-                        auto apps = boss.attach_element(desk::events::apps, world_ptr, apps_template);
+                        auto apps = boss.attach_element(desk::events::apps::applist, world_ptr, apps_template);
                     };
                 });
             auto users_area = apps_users->attach(slot::_2, ui::list::ctor());

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1696,6 +1696,8 @@ struct impl : consrv
         auto readevents(Payload& packet, cdrw& answer)
         {
             if (!server.size_check(packet.echosz, answer.sendoffset())) return;
+            // Test unstable stdin.
+            //os::sleep(150ms);
             auto avail = packet.echosz - answer.sendoffset();
             auto limit = avail / (ui32)sizeof(recbuf.front());
             if (server.io_log) log("\tuser limit: ", limit);
@@ -1703,8 +1705,9 @@ struct impl : consrv
             if (packet.input.utf16)
             {
                 recbuf.clear();
-                recbuf.reserve(count());
-                auto tail = head + std::min(limit, count());
+                auto mx = count();//std::min(2u, (ui32)count());
+                recbuf.reserve(mx);
+                auto tail = head + std::min(limit, mx);
                 while (head != tail)
                 {
                     recbuf.emplace_back(*head++);

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -31,13 +31,12 @@
     #include <spawn.h>      // ::exec
     #include <unistd.h>     // ::gethostname(), ::getpid(), ::read()
     #include <sys/param.h>  //
-    #include <sys/types.h>  // ::getaddrinfo
+    #include <sys/types.h>  // ::getaddrinfo(), ::sysctl()
     #include <sys/socket.h> // ::shutdown() ::socket(2)
     #include <netdb.h>      //
     //#include <arpa/inet.h>  // ::inet_ntop() ?This may require dynamic linking. #GH696
 
     #include <stdio.h>
-    #include <unistd.h>     // ::read()
     #include <sys/un.h>
     #include <stdlib.h>
 
@@ -47,7 +46,6 @@
     #include <sys/wait.h>   // ::waitpid
     #include <syslog.h>     // syslog, daemonize
 
-    #include <sys/types.h>
     #include <sys/stat.h>   // ::chmod()
     #include <fcntl.h>      // ::splice()
 
@@ -69,7 +67,6 @@
     #if defined(__APPLE__)
         #include <mach-o/dyld.h>    // ::_NSGetExecutablePath()
     #elif defined(__BSD__)
-        #include <sys/types.h>  // ::sysctl()
         #include <sys/sysctl.h>
     #endif
 

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1017,11 +1017,13 @@ namespace netxs::app::vtm
                 {
                     apps_list.erase(menuid);
                 }
-                base::signal(tier::release, desk::events::apps, apps_list_ptr); // Update taskbar app list.
+                world_ptr->base::signal(tier::release, desk::events::apps::applist, apps_list_ptr); // Update taskbar app list.
+                //world_ptr->base::signal(tier::release, desk::events::apps::removed, what_copy); // Update taskbar app list.
             };
             auto root_ptr = is_handoff ? sptr{} : what.applet;
             window_ptr->base::broadcast(tier::anycast, e2::form::upon::started, root_ptr);
-            base::signal(tier::release, desk::events::apps, apps_list_ptr);
+            base::signal(tier::release, desk::events::apps::applist, apps_list_ptr);
+            //base::signal(tier::release, desk::events::apps::created, what_copy);
             window_ptr->base::reflow();
             return window_ptr;
         }
@@ -1417,7 +1419,7 @@ namespace netxs::app::vtm
             {
                 usrs_ptr = usrs_list_ptr;
             };
-            LISTEN(tier::request, desk::events::apps, apps_ptr)
+            LISTEN(tier::request, desk::events::apps::applist, apps_ptr)
             {
                 apps_ptr = apps_list_ptr;
             };


### PR DESCRIPTION
### Changes

- Fix spaces after wide characters (in titles, on copy, etc).