### PR TITLE
Show literal keys on info-page for non-US kb layouts

### DIFF
--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -720,7 +720,7 @@ namespace netxs::app::shared
                     if (i == 4) break;
                     if (i == 1)
                     {
-                        if (is_key_event && gear.vkchord.size())
+                        if (is_key_event && (gear.vkchord.size() || gear.chchord.size() || gear.scchord.size()))
                         {
                             auto& dst = gear.keystat ? pressed : released;
                             auto generic = input::key::kmap::to_string(gear.vkchord, true);

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -228,7 +228,7 @@ namespace netxs::app::desk
                 });
             return item_area;
         };
-        auto apps_template = [](auto& data_src, auto& apps_map_ptr)
+        auto apps_template = [](auto& world_ptr, auto& apps_map_ptr)
         {
             auto tall = si32{ skin::globals().menuwide };
             auto inactive_color  = skin::globals().inactive;
@@ -237,6 +237,7 @@ namespace netxs::app::desk
             auto c1 = danger_color;
             auto c9 = selected_color;
             auto cA = inactive_color;
+            auto& world_inst = *world_ptr;
 
             auto apps = ui::list::ctor()
                 ->invoke([&](auto& boss)
@@ -249,10 +250,33 @@ namespace netxs::app::desk
                         auto state = boss.base::riseup(tier::request, desk::events::ui::toggle);
                         boss.base::riseup(tier::anycast, desk::events::ui::recalc, state);
                     };
+                    //auto& menu_list = boss.base::field();
+                    //auto& apps_list = boss.base::field();
+                    //auto& inst_list = boss.base::field();
+                    //world_inst.LISTEN(tier::release, desk::events::apps::created, window_ptr, boss.sensors)
+                    //{
+                    //    auto& window = *window_ptr;
+                    //    auto& menuid = window.base::property("window.menuid");
+                    //    auto& cfg = menu_list[menuid];
+                    //    auto& [fixed_menu_item, inst_list] = apps_list[menuid];
+                    //    fixed_menu_item = !cfg.hidden;
+                    //    inst_list.push_back(window_ptr);
+                    //};
+                    //world_inst.LISTEN(tier::release, desk::events::apps::removed, window_ptr, boss.sensors)
+                    //{
+                    //    auto& window = *window_ptr;
+                    //    auto& menuid = window.base::property("window.menuid");
+                    //    auto& [fixed_menu_item, inst_list] = apps_list[menuid];
+                    //    inst_list.remove(window_ptr);
+                    //    if (!fixed_menu_item && inst_list.empty()) // Remove non-fixed menu group if it is empty.
+                    //    {
+                    //        apps_list.erase(menuid);
+                    //    }
+                    //};
                 });
 
             auto def_note = skin::globals().NsTaskbarApps_deftooltip;
-            auto conf_list_ptr = data_src->base::riseup(tier::request, desk::events::menu);
+            auto conf_list_ptr = world_inst.base::riseup(tier::request, desk::events::menu);
             if (!conf_list_ptr || !apps_map_ptr) return apps;
             auto& conf_list = *conf_list_ptr;
             auto& apps_map = *apps_map_ptr;
@@ -313,15 +337,12 @@ namespace netxs::app::desk
                             }
                             boss.base::signal(tier::anycast, desk::events::ui::selected, inst_id);
                             static auto offset = dot_00; // static: Share initial offset between all instances.
