### PR TITLE
Filter fake LeftCtrl when AltGr pressed/repeated/released

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.09.05a";
+    static const auto version = "v2025.09.06";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;


### PR DESCRIPTION
### Changes

- Filter fake LeftCtrl when AltGr pressed/repeated/released (GUI mode, non-US keyboard layouts).