### PR TITLE
#820: Fix additional screen buffer rendering (win32api)

### DIFF
--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -303,7 +303,6 @@ namespace netxs::app::desk
                         };
                         boss.on(tier::mouserelease, input::key::RightClick, [&, inst_id](hids& gear)
                         {
-                            pro::focus::set(boss.This(), gear.id, solo::on);
                             boss.base::signal(tier::anycast, desk::events::ui::selected, inst_id);
                             gear.dismiss(true);
                         });

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2025.09.27";
+    static const auto version = "v2025.10.03";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -2345,8 +2345,12 @@ struct impl : consrv
         {
             if (handle_ptr->link == &uiterm.target)
             {
-                     if (uiterm.target == &uiterm.normal) unsync |= proc(uiterm.normal);
-                else if (uiterm.target == &uiterm.altbuf) unsync |= proc(uiterm.altbuf);
+                if (uiterm.target == &uiterm.normal) unsync |= proc(uiterm.normal);
+                else
+                {
+                    auto& target_buffer = *(decltype(uiterm.altbuf)*)uiterm.target;
+                    unsync |= proc(target_buffer);
+                }
                 return true;
             }
             else
@@ -3839,6 +3843,7 @@ struct impl : consrv
             auto handle_ptr = (hndl*)packet.target;
             if (handle_ptr->link == &uiterm.target) // Restore original buffer mode.
             {
+                log("\t  restore original buffer mode to ", altmod ? "'altbuf'" : "'normal'");
                 auto& console = *uiterm.target;
                 if (altmod) uiterm.reset_to_altbuf(console);
                 else        uiterm.reset_to_normal(console);
@@ -3846,10 +3851,12 @@ struct impl : consrv
             else // Switch to additional buffer.
             {
                 auto window_ptr = select_buffer(packet.target);
+                log("\t  switch to additional buffer (%%)", window_ptr);
                 if (!window_ptr) return;
                 if (uiterm.target == &uiterm.normal || uiterm.target == &uiterm.altbuf) // Save/update original buffer mode.
                 {
                     altmod = uiterm.target == &uiterm.altbuf;
+                    log("\t  prev mode was ", altmod ? "'altbuf'" : "'normal'");
                 }
                 auto& console = *window_ptr;
                 uiterm.reset_to_altbuf(console);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -631,7 +631,7 @@ namespace netxs::ui
                         // 22: Color text
                         // 28: Rectangular area operations
                         // 52: Clipboard operations
-                        // 10060c: VT2D
+                        // 10060: VT2D
                         queue.add("\x1b[?61;22;28;52;10060c");
                         break;
                 }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -627,7 +627,12 @@ namespace netxs::ui
                 {
                     case 0:
                     default:
-                        queue.add("\x1b[?1;2;10060c"); // Announce support for \e[?10060h mode.
+                        // 61: VT Level 1 conformance
+                        // 22: Color text
+                        // 28: Rectangular area operations
+                        // 52: Clipboard operations
+                        // 10060c: VT2D
+                        queue.add("\x1b[?61;22;28;52;10060c");
                         break;
                 }
                 owner.answer(queue);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7154,8 +7154,12 @@ namespace netxs::ui
             {
                 area.coor = {};
                 fragment.area(area);
-                     if (target == &normal) write_block(normal, fragment, coor, src_area, cell::shaders::full);
-                else if (target == &altbuf) write_block(altbuf, fragment, coor, src_area, cell::shaders::full);
+                if (target == &normal) write_block(normal, fragment, coor, src_area, cell::shaders::full);
+                else
+                {
+                    auto& target_buffer = *(alt_screen*)target;
+                    write_block(target_buffer, fragment, coor, src_area, cell::shaders::full);
+                }
             }
             else
             {
@@ -7935,7 +7939,7 @@ namespace netxs::ui
                 else
                 {
                     if (gear.meta(hids::anyCtrl)) return; // Ctrl+Wheel is reserved for zooming.
-                    if (altscr && target == &altbuf)
+                    if (altscr && target != &normal)
                     {
                         if (gear.whlsi)
                         {
@@ -8231,12 +8235,15 @@ namespace netxs::ui
             if (auto width = cooked.length())
             {
                 auto& proto = cooked.pick();
-                auto& brush = target == &normal ? normal.parser::brush
-                                                : altbuf.parser::brush;
+                auto& brush = target->parser::brush;
                 cooked.each([&](cell& c){ c.meta(brush); });
                 //todo split by char height and do _data2d(...) for each
                 if (target == &normal) normal._data(width, proto, fx);
-                else                   altbuf._data(width, proto, fx);
+                else
+                {
+                    auto& target_buffer = *(alt_screen*)target;
+                    target_buffer._data(width, proto, fx);
+                }
             }
         }
         // term: Move composition cursor (imebox.caret) inside viewport with wordwrapping.


### PR DESCRIPTION
### Changes

- Fix additional screen buffer rendering (win32api). #820
- Don't focus taskbar menu items by right click.
- Advertise correct Primary device attributes (DA1).
  - 61: VT Level 1 conformance.
  - 22: Color text.
  - 28: Rectangular area operations.
  - 52: Clipboard operations.
  - 10060: VT2D.