-                            if (auto world_ptr = boss.base::signal(tier::general, e2::config::creator))
-                            {
-                                auto current_viewport = gear.owner.base::signal(tier::request, e2::form::prop::viewport);
-                                offset = (offset + dot_21 * 2) % std::max(dot_11, current_viewport.size * 7 / 32);
-                                gear.slot.coor = current_viewport.coor + offset + current_viewport.size * 1 / 32 + dot_11;
-                                gear.slot.size = current_viewport.size * 3 / 4;
-                                gear.slot_forced = faux;
-                                world_ptr->base::riseup(tier::request, e2::form::proceed::createby, gear);
-                            }
+                            auto current_viewport = gear.owner.base::signal(tier::request, e2::form::prop::viewport);
+                            offset = (offset + dot_21 * 2) % std::max(dot_11, current_viewport.size * 7 / 32);
+                            gear.slot.coor = current_viewport.coor + offset + current_viewport.size * 1 / 32 + dot_11;
+                            gear.slot.size = current_viewport.size * 3 / 4;
+                            gear.slot_forced = faux;
+                            world_inst.base::riseup(tier::request, e2::form::proceed::createby, gear);
                             gear.dismiss(true);
                         });
                     });
@@ -397,6 +418,8 @@ namespace netxs::app::desk
                         });
                     for (auto& inst_ptr : inst_ptr_list)
                     {
+                        //todo
+                        //auto taskbar_item_ptr = app_template(inst_ptr);
                         auto taskbar_item_ptr = app_template(inst_ptr)
                                                 ->depend(inst_ptr);
                         insts->attach(taskbar_item_ptr);
@@ -714,6 +737,9 @@ namespace netxs::app::desk
                     {
                         auto world_ptr = world.This();
                         auto apps = boss.attach_element(desk::events::apps::applist, world_ptr, apps_template);
+                        //todo
+                        //auto apps = world_ptr->base::signal(tier::request, desk::events::apps::applist);
+                        //world_ptr->attach(apps_template(world_ptr, apps));
                     };
                 });
             auto users_area = apps_users->attach(slot::_2, ui::list::ctor());

--- a/src/netxs/apps/text.hpp
+++ b/src/netxs/apps/text.hpp
@@ -39,10 +39,10 @@ namespace netxs::app::textancy
         constexpr auto vss = utf::matrix::vss<Args...>;
         auto header = [](auto caption)
         {
-            return ansi::wrp(wrap::off).mgr(0).bld(true).cap(caption).erl().und(unln::none).eol().mgr(1).unc(0).wrp(wrap::on);
+            return ansi::wrp(wrap::off).mgr(0).cap(caption).erl().und(unln::none).eol().mgr(1).unc(0).wrp(wrap::on);
         };
         auto topic3_chars =
-"\nThere are important differences between \033[22mplain text\033[1m (created and edited by text editors) and "
+"\nThere are important differences between plain text (created and edited by text editors) and "
 "\033[38:2:109:231:237m""r"
 "\033[38:2:109:237:186m""i"
 "\033[38:2:60:255:60m"  "c"
@@ -55,7 +55,7 @@ namespace netxs::app::textancy
 "\033[38:2:255:49:214m" " " "\033[39m"
 "(such as that created by word processors or desktop publishing software).\n\n"
 "Plain text exclusively consists of character representation. Each character is represented by a fixed-length sequence of one, two, or four bytes, or as a variable-length sequence of one to four bytes, in accordance to specific character encoding conventions, such as ASCII, ISO/IEC 2022, UTF-8, or Unicode. These conventions define many printable characters, but also non-printing characters that control the flow of the text, such as space, line break, and page break. Plain text contains no other information about the text itself, not even the character encoding convention employed. Plain text is stored in text files, although text files do not exclusively store plain text. In the early days of computers, plain text was displayed using a monospace font, such that horizontal alignment and columnar formatting were sometimes done using hitespace characters. For compatibility reasons, this tradition has not changed.\n\n"
-"Rich text, on the other hand, may contain metadata, character formatting data (e.g. typeface, size, \033[22mweight\033[1m and \033[22;3mstyle\033[23;1m), paragraph formatting data (e.g. indentation, alignment, letter and word distribution, and space between lines or other paragraphs), and page specification data (e.g. size, margin and reading direction). Rich text can be very complex. Rich text can be saved in binary format (e.g. DOC), text files adhering to a markup language (e.g. RTF or HTML), or in a hybrid form of both (e.g. Office Open XML).\n\n"
+"Rich text, on the other hand, may contain metadata, character formatting data (e.g. typeface, size, \033[1mweight\033[22m and \033[3mstyle\033[23m), paragraph formatting data (e.g. indentation, alignment, letter and word distribution, and space between lines or other paragraphs), and page specification data (e.g. size, margin and reading direction). Rich text can be very complex. Rich text can be saved in binary format (e.g. DOC), text files adhering to a markup language (e.g. RTF or HTML), or in a hybrid form of both (e.g. Office Open XML).\n\n"
 R"(Text editors are intended to open and save text files containing either plain text or anything that can be interpreted as plain text, including the markup for rich text or the markup for something else (e.g. SVG).
 
 History

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -194,7 +194,7 @@ namespace netxs::app::tile
         auto app_window = [](auto& what)
         {
             return ui::fork::ctor(axis::Y)
-                    ->template plugin<pro::title>(what.applet->base::property("window.header"), what.applet->base::property("window.footer"), true, faux, true)
+                    ->template plugin<pro::title>(what.applet->base::property("applet.header"), what.applet->base::property("applet.footer"), true, faux, true)
                     ->template plugin<pro::light>() //todo gcc requires template keyword
                     ->template plugin<pro::focus>()
                     ->limits({ 10, -1 }, { -1, -1 })
@@ -217,8 +217,8 @@ namespace netxs::app::tile
 
                                 // Take current title.
                                 auto what = vtm::events::handoff.param();
-                                auto& header = applet.base::property("window.header");
-                                if (header.empty()) header = applet.base::property("window.menuid");
+                                auto& header = applet.base::property("applet.header");
+                                if (header.empty()) header = applet.base::property("applet.menuid");
 
                                 // Get creator.
                                 auto world_ptr = boss.base::signal(tier::general, e2::config::creator);
@@ -227,7 +227,7 @@ namespace netxs::app::tile
                                 // Take coor.
                                 gear.coord -= applet.base::coor(); // Rebase mouse coor.
                                 gear.click -= applet.base::coor(); // Rebase mouse click.
-                                auto& applet_area = applet.base::template property<rect>("window.area");
+                                auto& applet_area = applet.base::template property<rect>("applet.area");
                                 if (!applet_area) applet_area.size = applet.base::size();
                                 auto coor = dot_00;
                                 applet.base::global(coor);
@@ -270,7 +270,7 @@ namespace netxs::app::tile
                         };
                     })
                     ->branch(slot::_1, ui::postfx<cell::shaders::contrast>::ctor()
-                        ->upload(what.applet->base::property("window.header"))
+                        ->upload(what.applet->base::property("applet.header"))
                         ->shader(cell::shaders::text(cell{ whitespace }))
                         ->invoke([&](auto& boss)
                         {

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.09.02";
+    static const auto version = "v2025.09.05";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -3070,33 +3070,30 @@ namespace netxs::ui
                                                 : k.payload == input::keybd::type::imeanons ? "IME composition"
                                                 : k.payload == input::keybd::type::imeinput ? "IME input"
                                                 : k.payload == input::keybd::type::kblayout ? "keyboard layout" : "unknown payload";
-                    if (k.vkchord.length())
+                    auto t = text{};
+                    if (k.keystat != input::key::repeated)
                     {
-                        auto t = text{};
-                        if (k.vkchord.size() && k.keystat != input::key::repeated)
-                        {
-                            auto vkchord =     input::key::kmap::to_string(k.vkchord, faux);
-                            auto scchord =     input::key::kmap::to_string(k.scchord, faux);
-                            auto chchord =     input::key::kmap::to_string(k.chchord, faux);
-                            auto gen_vkchord = input::key::kmap::to_string(k.vkchord, true);
-                            auto gen_chchord = input::key::kmap::to_string(k.chchord, true);
-                            //log("Keyboard chords: %%  %%  %%", utf::buffer_to_hex(gear.vkchord), utf::buffer_to_hex(gear.scchord), utf::buffer_to_hex(gear.chchord),
-                            if (vkchord.size()) t += (t.size() ? "  " : "") + (vkchord == gen_vkchord ? vkchord : gen_vkchord + "  " + vkchord);
-                            if (chchord.size()) t += (t.size() ? "  " : "") + (chchord == gen_chchord ? chchord : gen_chchord + "  " + chchord);
-                            if (scchord.size()) t += (t.size() ? "  " : "") + scchord;
-                        }
-                        else if (k.cluster.length()) //todo revise
-                        {
-                            for (byte c : k.cluster)
-                            {
-                                     if (c <  0x20) t += "^" + utf::to_utf_from_code(c + 0x40);
-                                else if (c == 0x7F) t += "\\x7F";
-                                else if (c == 0x20) t += "\\x20";
-                                else                t.push_back(c);
-                            }
-                        }
-                        if (t.size()) status[prop::key_chord] = t;
+                        auto vkchord =     input::key::kmap::to_string(k.vkchord, faux);
+                        auto scchord =     input::key::kmap::to_string(k.scchord, faux);
+                        auto chchord =     input::key::kmap::to_string(k.chchord, faux);
+                        auto gen_vkchord = input::key::kmap::to_string(k.vkchord, true);
+                        auto gen_chchord = input::key::kmap::to_string(k.chchord, true);
+                        //log("Keyboard chords: %%  %%  %%", utf::buffer_to_hex(gear.vkchord), utf::buffer_to_hex(gear.scchord), utf::buffer_to_hex(gear.chchord),
+                        if (vkchord.size()) t += (t.size() ? "  " : "") + (vkchord == gen_vkchord ? vkchord : gen_vkchord + "  " + vkchord);
+                        if (chchord.size()) t += (t.size() ? "  " : "") + (chchord == gen_chchord ? chchord : gen_chchord + "  " + chchord);
+                        if (scchord.size()) t += (t.size() ? "  " : "") + scchord;
                     }
+                    else if (k.cluster.length()) //todo revise
+                    {
+                        for (byte c : k.cluster)
+                        {
+                                 if (c <  0x20) t += "^" + utf::to_utf_from_code(c + 0x40);
+                            else if (c == 0x7F) t += "\\x7F";
+                            else if (c == 0x20) t += "\\x20";
+                            else                t.push_back(c);
+                        }
+                    }
+                    if (t.size()) status[prop::key_chord] = t;
                     boss.base::deface();
                 };
             }

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -447,9 +447,9 @@ namespace netxs::input
                             return is_released;
                         });
                         auto sign = !!k.keystat;
-                        if (vk_valid && k.cluster.size() && k.cluster.front() != '\0')
+                        if (k.cluster.size() && k.cluster.front() != '\0')
                         {
-                            k.chchord = k.vkchord;
+                            if (vk_valid) k.chchord = k.vkchord;
                             push_cluster(sign, k.chchord, k.cluster);
                         }
                         push_keyid(sign, k.vkchord, k.keycode);

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -131,7 +131,7 @@ R"==(
             <height=1/>  <!-- Desktop space reserved on top. -->
         </panel>
         <background>  <!-- Desktop background. -->
-            <color fgc=whitedk bgc= #00007f80/>  <!-- Desktop background color. -->
+            <color fgc=whitedk bgc= #00003f80/>  <!-- Desktop background color. -->
             <tile=""/>                           <!-- Truecolor ANSI-art can be used here. -->
         </background>
     </desktop>


### PR DESCRIPTION
### Changes

- Show literal keys on info-page for non-US keyboard layouts. https://github.com/directvt/vtm/issues/803#issuecomment-3255640746
- Make default desktop background less intense.